### PR TITLE
Change links to bitcoin-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bitcoin Hardware Wallet Interaction scripts
 
-[![Build Status](https://travis-ci.org/achow101/HWI.svg?branch=master)](https://travis-ci.org/achow101/HWI)
+[![Build Status](https://travis-ci.org/bitcoin-core/HWI.svg?branch=master)](https://travis-ci.org/bitcoin-core/HWI)
 
 This project contains several scripts for interacting with Bitcoin hardware wallets.
 
@@ -22,7 +22,7 @@ pip3 install pyaes # For digitalbitbox
 ## Install
 
 ```
-git clone https://github.com/achow101/HWI.git
+git clone https://github.com/bitcoin-core/HWI.git
 cd HWI
 ```
 

--- a/docs/bitcoin-core-usage.md
+++ b/docs/bitcoin-core-usage.md
@@ -30,7 +30,7 @@ $ ./configure
 $ make
 $ src/bitcoind -daemon -addresstype=bech32 -changetype=bech32
 $ cd ..
-$ git clone https://github.com/achow101/HWI.git
+$ git clone https://github.com/bitcoin-core/HWI.git
 $ cd HWI
 $ python3 setup.py install
 ```

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     description="A library for working with Bitcoin hardware wallets",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/achow101/hwi",
+    url="https://github.com/bitcoin-core/hwi",
     packages=setuptools.find_packages(exclude=['docs', 'test']),
     install_requires=[
         'hidapi', # HID API needed in general


### PR DESCRIPTION
The repo migrated to bitcoin-core, so changing things that referred to the old location to point to the new one.