### PR TITLE
Descriptor support for displayaddress

### DIFF
--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -22,7 +22,7 @@ def backup_device_handler(args, client):
     return backup_device(client, label=args.label, backup_passphrase=args.backup_passphrase)
 
 def displayaddress_handler(args, client):
-    return displayaddress(client, path=args.path, sh_wpkh=args.sh_wpkh, wpkh=args.wpkh)
+    return displayaddress(client, desc=args.desc, path=args.path, sh_wpkh=args.sh_wpkh, wpkh=args.wpkh)
 
 def enumerate_handler(args):
     return enumerate(password=args.password)
@@ -102,7 +102,9 @@ def process_commands(args):
     getkeypool_parser.set_defaults(func=getkeypool_handler)
 
     displayaddr_parser = subparsers.add_parser('displayaddress', help='Display an address')
-    displayaddr_parser.add_argument('path', help='The BIP 32 derivation path of the key embedded in the address')
+    group = displayaddr_parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--desc', help='Output Descriptor. E.g. wpkh([00000000/84h/0h/0h]xpub.../0/0), where 00000000 must match --fingerprint and xpub can be obtained with getxpub. See doc/descriptors.md in Bitcoin Core')
+    group.add_argument('--path', help='The BIP 32 derivation path of the key embedded in the address, default follows BIP43 convention, e.g. m/84h/0h/0h/1/*')
     displayaddr_parser.add_argument('--sh_wpkh', action='store_true', help='Display the p2sh-nested segwit address associated with this key path')
     displayaddr_parser.add_argument('--wpkh', action='store_true', help='Display the bech32 version of the address associated with this key path')
     displayaddr_parser.set_defaults(func=displayaddress_handler)

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -58,6 +58,7 @@ def find_device(device_path, password='', device_type=None, fingerprint=None):
                 client.close()
                 continue
             else:
+                client.fingerprint = master_fpr
                 return client
         except:
             if client:

--- a/hwilib/descriptor.py
+++ b/hwilib/descriptor.py
@@ -1,0 +1,77 @@
+import re
+
+class Descriptor:
+    def __init__(self, origin_fingerprint, origin_path, base_key, path_suffix, testnet, sh_wpkh, wpkh):
+        self.origin_fingerprint = origin_fingerprint
+        self.origin_path = origin_path
+        self.path_suffix = path_suffix
+        self.base_key = base_key
+        self.testnet = testnet
+        self.sh_wpkh = sh_wpkh
+        self.wpkh = wpkh
+        self.m_path = None
+
+        if origin_path:
+            self.m_path_base = "m" + origin_path
+            self.m_path = "m" + origin_path + (path_suffix or "")
+
+    @classmethod
+    def parse(cls, desc, testnet = False):
+        sh_wpkh = None
+        wpkh = None
+        origin_fingerprint = None
+        origin_path = None
+        base_key_and_path_match = None
+        base_key = None
+        path_suffix = None
+
+        if desc.startswith("sh(wpkh("):
+            sh_wpkh = True
+        elif desc.startswith("wpkh("):
+            wpkh = True
+
+        origin_match = re.search(r"\[(.*)\]", desc)
+        if origin_match:
+            origin = origin_match.group(1)
+            match = re.search(r"^([0-9a-fA-F]{8})(\/.*)", origin)
+            if  match:
+              origin_fingerprint = match.group(1)
+              origin_path = match.group(2)
+              # Replace h with '
+              origin_path = origin_path.replace('h', '\'')
+
+            base_key_and_path_match = re.search(r"\[.*\](\w+)([\/\)][\d'\/\*]*)", desc)
+        else:
+            base_key_and_path_match = re.search(r"\((\w+)([\/\)][\d'\/\*]*)", desc)
+
+        if base_key_and_path_match:
+            base_key = base_key_and_path_match.group(1)
+            path_suffix = base_key_and_path_match.group(2)
+            if path_suffix == ")":
+                path_suffix = None
+        else:
+            if origin_match == None:
+                return None
+
+        return cls(origin_fingerprint, origin_path, base_key, path_suffix, testnet, sh_wpkh, wpkh)
+
+
+    def serialize(self):
+        descriptor_open = 'pkh('
+        descriptor_close = ')'
+        origin = ''
+        path_suffix = ''
+
+        if self.wpkh == True:
+            descriptor_open = 'wpkh('
+        elif self.sh_wpkh == True:
+            descriptor_open = 'sh(wpkh('
+            descriptor_close = '))'
+
+        if self.origin_fingerprint and self.origin_path:
+            origin = '[' + self.origin_fingerprint + self.origin_path + ']'
+
+        if self.path_suffix:
+            path_suffix = self.path_suffix
+
+        return descriptor_open + origin + self.base_key + path_suffix + descriptor_close

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -8,6 +8,7 @@ class HardwareWalletClient(object):
         self.password = password
         self.message_magic = b"\x18Bitcoin Signed Message:\n"
         self.is_testnet = False
+        self.fingerprint = None
 
     # Get the master BIP 44 pubkey
     def get_master_xpub(self):

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -7,6 +7,7 @@ import unittest
 
 from test_bech32 import TestSegwitAddress
 from test_coldcard import coldcard_test_suite
+from test_descriptor import TestDescriptor
 from test_device import start_bitcoind
 from test_psbt import TestPSBT
 from test_trezor import trezor_test_suite
@@ -35,6 +36,7 @@ args = parser.parse_args()
 
 # Run tests
 suite = unittest.TestSuite()
+suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestDescriptor))
 suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestSegwitAddress))
 suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestPSBT))
 

