### PR TITLE
Handle all exceptions so that none are shown to the user

### DIFF
--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -4,6 +4,7 @@ from .commands import backup_device, displayaddress, enumerate, find_device, \
     get_client, getmasterxpub, getxpub, getkeypool, prompt_pin, restore_device, send_pin, setup_device, \
     signmessage, signtx, wipe_device
 from .errors import (
+    HWWError,
     NO_DEVICE_PATH,
     DEVICE_CONN_ERROR,
     NO_PASSWORD,

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -2,8 +2,13 @@
 
 from .commands import backup_device, displayaddress, enumerate, find_device, \
     get_client, getmasterxpub, getxpub, getkeypool, prompt_pin, restore_device, send_pin, setup_device, \
-    signmessage, signtx, wipe_device, NO_DEVICE_PATH, DEVICE_CONN_ERROR, NO_PASSWORD, \
+    signmessage, signtx, wipe_device
+from .errors import (
+    NO_DEVICE_PATH,
+    DEVICE_CONN_ERROR,
+    NO_PASSWORD,
     UNKNWON_DEVICE_TYPE
+)
 
 import argparse
 import getpass

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -8,7 +8,8 @@ from .errors import (
     NO_DEVICE_PATH,
     DEVICE_CONN_ERROR,
     NO_PASSWORD,
-    UNKNWON_DEVICE_TYPE
+    UNKNWON_DEVICE_TYPE,
+    UNKNOWN_ERROR
 )
 
 import argparse
@@ -157,10 +158,8 @@ def process_commands(args):
     elif args.device_type and args.device_path:
         try:
             client = get_client(device_type, device_path, password)
-        except NoPasswordError as e:
-            return {'error':str(e),'code':NO_PASSWORD}
-        except UnknownDeviceError as e:
-            return {'error':str(e),'code':UNKNWON_DEVICE_TYPE}
+        except HWWError as e:
+            return {'error': e.get_msg(), 'code': e.get_code()}
         except Exception as e:
             return {'error':str(e),'code':DEVICE_CONN_ERROR}
     else:
@@ -169,10 +168,26 @@ def process_commands(args):
     client.is_testnet = args.testnet
 
     # Do the commands
-    result = args.func(args, client)
+    try:
+        result = args.func(args, client)
+    except HWWError as e:
+        result = {'error': e.get_msg(), 'code': e.get_code()}
+    except Exception as e:
+        if args.debug:
+            import traceback
+            traceback.print_exc()
+        result = {'error': str(e), 'code': UNKNOWN_ERROR}
 
     # Close the device
-    client.close()
+    try:
+        client.close()
+    except HWWError as e:
+        result = {'error': e.get_msg(), 'code': e.get_code()}
+    except Exception as e:
+        if args.debug:
+            import traceback
+            traceback.print_exc()
+        result = {'error': str(e), 'code': UNKNOWN_ERROR}
 
     return result
 

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -8,24 +8,7 @@ import importlib
 from .serializations import PSBT, Base64ToHex, HexToBase64, hash160
 from .base58 import xpub_to_address, xpub_to_pub_hex, get_xpub_fingerprint_as_id, get_xpub_fingerprint_hex
 from os.path import dirname, basename, isfile
-from .hwwclient import NoPasswordError, UnavailableActionError, DeviceAlreadyInitError, DeviceAlreadyUnlockedError
-
-# Error codes
-NO_DEVICE_PATH = -1
-NO_DEVICE_TYPE = -2
-DEVICE_CONN_ERROR = -3
-UNKNWON_DEVICE_TYPE = -4
-INVALID_TX = -5
-NO_PASSWORD = -6
-BAD_ARGUMENT = -7
-NOT_IMPLEMENTED = -8
-UNAVAILABLE_ACTION = -9
-DEVICE_ALREADY_INIT = -10
-DEVICE_ALREADY_UNLOCKED = -11
-
-class UnknownDeviceError(Exception):
-    def __init__(self,*args,**kwargs):
-        Exception.__init__(self,*args,**kwargs)
+from .errors import NoPasswordError, UnavailableActionError, DeviceAlreadyInitError, DeviceAlreadyUnlockedError, UnknownDeviceError, BAD_ARGUMENT, NOT_IMPLEMENTED
 
 # Get the client for the device
 def get_client(device_type, device_path, password=''):

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -66,37 +66,19 @@ def find_device(device_path, password='', device_type=None, fingerprint=None):
     return None
 
 def getmasterxpub(client):
-    try:
-        return client.get_master_xpub()
-    except NotImplementedError as e:
-        return {'error': str(e), 'code': NOT_IMPLEMENTED}
+    return client.get_master_xpub()
 
 def signtx(client, psbt):
     # Deserialize the transaction
-    try:
-        tx = PSBT()
-        tx.deserialize(psbt)
-        return client.sign_tx(tx)
-    except NotImplementedError as e:
-        return {'error': str(e), 'code': NOT_IMPLEMENTED}
-    except IOError as e:
-        return {'error':'You must provide a PSBT','code':INVALID_TX}
-    except Exception as e:
-        return {'error': str(e), 'code': BAD_ARGUMENT}
+    tx = PSBT()
+    tx.deserialize(psbt)
+    return client.sign_tx(tx)
 
 def getxpub(client, path):
-    try:
-        return client.get_pubkey_at_path(path)
-    except NotImplementedError as e:
-        return {'error': str(e), 'code': NOT_IMPLEMENTED}
+    return client.get_pubkey_at_path(path)
 
 def signmessage(client, message, path):
-    try:
-        return client.sign_message(message, path)
-    except NotImplementedError as e:
-        return {'error': str(e), 'code': NOT_IMPLEMENTED}
-    except ValueError as e:
-        return {'error': str(e), 'code': BAD_ARGUMENT}
+    return client.sign_message(message, path)
 
 def getkeypool(client, path, start, end, internal=False, keypool=False, account=0, sh_wpkh=False, wpkh=True):
     if sh_wpkh == True and wpkh == True:
@@ -178,49 +160,19 @@ def displayaddress(client, path, sh_wpkh=False, wpkh=False):
     return client.display_address(path, sh_wpkh, wpkh)
 
 def setup_device(client, label='', backup_passphrase=''):
-    try:
-        return client.setup_device(label, backup_passphrase)
-    except UnavailableActionError as e:
-        return {'error': str(e), 'code': UNAVAILABLE_ACTION}
-    except DeviceAlreadyInitError as e:
-        return {'error': str(e), 'code': DEVICE_ALREADY_INIT}
-    except ValueError as e:
-        return {'error': str(e), 'code': BAD_ARGUMENT}
+    return client.setup_device(label, backup_passphrase)
 
 def wipe_device(client):
-    try:
-        return client.wipe_device()
-    except UnavailableActionError as e:
-        return {'error': str(e), 'code': UNAVAILABLE_ACTION}
+    return client.wipe_device()
 
 def restore_device(client, label):
-    try:
-        return client.restore_device(label)
-    except UnavailableActionError as e:
-        return {'error': str(e), 'code': UNAVAILABLE_ACTION}
-    except DeviceAlreadyInitError as e:
-        return {'error': str(e), 'code': DEVICE_ALREADY_INIT}
-    except ValueError as e:
-        return {'error': str(e), 'code': BAD_ARGUMENT}
+    return client.restore_device(label)
 
 def backup_device(client, label='', backup_passphrase=''):
-    try:
-        return client.backup_device(label, backup_passphrase)
-    except UnavailableActionError as e:
-        return {'error': str(e), 'code': UNAVAILABLE_ACTION}
-    except ValueError as e:
-        return {'error': str(e), 'code': BAD_ARGUMENT}
+    return client.backup_device(label, backup_passphrase)
 
 def prompt_pin(client):
-    try:
-        return client.prompt_pin()
-    except DeviceAlreadyUnlockedError as e:
-        return {'error': str(e), 'code': DEVICE_ALREADY_UNLOCKED}
+    return client.prompt_pin()
 
 def send_pin(client, pin):
-    try:
-        return client.send_pin(pin)
-    except DeviceAlreadyUnlockedError as e:
-        return {'error': str(e), 'code': DEVICE_ALREADY_UNLOCKED}
-    except ValueError as e:
-        return {'error': str(e), 'code': BAD_ARGUMENT}
+    return client.send_pin(pin)

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -1,7 +1,7 @@
 # Coldcard interaction script
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import UnavailableActionError
+from ..errors import UnavailableActionError, DeviceFailureError
 from ckcc.client import ColdcardDevice, COINKITE_VID, CKCC_PID
 from ckcc.protocol import CCProtocolPacker, CCProtoError
 from ckcc.constants import MAX_BLK_LEN, AF_P2WPKH, AF_CLASSIC, AF_P2WPKH_P2SH
@@ -71,7 +71,7 @@ class ColdcardClient(HardwareWalletClient):
         result = self.device.send_recv(CCProtocolPacker.sha256())
         assert len(result) == 32
         if result != expect:
-            raise ValueError("Wrong checksum:\nexpect: %s\n   got: %s" % (b2a_hex(expect).decode('ascii'), b2a_hex(result).decode('ascii')))
+            raise DeviceFailureError("Wrong checksum:\nexpect: %s\n   got: %s" % (b2a_hex(expect).decode('ascii'), b2a_hex(result).decode('ascii')))
 
         # start the signing process
         ok = self.device.send_recv(CCProtocolPacker.sign_transaction(sz, expect), timeout=None)
@@ -89,7 +89,7 @@ class ColdcardClient(HardwareWalletClient):
             break
 
         if len(done) != 2:
-            raise ValueError('Failed: %r' % done)
+            raise DeviceFailureError('Failed: %r' % done)
 
         result_len, result_sha = done
 
@@ -109,7 +109,7 @@ class ColdcardClient(HardwareWalletClient):
             if self.device.is_simulator:
                 self.device.send_recv(CCProtocolPacker.sim_keypress(b'y'))
         except CCProtoError as e:
-            raise ValueError(str(e))
+            raise DeviceFailureError(str(e))
 
         while 1:
             time.sleep(0.250)
@@ -120,7 +120,7 @@ class ColdcardClient(HardwareWalletClient):
             break
 
         if len(done) != 2:
-            raise ValueError('Failed: %r' % done)
+            raise DeviceFailureError('Failed: %r' % done)
 
         addr, raw = done
 
@@ -171,7 +171,7 @@ class ColdcardClient(HardwareWalletClient):
             break
 
         if len(done) != 2:
-            raise ValueError('Failed: %r' % done)
+            raise DeviceFailureError('Failed: %r' % done)
 
         result_len, result_sha = done
 

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -1,6 +1,7 @@
 # Coldcard interaction script
 
-from ..hwwclient import HardwareWalletClient, UnavailableActionError
+from ..hwwclient import HardwareWalletClient
+from ..errors import UnavailableActionError
 from ckcc.client import ColdcardDevice, COINKITE_VID, CKCC_PID
 from ckcc.protocol import CCProtocolPacker, CCProtoError
 from ckcc.constants import MAX_BLK_LEN, AF_P2WPKH, AF_CLASSIC, AF_P2WPKH_P2SH

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -15,7 +15,7 @@ import sys
 import time
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import BadArgumentError, NoPasswordError, UnavailableActionError, DeviceFailureError
+from ..errors import ActionCanceledError, BadArgumentError, DeviceFailureError, DeviceNotReadyError, NoPasswordError, UnavailableActionError, DeviceFailureError
 from ..serializations import CTransaction, PSBT, hash256, hash160, ser_sig_der, ser_sig_compact, ser_compact_size
 from ..base58 import get_xpub_fingerprint, decode, to_address, xpub_main_2_test, get_xpub_fingerprint_hex
 
@@ -30,6 +30,90 @@ HWW_CMD = 0x80 + 0x40 + 0x01
 
 DBB_VENDOR_ID = 0x03eb
 DBB_DEVICE_ID = 0x2402
+
+# Errors codes from the device
+bad_args = [
+    102, # The password length must be at least " STRINGIFY(PASSWORD_LEN_MIN) " characters.
+    103, # No input received.
+    104, # Invalid command.
+    105, # Only one command allowed at a time.
+    109, # JSON parse error.
+    204, # Invalid seed.
+    253, # Incorrect serialized pubkey length. A 33-byte hexadecimal value (66 characters) is expected.
+    254, # Incorrect serialized pubkey hash length. A 32-byte hexadecimal value (64 characters) is expected.
+    256, # Failed to pair with second factor, because the previously received hash of the public key does not match the computed hash of the public key.
+    300, # Incorrect pubkey length. A 33-byte hexadecimal value (66 characters) is expected.
+    301, # Incorrect hash length. A 32-byte hexadecimal value (64 characters) is expected.
+    304, # Incorrect TFA pin.
+    411, # Filenames limited to alphanumeric values, hyphens, and underscores.
+    412, # Please provide an encryption key.
+    112, # Device password matches reset password. Disabling reset password.
+]
+
+device_failures = [
+    101, # Please set a password.
+    107, # Output buffer overflow.
+    200, # Seed creation requires an SD card for automatic encrypted backup of the seed.
+    250, # Master key not present.
+    251, # Could not generate key.
+    252, # Could not generate ECDH secret.
+    303, # Could not sign.
+    400, # Please insert SD card.
+    401, # Could not mount the SD card.
+    402, # Could not open a file to write - it may already exist.
+    403, # Could not open the directory.
+    405, # Could not write the file.
+    407, # Could not read the file.
+    408, # May not have erased all files (or no file present).
+    410, # Backup file does not match wallet.
+    500, # Chip communication error.
+    501, # Could not read flash.
+    502, # Could not encrypt.
+    110, # Too many failed access attempts. Device reset.
+    111, # Device locked. Erase device to access this command.
+    113, # Due to many login attempts, the next login requires holding the touch button for 3 seconds.
+    900, # attempts remain before the device is reset.
+    901, # Ignored for non-embedded testing.
+    902, # Too many backup files to read. The list is truncated.
+    903, # attempts remain before the device is reset. The next login requires holding the touch button.
+]
+
+cancels = [
+    600, # Aborted by user.
+    601, # Touchbutton timed out.
+]
+
+ERR_MEM_SETUP = 503 # Device initialization in progress.
+
+class DBBError(Exception):
+    def __init__(self, error):
+        Exception.__init__(self)
+        self.error = error
+
+    def get_error(self):
+        return self.error['error']['message']
+
+    def get_code(self):
+        return self.error['error']['code']
+
+    def __str__(self):
+        return 'Error: {}, Code: {}'.format(self.error['error']['message'], self.error['error']['code'])
+
+def digitalbitbox_exception(f):
+    def func(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except DBBError as e:
+            if e.get_code() in bad_args:
+                raise BadArgumentError(e.get_error())
+            elif e.get_code() in device_failures:
+                raise DeviceFailureError(e.get_error())
+            elif e.get_code() in cancels:
+                raise ActionCanceledError(e.get_error())
+            elif e.get_code() == ERR_MEM_SETUP:
+                raise DeviceNotReadyError(e.get_error())
+
+    return func
 
 def aes_encrypt_with_iv(key, iv, data):
     aes_cbc = pyaes.AESModeOfOperationCBC(key, iv=iv)
@@ -221,12 +305,13 @@ class DigitalbitboxClient(HardwareWalletClient):
 
     # Must return a dict with the xpub
     # Retrieves the public key at the specified BIP 32 derivation path
+    @digitalbitbox_exception
     def get_pubkey_at_path(self, path):
         if '\'' not in path and 'h' not in path and 'H' not in path:
             raise BadArgumentError('The digital bitbox requires one part of the derivation path to be derived using hardened keys')
         reply = send_encrypt('{"xpub":"' + path + '"}', self.password, self.device)
         if 'error' in reply:
-            return reply
+            raise DBBError(reply)
 
         if self.is_testnet:
             return {'xpub':xpub_main_2_test(reply['xpub'])}
@@ -235,6 +320,7 @@ class DigitalbitboxClient(HardwareWalletClient):
 
     # Must return a hex string with the signed transaction
     # The tx must be in the PSBT format
+    @digitalbitbox_exception
     def sign_tx(self, tx):
 
         # Create a transaction with all scriptsigs blanekd out
@@ -359,12 +445,12 @@ class DigitalbitboxClient(HardwareWalletClient):
         reply = send_encrypt(to_send, self.password, self.device)
         logging.debug(reply)
         if 'error' in reply:
-            return reply
+            raise DBBError(reply)
         print("Touch the device for 3 seconds to sign. Touch briefly to cancel", file=sys.stderr)
         reply = send_encrypt(to_send, self.password, self.device)
         logging.debug(reply)
         if 'error' in reply:
-            return reply
+            raise DBBError(reply)
 
         # Extract sigs
         sigs = []
@@ -384,6 +470,7 @@ class DigitalbitboxClient(HardwareWalletClient):
 
     # Must return a base64 encoded string with the signed message
     # The message can be any string
+    @digitalbitbox_exception
     def sign_message(self, message, keypath):
         to_hash = b""
         to_hash += self.message_magic
@@ -401,12 +488,12 @@ class DigitalbitboxClient(HardwareWalletClient):
         reply = send_encrypt(to_send, self.password, self.device)
         logging.debug(reply)
         if 'error' in reply:
-            return reply
+            raise DBBError(reply)
         print("Touch the device for 3 seconds to sign. Touch briefly to cancel", file=sys.stderr)
         reply = send_encrypt(to_send, self.password, self.device)
         logging.debug(reply)
         if 'error' in reply:
-            return reply
+            raise DBBError(reply)
 
         sig = binascii.unhexlify(reply['sign'][0]['sig'])
         r = sig[0:32]
@@ -422,6 +509,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         raise UnavailableActionError('The Digital Bitbox does not have a screen to display addresses on')
 
     # Setup a new device
+    @digitalbitbox_exception
     def setup_device(self, label='', passphrase=''):
         # Make sure this is not initialized
         reply = send_encrypt('{"device" : "info"}', self.password, self.device)
@@ -446,6 +534,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         return {'success': True}
 
     # Wipe this device
+    @digitalbitbox_exception
     def wipe_device(self):
         reply = send_encrypt('{"reset" : "__ERASE__"}', self.password, self.device)
         if 'error' in reply:
@@ -457,6 +546,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         raise UnavailableActionError('The Digital Bitbox does not support restoring via software')
 
     # Begin backup process
+    @digitalbitbox_exception
     def backup_device(self, label='', passphrase=''):
         key = stretch_backup_key(passphrase)
         backup_filename = format_backup_filename(label)

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -15,7 +15,7 @@ import sys
 import time
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import NoPasswordError, UnavailableActionError
+from ..errors import BadArgumentError, NoPasswordError, UnavailableActionError, DeviceFailureError
 from ..serializations import CTransaction, PSBT, hash256, hash160, ser_sig_der, ser_sig_compact, ser_compact_size
 from ..base58 import get_xpub_fingerprint, decode, to_address, xpub_main_2_test, get_xpub_fingerprint_hex
 
@@ -76,7 +76,7 @@ def to_string(x, enc):
     if isinstance(x, str):
         return x
     else:
-        raise TypeError("Not a string or bytes like object")
+        raise DeviceFailureError("Not a string or bytes like object")
 
 class BitboxSimulator():
     def __init__(self, ip, port):
@@ -223,7 +223,7 @@ class DigitalbitboxClient(HardwareWalletClient):
     # Retrieves the public key at the specified BIP 32 derivation path
     def get_pubkey_at_path(self, path):
         if '\'' not in path and 'h' not in path and 'H' not in path:
-            raise ValueError('The digital bitbox requires one part of the derivation path to be derived using hardened keys')
+            raise BadArgumentError('The digital bitbox requires one part of the derivation path to be derived using hardened keys')
         reply = send_encrypt('{"xpub":"' + path + '"}', self.password, self.device)
         if 'error' in reply:
             return reply
@@ -430,7 +430,7 @@ class DigitalbitboxClient(HardwareWalletClient):
 
         # Need a wallet name and backup passphrase
         if not label or not passphrase:
-            raise ValueError('THe label and backup passphrase for a new Digital Bitbox wallet must be specified and cannot be empty')
+            raise BadArgumentError('THe label and backup passphrase for a new Digital Bitbox wallet must be specified and cannot be empty')
 
         # Set password
         to_send = {'password': self.password}

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -14,7 +14,8 @@ import socket
 import sys
 import time
 
-from ..hwwclient import HardwareWalletClient, NoPasswordError, UnavailableActionError
+from ..hwwclient import HardwareWalletClient
+from ..errors import NoPasswordError, UnavailableActionError
 from ..serializations import CTransaction, PSBT, hash256, hash160, ser_sig_der, ser_sig_compact, ser_compact_size
 from ..base58 import get_xpub_fingerprint, decode, to_address, xpub_main_2_test, get_xpub_fingerprint_hex
 

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -1,7 +1,7 @@
 # KeepKey interaction script
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import DeviceAlreadyUnlockedError, UnavailableActionError, DeviceNotReadyError
+from ..errors import BadArgumentError, DeviceAlreadyUnlockedError, UnavailableActionError, DeviceNotReadyError
 from keepkeylib.transport_hid import HidTransport
 from keepkeylib.transport_udp import UDPTransport
 from keepkeylib.client import BaseClient, DebugWireMixin, DebugLinkMixin, ProtocolMixin, TextUIMixin
@@ -70,7 +70,7 @@ class TxAPIPSBT(TxApi):
             o.amount = psbt_in.witness_utxo.nValue
             o.script_pubkey = psbt_in.witness_utxo.scriptPubKey
         else:
-            raise ValueError('{} is not an input in this transaction'.format(txhash))
+            raise BadArgumentError('{} is not an input in this transaction'.format(txhash))
 
         return t
 
@@ -293,7 +293,7 @@ class KeepkeyClient(HardwareWalletClient):
                     if wit:
                         txoutput.address = bech32.encode(bech32_hrp, ver, prog)
                     else:
-                        raise TypeError("Output is not an address")
+                        raise BadArgumentError("Output is not an address")
 
                 # append to outputs
                 outputs.append(txoutput)
@@ -384,7 +384,7 @@ class KeepkeyClient(HardwareWalletClient):
     # Send the pin
     def send_pin(self, pin):
         if not pin.isdigit():
-            raise ValueError("Non-numeric PIN provided")
+            raise BadArgumentError("Non-numeric PIN provided")
         resp = self.client.call_raw(messages.PinMatrixAck(pin=pin))
         if isinstance(resp, messages.Failure):
             self.client.features = self.client.call_raw(messages.GetFeatures())

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -1,6 +1,7 @@
 # KeepKey interaction script
 
-from ..hwwclient import DeviceAlreadyUnlockedError, HardwareWalletClient, UnavailableActionError, DeviceNotReadyError
+from ..hwwclient import HardwareWalletClient
+from ..errors import DeviceAlreadyUnlockedError, UnavailableActionError, DeviceNotReadyError
 from keepkeylib.transport_hid import HidTransport
 from keepkeylib.transport_udp import UDPTransport
 from keepkeylib.client import BaseClient, DebugWireMixin, DebugLinkMixin, ProtocolMixin, TextUIMixin

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -1,6 +1,7 @@
 # Ledger interaction script
 
-from ..hwwclient import HardwareWalletClient, UnavailableActionError
+from ..hwwclient import HardwareWalletClient
+from ..errors import UnavailableActionError
 from btchip.btchip import *
 from btchip.btchipUtils import *
 import base64

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -95,7 +95,10 @@ class TrezorClient(HardwareWalletClient):
     # Retrieves the public key at the specified BIP 32 derivation path
     def get_pubkey_at_path(self, path):
         self._check_unlocked()
-        expanded_path = tools.parse_path(path)
+        try:
+            expanded_path = tools.parse_path(path)
+        except ValueError as e:
+            raise BadArgumentError(str(e))
         output = btc.get_public_node(self.client, expanded_path)
         if self.is_testnet:
             return {'xpub':xpub_main_2_test(output.xpub)}

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -1,7 +1,7 @@
 # Trezor interaction script
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import DeviceAlreadyInitError, DeviceAlreadyUnlockedError, UnavailableActionError, DeviceNotReadyError
+from ..errors import BadArgumentError, DeviceAlreadyInitError, DeviceAlreadyUnlockedError, UnavailableActionError, DeviceNotReadyError
 from trezorlib.client import TrezorClient as Trezor
 from trezorlib.debuglink import TrezorClientDebugLink
 from trezorlib.transport import enumerate_devices, get_transport
@@ -226,7 +226,7 @@ class TrezorClient(HardwareWalletClient):
                     if wit:
                         txoutput.address = bech32.encode(bech32_hrp, ver, prog)
                     else:
-                        raise TypeError("Output is not an address")
+                        raise BadArgumentError("Output is not an address")
 
                 # append to outputs
                 outputs.append(txoutput)
@@ -352,7 +352,7 @@ class TrezorClient(HardwareWalletClient):
             if self.client.features.pin_cached:
                 raise DeviceAlreadyUnlockedError('The PIN has already been sent to this device')
         if not pin.isdigit():
-            raise ValueError("Non-numeric PIN provided")
+            raise BadArgumentError("Non-numeric PIN provided")
         resp = self.client.call_raw(proto.PinMatrixAck(pin=pin))
         if isinstance(resp, proto.Failure):
             return {'success': False}

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -1,6 +1,7 @@
 # Trezor interaction script
 
-from ..hwwclient import HardwareWalletClient, DeviceAlreadyInitError, DeviceAlreadyUnlockedError, UnavailableActionError, DeviceNotReadyError
+from ..hwwclient import HardwareWalletClient
+from ..errors import DeviceAlreadyInitError, DeviceAlreadyUnlockedError, UnavailableActionError, DeviceNotReadyError
 from trezorlib.client import TrezorClient as Trezor
 from trezorlib.debuglink import TrezorClientDebugLink
 from trezorlib.transport import enumerate_devices, get_transport

--- a/hwilib/errors.py
+++ b/hwilib/errors.py
@@ -14,6 +14,8 @@ DEVICE_ALREADY_INIT = -10
 DEVICE_ALREADY_UNLOCKED = -11
 DEVICE_NOT_READY = -12
 UNKNOWN_ERROR = -13
+ACTION_CANCELED = -14
+DEVICE_BUSY = -15
 
 # Exceptions
 class HWWError(Exception):
@@ -70,3 +72,15 @@ class BadArgumentError(HWWError):
 class DeviceFailureError(HWWError):
     def __init__(self, msg):
         HWWError.__init__(self, msg, UNKNOWN_ERROR)
+
+class ActionCanceledError(HWWError):
+    def __init__(self, msg):
+        HWWError.__init__(self, msg, ACTION_CANCELED)
+
+class DeviceConnectionError(HWWError):
+    def __init__(self, msg):
+        HWWError.__init__(self, msg, DEVICE_CONN_ERROR)
+
+class DeviceBusyError(HWWError):
+    def __init__(self, msg):
+        HWWError.__init__(self, msg, DEVICE_BUSY)

--- a/hwilib/errors.py
+++ b/hwilib/errors.py
@@ -12,6 +12,8 @@ NOT_IMPLEMENTED = -8
 UNAVAILABLE_ACTION = -9
 DEVICE_ALREADY_INIT = -10
 DEVICE_ALREADY_UNLOCKED = -11
+DEVICE_NOT_READY = -12
+UNKNOWN_ERROR = -13
 
 # Exceptions
 class HWWError(Exception):
@@ -52,3 +54,19 @@ class DeviceAlreadyUnlockedError(HWWError):
 class UnknownDeviceError(HWWError):
     def __init__(self, msg):
         HWWError.__init__(self, msg, UNKNWON_DEVICE_TYPE)
+
+class NotImplementedError(HWWError):
+    def __init__(self, msg):
+        HWWError.__init__(self, msg, NOT_IMPLEMENTED)
+
+class PSBTSerializationError(HWWError):
+    def __init__(self, msg):
+        HWWError.__init__(self, msg, INVALID_TX)
+
+class BadArgumentError(HWWError):
+    def __init__(self, msg):
+        HWWError.__init__(self, msg, BAD_ARGUMENT)
+
+class DeviceFailureError(HWWError):
+    def __init__(self, msg):
+        HWWError.__init__(self, msg, UNKNOWN_ERROR)

--- a/hwilib/errors.py
+++ b/hwilib/errors.py
@@ -1,0 +1,39 @@
+# Defines errors and error codes
+
+# Error codes
+NO_DEVICE_PATH = -1
+NO_DEVICE_TYPE = -2
+DEVICE_CONN_ERROR = -3
+UNKNWON_DEVICE_TYPE = -4
+INVALID_TX = -5
+NO_PASSWORD = -6
+BAD_ARGUMENT = -7
+NOT_IMPLEMENTED = -8
+UNAVAILABLE_ACTION = -9
+DEVICE_ALREADY_INIT = -10
+DEVICE_ALREADY_UNLOCKED = -11
+
+# Exceptions
+class NoPasswordError(Exception):
+    def __init__(self,*args,**kwargs):
+        Exception.__init__(self,*args,**kwargs)
+
+class UnavailableActionError(Exception):
+    def __init__(self,*args,**kwargs):
+        Exception.__init__(self,*args,**kwargs)
+
+class DeviceAlreadyInitError(Exception):
+    def __init__(self,*args,**kwargs):
+        Exception.__init__(self,*args,**kwargs)
+
+class DeviceNotReadyError(Exception):
+    def __init__(self,*args,**kwargs):
+        Exception.__init__(self,*args,**kwargs)
+
+class DeviceAlreadyUnlockedError(Exception):
+    def __init__(self,*args,**kwargs):
+        Exception.__init__(self,*args,**kwargs)
+
+class UnknownDeviceError(Exception):
+    def __init__(self,*args,**kwargs):
+        Exception.__init__(self,*args,**kwargs)

--- a/hwilib/errors.py
+++ b/hwilib/errors.py
@@ -14,26 +14,41 @@ DEVICE_ALREADY_INIT = -10
 DEVICE_ALREADY_UNLOCKED = -11
 
 # Exceptions
-class NoPasswordError(Exception):
-    def __init__(self,*args,**kwargs):
-        Exception.__init__(self,*args,**kwargs)
+class HWWError(Exception):
+    def __init__(self, msg, code):
+        Exception.__init__(self)
+        self.code = code
+        self.msg = msg
 
-class UnavailableActionError(Exception):
-    def __init__(self,*args,**kwargs):
-        Exception.__init__(self,*args,**kwargs)
+    def get_code(self):
+        return self.code
 
-class DeviceAlreadyInitError(Exception):
-    def __init__(self,*args,**kwargs):
-        Exception.__init__(self,*args,**kwargs)
+    def get_msg(self):
+        return self.msg
 
-class DeviceNotReadyError(Exception):
-    def __init__(self,*args,**kwargs):
-        Exception.__init__(self,*args,**kwargs)
+    def __str__(self):
+        return self.msg
 
-class DeviceAlreadyUnlockedError(Exception):
-    def __init__(self,*args,**kwargs):
-        Exception.__init__(self,*args,**kwargs)
+class NoPasswordError(HWWError):
+    def __init__(self, msg):
+        HWWError.__init__(self, msg, NO_PASSWORD)
 
-class UnknownDeviceError(Exception):
-    def __init__(self,*args,**kwargs):
-        Exception.__init__(self,*args,**kwargs)
+class UnavailableActionError(HWWError):
+    def __init__(self, msg):
+        HWWError.__init__(self, msg, UNAVAILABLE_ACTION)
+
+class DeviceAlreadyInitError(HWWError):
+    def __init__(self, msg):
+        HWWError.__init__(self, msg, DEVICE_ALREADY_INIT)
+
+class DeviceNotReadyError(HWWError):
+    def __init__(self, msg):
+        HWWError.__init__(self, msg, DEVICE_NOT_READY)
+
+class DeviceAlreadyUnlockedError(HWWError):
+    def __init__(self, msg):
+        HWWError.__init__(self, msg, DEVICE_ALREADY_UNLOCKED)
+
+class UnknownDeviceError(HWWError):
+    def __init__(self, msg):
+        HWWError.__init__(self, msg, UNKNWON_DEVICE_TYPE)

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -61,23 +61,3 @@ class HardwareWalletClient(object):
     # Send pin
     def send_pin(self):
         raise NotImplementedError('The HardwareWalletClient base class does not implement this method')
-
-class NoPasswordError(Exception):
-    def __init__(self,*args,**kwargs):
-        Exception.__init__(self,*args,**kwargs)
-
-class UnavailableActionError(Exception):
-    def __init__(self,*args,**kwargs):
-        Exception.__init__(self,*args,**kwargs)
-
-class DeviceAlreadyInitError(Exception):
-    def __init__(self,*args,**kwargs):
-        Exception.__init__(self,*args,**kwargs)
-
-class DeviceNotReadyError(Exception):
-    def __init__(self,*args,**kwargs):
-        Exception.__init__(self,*args,**kwargs)
-
-class DeviceAlreadyUnlockedError(Exception):
-    def __init__(self,*args,**kwargs):
-        Exception.__init__(self,*args,**kwargs)

--- a/test/test_psbt.py
+++ b/test/test_psbt.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 
 from hwilib.serializations import PSBT
+from hwilib.errors import PSBTSerializationError
 import json
 import os
 import unittest
@@ -15,7 +16,7 @@ class TestPSBT(unittest.TestCase):
     def test_invalid_psbt(self):
         for invalid in self.data['invalid']:
             with self.subTest(invalid=invalid):
-                with self.assertRaises(IOError) as cm:
+                with self.assertRaises(PSBTSerializationError) as cm:
                     psbt = PSBT()
                     psbt.deserialize(invalid)
 


### PR DESCRIPTION
This PR adds `except` statements around the main command function to catch any and all exceptions and output the correct error code and message. Additional exceptions and error codes are added for new types of errors. Any exception thrown by a library will be caught and converted into the correct type of exception so that the correct message and code can be returned. This change makes it so that users using the command line tool should never see a backtrace.

This removes from the main `commands.py` file handling of exceptions. Instead those functions (which are intended for use as a library in other software) will throw the exceptions and the caller can handle them.