--- a/test/test_descriptor.py
+++ b/test/test_descriptor.py
@@ -1,0 +1,80 @@
+#! /usr/bin/env python3
+
+from hwilib.descriptor import Descriptor
+import unittest
+
+class TestDescriptor(unittest.TestCase):
+    def test_parse_descriptor_with_origin(self):
+        desc = Descriptor.parse("wpkh([00000001/84'/1'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0)", True)
+        self.assertIsNotNone(desc)
+        self.assertEqual(desc.wpkh, True)
+        self.assertEqual(desc.sh_wpkh, None)
+        self.assertEqual(desc.origin_fingerprint, "00000001")
+        self.assertEqual(desc.origin_path, "/84'/1'/0'")
+        self.assertEqual(desc.base_key, "tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B")
+        self.assertEqual(desc.path_suffix, "/0/0")
+        self.assertEqual(desc.testnet, True)
+        self.assertEqual(desc.m_path, "m/84'/1'/0'/0/0")
+
+    def test_parse_descriptor_without_origin(self):
+        desc = Descriptor.parse("wpkh(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0)", True)
+        self.assertIsNotNone(desc)
+        self.assertEqual(desc.wpkh, True)
+        self.assertEqual(desc.sh_wpkh, None)
+        self.assertEqual(desc.origin_fingerprint, None)
+        self.assertEqual(desc.origin_path, None)
+        self.assertEqual(desc.base_key, "tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B")
+        self.assertEqual(desc.path_suffix, "/0/0")
+        self.assertEqual(desc.testnet, True)
+        self.assertEqual(desc.m_path, None)
+
+    def test_parse_descriptor_with_key_at_end_with_origin(self):
+        desc = Descriptor.parse("wpkh([00000001/84'/1'/0'/0/0]0297dc3f4420402e01a113984311bf4a1b8de376cac0bdcfaf1b3ac81f13433c7)", True)
+        self.assertIsNotNone(desc)
+        self.assertEqual(desc.wpkh, True)
+        self.assertEqual(desc.sh_wpkh, None)
+        self.assertEqual(desc.origin_fingerprint, "00000001")
+        self.assertEqual(desc.origin_path, "/84'/1'/0'/0/0")
+        self.assertEqual(desc.base_key, "0297dc3f4420402e01a113984311bf4a1b8de376cac0bdcfaf1b3ac81f13433c7")
+        self.assertEqual(desc.path_suffix, None)
+        self.assertEqual(desc.testnet, True)
+        self.assertEqual(desc.m_path, "m/84'/1'/0'/0/0")
+
+    def test_parse_descriptor_with_key_at_end_without_origin(self):
+        desc = Descriptor.parse("wpkh(0297dc3f4420402e01a113984311bf4a1b8de376cac0bdcfaf1b3ac81f13433c7)", True)
+        self.assertIsNotNone(desc)
+        self.assertEqual(desc.wpkh, True)
+        self.assertEqual(desc.sh_wpkh, None)
+        self.assertEqual(desc.origin_fingerprint, None)
+        self.assertEqual(desc.origin_path, None)
+        self.assertEqual(desc.base_key, "0297dc3f4420402e01a113984311bf4a1b8de376cac0bdcfaf1b3ac81f13433c7")
+        self.assertEqual(desc.path_suffix, None)
+        self.assertEqual(desc.testnet, True)
+        self.assertEqual(desc.m_path, None)
+
+    def test_parse_empty_descriptor(self):
+        desc = Descriptor.parse("", True)
+        self.assertIsNone(desc)
+
+    def test_parse_descriptor_replace_h(self):
+        desc = Descriptor.parse("wpkh([00000001/84h/1h/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0)", True)
+        self.assertIsNotNone(desc)
+        self.assertEqual(desc.origin_path, "/84'/1'/0'")
+
+    def test_serialize_descriptor_with_origin(self):
+        descriptor = "wpkh([00000001/84'/1'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0)"
+        desc = Descriptor.parse(descriptor, True)
+        self.assertEqual(desc.serialize(), descriptor)
+
+    def test_serialize_descriptor_without_origin(self):
+        descriptor = "wpkh(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0)"
+        desc = Descriptor.parse(descriptor, True)
+        self.assertEqual(desc.serialize(), descriptor)
+
+    def test_serialize_descriptor_with_key_at_end_with_origin(self):
+        descriptor = "wpkh([00000001/84'/1'/0'/0/0]0297dc3f4420402e01a113984311bf4a1b8de376cac0bdcfaf1b3ac81f13433c7)"
+        desc = Descriptor.parse(descriptor, True)
+        self.assertEqual(desc.serialize(), descriptor)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -64,7 +64,7 @@ def digitalbitbox_test_suite(rpc, userpass, simulator):
             self.assertEqual(result['code'], -9)
 
         def test_display(self):
-            result = process_commands(self.dev_args + ['displayaddress', 'm/0h'])
+            result = process_commands(self.dev_args + ['displayaddress', '--path', 'm/0h'])
             self.assertIn('error', result)
             self.assertIn('code', result)
             self.assertEqual(result['error'], 'The Digital Bitbox does not have a screen to display addresses on')


### PR DESCRIPTION
Adds a `Descriptor` class, which currently handles some of the descriptor functionality.

Changes `displayaddress` to allow a descriptor argument. This means `--path` and `--desc` are now named arguments.

When using a descriptor  `displayaddress` performs additional checks to make sure the fingerprint and xpub match. To enable the fingerprint check, I'm storing the fingerprint on `HardwareWalletClient` instances.