### PR TITLE
Add more tests and related fixes

### DIFF
--- a/hwilib/base58.py
+++ b/hwilib/base58.py
@@ -87,18 +87,6 @@ def to_address(b, version):
     data += checksum
     return encode(data)
 
-def pubkey_to_address(pubkey, testnet=False):
-    pkh = hash160(pubkey)
-    if testnet:
-        return to_address(pkh, b'\x6f')
-    else:
-        return to_address(pkh, b'\x00')
-
-def xpub_to_address(xpub, testnet=False):
-    data = decode(xpub)
-    pubkey = data[-37:-4]
-    return pubkey_to_address(pubkey, testnet)
-
 def xpub_to_pub_hex(xpub):
     data = decode(xpub)
     pubkey = data[-37:-4]

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -6,7 +6,7 @@ import glob
 import importlib
 
 from .serializations import PSBT, Base64ToHex, HexToBase64, hash160
-from .base58 import xpub_to_address, xpub_to_pub_hex, get_xpub_fingerprint_as_id, get_xpub_fingerprint_hex
+from .base58 import get_xpub_fingerprint_as_id, get_xpub_fingerprint_hex
 from os.path import dirname, basename, isfile
 from .errors import NoPasswordError, UnavailableActionError, DeviceAlreadyInitError, DeviceAlreadyUnlockedError, UnknownDeviceError, BAD_ARGUMENT, NOT_IMPLEMENTED
 

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -176,8 +176,13 @@ class ColdcardClient(HardwareWalletClient):
 
         ok = self.device.send_recv(CCProtocolPacker.start_backup())
         assert ok == None
+        if self.device.is_simulator:
+            self.device.send_recv(CCProtocolPacker.sim_keypress(b'y'))
 
         while 1:
+            if self.device.is_simulator: # For the simulator, work through the password quiz. Eventually pressing 1 will work
+                self.device.send_recv(CCProtocolPacker.sim_keypress(b'1'))
+
             time.sleep(0.250)
             done = self.device.send_recv(CCProtocolPacker.get_backup_file(), timeout=None)
             if done == None:
@@ -192,7 +197,7 @@ class ColdcardClient(HardwareWalletClient):
         result = self.device.download_file(result_len, result_sha, file_number=0)
         filename = time.strftime('backup-%Y%m%d-%H%M.7z')
         open(filename, 'wb').write(result)
-        return {'success': True, 'message': 'The backup has be written to {}'.format(filename)}
+        return {'success': True, 'message': 'The backup has been written to {}'.format(filename)}
 
     # Close the device
     def close(self):
@@ -203,7 +208,7 @@ class ColdcardClient(HardwareWalletClient):
         raise UnavailableActionError('The Coldcard does not need a PIN sent from the host')
 
     # Send pin
-    def send_pin(self):
+    def send_pin(self, pin):
         raise UnavailableActionError('The Coldcard does not need a PIN sent from the host')
 
 def enumerate(password=''):

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -118,13 +118,10 @@ class ColdcardClient(HardwareWalletClient):
         keypath = keypath.replace('h', '\'')
         keypath = keypath.replace('H', '\'')
 
-        try:
-            ok = self.device.send_recv(CCProtocolPacker.sign_message(message.encode(), keypath, AF_CLASSIC), timeout=None)
-            assert ok == None
-            if self.device.is_simulator:
-                self.device.send_recv(CCProtocolPacker.sim_keypress(b'y'))
-        except CCProtoError as e:
-            raise DeviceFailureError(str(e))
+        ok = self.device.send_recv(CCProtocolPacker.sign_message(message.encode(), keypath, AF_CLASSIC), timeout=None)
+        assert ok == None
+        if self.device.is_simulator:
+            self.device.send_recv(CCProtocolPacker.sim_keypress(b'y'))
 
         while 1:
             time.sleep(0.250)

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -48,6 +48,7 @@ bad_args = [
     411, # Filenames limited to alphanumeric values, hyphens, and underscores.
     412, # Please provide an encryption key.
     112, # Device password matches reset password. Disabling reset password.
+    251, # Could not generate key.
 ]
 
 device_failures = [
@@ -55,7 +56,6 @@ device_failures = [
     107, # Output buffer overflow.
     200, # Seed creation requires an SD card for automatic encrypted backup of the seed.
     250, # Master key not present.
-    251, # Could not generate key.
     252, # Could not generate ECDH secret.
     303, # Could not sign.
     400, # Please insert SD card.

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -309,7 +309,7 @@ class LedgerClient(HardwareWalletClient):
         raise UnavailableActionError('The Ledger Nano S does not need a PIN sent from the host')
 
     # Send pin
-    def send_pin(self):
+    def send_pin(self, pin):
         raise UnavailableActionError('The Ledger Nano S does not need a PIN sent from the host')
 
 def enumerate(password=''):

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -3,7 +3,7 @@
 from ..hwwclient import HardwareWalletClient
 from ..errors import ActionCanceledError, BadArgumentError, DeviceAlreadyInitError, DeviceAlreadyUnlockedError, DeviceConnectionError, UnavailableActionError, DeviceNotReadyError
 from trezorlib.client import TrezorClient as Trezor
-from trezorlib.debuglink import TrezorClientDebugLink
+from trezorlib.debuglink import DebugLink, DebugUI, TrezorClientDebugLink
 from trezorlib.exceptions import Cancelled
 from trezorlib.transport import enumerate_devices, get_transport
 from trezorlib.ui import ClickUI, mnemonic_words, PIN_MATRIX_DESCRIPTION
@@ -58,15 +58,24 @@ def parse_multisig(script):
     return (True, multisig)
 
 class TrezorNoInit(Trezor):
-    def __init__(self, transport, ui=None, state=None):
-        self.transport = transport
-        self.ui = ui
-        self.state = state
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-        if ui is None:
-            warnings.warn("UI class not supplied. This will probably crash soon.")
+    def init_device(self):
+        pass
 
-        self.session_counter = 0
+    def actual_init_device(self):
+        return super().init_device()
+
+class TrezorDebugNoInit(TrezorClientDebugLink):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def init_device(self):
+        pass
+
+    def actual_init_device(self):
+        return super().init_device()
 
 def trezor_exception(f):
     def func(*args, **kwargs):
@@ -88,7 +97,7 @@ class TrezorClient(HardwareWalletClient):
         if path.startswith('udp'):
             logging.debug('Simulator found, using DebugLink')
             transport = get_transport(path)
-            self.client = TrezorClientDebugLink(transport=transport)
+            self.client = TrezorDebugNoInit(transport=transport)
         else:
             self.client = TrezorNoInit(transport=get_transport(path), ui=ClickUI())
 
@@ -101,7 +110,7 @@ class TrezorClient(HardwareWalletClient):
         self.client.open()
 
     def _check_unlocked(self):
-        self.client.init_device()
+        self.client.actual_init_device()
         if self.client.features.pin_protection and not self.client.features.pin_cached:
             raise DeviceNotReadyError('Trezor is locked. Unlock by using \'promptpin\' and then \'sendpin\'.')
 
@@ -325,7 +334,7 @@ class TrezorClient(HardwareWalletClient):
     # Setup a new device
     @trezor_exception
     def setup_device(self, label='', passphrase=''):
-        self.client.init_device()
+        self.client.actual_init_device()
         if self.client.features.initialized:
             raise DeviceAlreadyInitError('Device is already initialized. Use wipe first and try again')
         passphrase_enabled = False
@@ -360,7 +369,7 @@ class TrezorClient(HardwareWalletClient):
     # Prompt for a pin on device
     @trezor_exception
     def prompt_pin(self):
-        self.client.init_device()
+        self.client.actual_init_device()
         if not self.client.features.pin_protection:
             raise DeviceAlreadyUnlockedError('This device does not need a PIN')
         if self.client.features.pin_cached:
@@ -397,7 +406,7 @@ def enumerate(password=''):
         client = None
         try:
             client = TrezorClient(d_data['path'], password)
-            client.client.init_device()
+            client.client.actual_init_device()
             if client.client.features.initialized:
                 master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
                 d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -91,12 +91,6 @@ def uint256_from_str(s):
     return r
 
 
-def uint256_from_compact(c):
-    nbytes = (c >> 24) & 0xFF
-    v = (c & 0xFFFFFF) << (8 * (nbytes - 3))
-    return v
-
-
 def deser_vector(f, c):
     nit = deser_compact_size(f)
     r = []
@@ -120,22 +114,6 @@ def ser_vector(l, ser_function_name=None):
     return r
 
 
-def deser_uint256_vector(f):
-    nit = deser_compact_size(f)
-    r = []
-    for i in range(nit):
-        t = deser_uint256(f)
-        r.append(t)
-    return r
-
-
-def ser_uint256_vector(l):
-    r = ser_compact_size(len(l))
-    for i in l:
-        r += ser_uint256(i)
-    return r
-
-
 def deser_string_vector(f):
     nit = deser_compact_size(f)
     r = []
@@ -150,31 +128,6 @@ def ser_string_vector(l):
     for sv in l:
         r += ser_string(sv)
     return r
-
-
-def deser_int_vector(f):
-    nit = deser_compact_size(f)
-    r = []
-    for i in range(nit):
-        t = struct.unpack("<i", f.read(4))[0]
-        r.append(t)
-    return r
-
-
-def ser_int_vector(l):
-    r = ser_compact_size(len(l))
-    for i in l:
-        r += struct.pack("<i", i)
-    return r
-
-# Deserialize from a hex string representation (eg from RPC)
-def FromHex(obj, hex_string):
-    obj.deserialize(BytesIO(hex_str_to_bytes(hex_string)))
-    return obj
-
-# Convert a binary-serializable object to hex (eg for submission via RPC)
-def ToHex(obj):
-    return bytes_to_hex_str(obj.serialize())
 
 def Base64ToHex(s):
     return binascii.hexlify(base64.b64decode(s))
@@ -477,13 +430,6 @@ class CTransaction(object):
         if self.sha256 is None:
             self.sha256 = uint256_from_str(hash256(self.serialize_without_witness()))
         self.hash = encode(hash256(self.serialize())[::-1], 'hex_codec').decode('ascii')
-
-    def is_valid(self):
-        self.calc_sha256()
-        for tout in self.vout:
-            if tout.nValue < 0 or tout.nValue > 21000000 * COIN:
-                return False
-        return True
 
     def is_null(self):
         return len(self.vin) == 0 and len(self.vout) == 0

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -38,7 +38,7 @@ suite = unittest.TestSuite()
 suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestSegwitAddress))
 suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestPSBT))
 
-if not args.no_trezor or not args.no_coldcard or args.ledger or not args.no_bitbox:
+if not args.no_trezor or not args.no_coldcard or args.ledger or not args.no_bitbox or not args.no_keepkey:
     # Start bitcoind
     rpc, userpass = start_bitcoind(args.bitcoind)
 

--- a/test/test_coldcard.py
+++ b/test/test_coldcard.py
@@ -27,8 +27,8 @@ def coldcard_test_suite(simulator, rpc, userpass):
         resp = dev.send_recv(CCProtocolPacker.logout())
     atexit.register(cleanup_simulator)
 
-    # Coldcard specific setup and wipe tests
-    class TestColdcardSetupWipe(DeviceTestCase):
+    # Coldcard specific management command tests
+    class TestColdcardManCommands(DeviceTestCase):
         def test_setup(self):
             result = process_commands(self.dev_args + ['setup'])
             self.assertIn('error', result)
@@ -43,9 +43,34 @@ def coldcard_test_suite(simulator, rpc, userpass):
             self.assertEqual(result['error'], 'The Coldcard does not support wiping via software')
             self.assertEqual(result['code'], -9)
 
+        def test_restore(self):
+            result = process_commands(self.dev_args + ['restore'])
+            self.assertIn('error', result)
+            self.assertIn('code', result)
+            self.assertEqual(result['error'], 'The Coldcard does not support restoring via software')
+            self.assertEqual(result['code'], -9)
+
+        def test_backup(self):
+            result = process_commands(self.dev_args + ['backup'])
+            self.assertTrue(result['success'])
+            self.assertIn('The backup has been written to', result['message'])
+
+        def test_pin(self):
+            result = process_commands(self.dev_args + ['promptpin'])
+            self.assertIn('error', result)
+            self.assertIn('code', result)
+            self.assertEqual(result['error'], 'The Coldcard does not need a PIN sent from the host')
+            self.assertEqual(result['code'], -9)
+
+            result = process_commands(self.dev_args + ['sendpin', '1234'])
+            self.assertIn('error', result)
+            self.assertIn('code', result)
+            self.assertEqual(result['error'], 'The Coldcard does not need a PIN sent from the host')
+            self.assertEqual(result['code'], -9)
+
     # Generic device tests
     suite = unittest.TestSuite()
-    suite.addTest(DeviceTestCase.parameterize(TestColdcardSetupWipe, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', ''))
+    suite.addTest(DeviceTestCase.parameterize(TestColdcardManCommands, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', ''))
     suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd'))
     suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd'))
     suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd'))

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -401,6 +401,10 @@ class TestDisplayAddress(DeviceTestCase):
         process_commands(self.dev_args + ['displayaddress', '--sh_wpkh', 'm/49h/1h/0h/0/0'])
         process_commands(self.dev_args + ['displayaddress', '--wpkh', 'm/84h/1h/0h/0/0'])
 
+    def test_bad_path(self):
+        result = process_commands(self.dev_args + ['displayaddress', 'f'])
+        self.assertEquals(result['code'], -7)
+
 class TestSignMessage(DeviceTestCase):
     def setUp(self):
         self.emulator.start()
@@ -410,3 +414,7 @@ class TestSignMessage(DeviceTestCase):
 
     def test_sign_msg(self):
         process_commands(self.dev_args + ['signmessage', 'Message signing test', 'm/44h/1h/0h/0/0'])
+
+    def test_bad_path(self):
+        result = process_commands(self.dev_args + ['signmessage', 'Message signing test', 'f'])
+        self.assertEquals(result['code'], -7)

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -112,9 +112,19 @@ class TestDeviceConnect(DeviceTestCase):
         gmxp_res = process_commands(['-f', self.fingerprint, '-p', self.password, 'getmasterxpub'])
         self.assertEqual(gmxp_res['xpub'], self.master_xpub)
 
-    def test_type_only_autodetech(self):
+        # Nonexistent fingerprint
+        gmxp_res = process_commands(['-f', '0000ffff', '-p', self.password, 'getmasterxpub'])
+        self.assertEqual(gmxp_res['error'], 'Could not find device with specified fingerprint')
+        self.assertEqual(gmxp_res['code'], -3)
+
+    def test_type_only_autodetect(self):
         gmxp_res = process_commands(['-t', self.type, '-p', self.password, 'getmasterxpub'])
         self.assertEqual(gmxp_res['xpub'], self.master_xpub)
+
+        # Unknown device type
+        gmxp_res = process_commands(['-t', 'fakedev', '-d', 'fakepath', 'getmasterxpub'])
+        self.assertEqual(gmxp_res['error'], 'Unknown device type specified')
+        self.assertEqual(gmxp_res['code'], -4)
 
 class TestGetKeypool(DeviceTestCase):
     def setUp(self):

--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -41,8 +41,89 @@ def digitalbitbox_test_suite(rpc, userpass, simulator):
     fingerprint = 'a31b978a'
     master_xpub = 'xpub6BsWJiRvbzQJg3J6tgUKmHWYbHJSj41EjAAje6LuDwnYLqLiNSWK4N7rCXwiUmNJTBrKL8AEH3LBzhJdgdxoy4T9aMPLCWAa6eWKGCFjQhq'
 
+    # DigitalBitbox specific management command tests
+    class TestDBBManCommands(DeviceTestCase):
+        def test_restore(self):
+            result = process_commands(self.dev_args + ['restore'])
+            self.assertIn('error', result)
+            self.assertIn('code', result)
+            self.assertEqual(result['error'], 'The Digital Bitbox does not support restoring via software')
+            self.assertEqual(result['code'], -9)
+
+        def test_pin(self):
+            result = process_commands(self.dev_args + ['promptpin'])
+            self.assertIn('error', result)
+            self.assertIn('code', result)
+            self.assertEqual(result['error'], 'The Digital Bitbox does not need a PIN sent from the host')
+            self.assertEqual(result['code'], -9)
+
+            result = process_commands(self.dev_args + ['sendpin', '1234'])
+            self.assertIn('error', result)
+            self.assertIn('code', result)
+            self.assertEqual(result['error'], 'The Digital Bitbox does not need a PIN sent from the host')
+            self.assertEqual(result['code'], -9)
+
+        def test_display(self):
+            result = process_commands(self.dev_args + ['displayaddress', 'm/0h'])
+            self.assertIn('error', result)
+            self.assertIn('code', result)
+            self.assertEqual(result['error'], 'The Digital Bitbox does not have a screen to display addresses on')
+            self.assertEqual(result['code'], -9)
+
+        def test_setup_wipe(self):
+            # Device is init, setup should fail
+            result = process_commands(self.dev_args + ['setup', '--label', 'setup_test', '--backup_passphrase', 'testpass'])
+            self.assertEquals(result['code'], -10)
+            self.assertEquals(result['error'], 'Device is already initialized. Use wipe first and try again')
+
+            # Wipe
+            result = process_commands(self.dev_args + ['wipe'])
+            self.assertTrue(result['success'])
+
+            # Check arguments
+            result = process_commands(self.dev_args + ['setup', '--label', 'setup_test'])
+            self.assertEquals(result['code'], -7)
+            self.assertEquals(result['error'], 'The label and backup passphrase for a new Digital Bitbox wallet must be specified and cannot be empty')
+            result = process_commands(self.dev_args + ['setup', '--backup_passphrase', 'testpass'])
+            self.assertEquals(result['code'], -7)
+            self.assertEquals(result['error'], 'The label and backup passphrase for a new Digital Bitbox wallet must be specified and cannot be empty')
+
+            # Setup
+            result = process_commands(self.dev_args + ['setup', '--label', 'setup_test', '--backup_passphrase', 'testpass'])
+            self.assertTrue(result['success'])
+
+            # Reset back to original
+            send_encrypt(json.dumps({"seed":{"source":"backup","filename":"test_backup.pdf","key":"key"}}), '0000', dev)
+
+            # Make sure device is init, setup should fail
+            result = process_commands(self.dev_args + ['setup', '--label', 'setup_test', '--backup_passphrase', 'testpass'])
+            self.assertEquals(result['code'], -10)
+            self.assertEquals(result['error'], 'Device is already initialized. Use wipe first and try again')
+
+        def test_backup(self):
+            # Check arguments
+            result = process_commands(self.dev_args + ['backup', '--label', 'backup_test'])
+            self.assertEquals(result['code'], -7)
+            self.assertEquals(result['error'], 'The label and backup passphrase for a Digital Bitbox backup must be specified and cannot be empty')
+            result = process_commands(self.dev_args + ['backup', '--backup_passphrase', 'key'])
+            self.assertEquals(result['code'], -7)
+            self.assertEquals(result['error'], 'The label and backup passphrase for a Digital Bitbox backup must be specified and cannot be empty')
+
+            # Wipe
+            result = process_commands(self.dev_args + ['wipe'])
+            self.assertTrue(result['success'])
+
+            # Setup
+            result = process_commands(self.dev_args + ['setup', '--label', 'backup_test', '--backup_passphrase', 'testpass'])
+            self.assertTrue(result['success'])
+
+            # make the backup
+            result = process_commands(self.dev_args + ['backup', '--label', 'backup_test_backup', '--backup_passphrase', 'testpass'])
+            self.assertTrue(result['success'])
+
     # Generic Device tests
     suite = unittest.TestSuite()
+    suite.addTest(DeviceTestCase.parameterize(TestDBBManCommands, rpc, userpass, type, path, fingerprint, master_xpub, '0000'))
     suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, type, path, fingerprint, master_xpub, '0000'))
     suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, type, path, fingerprint, master_xpub, '0000'))
     suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, type, path, fingerprint, master_xpub, '0000'))

--- a/test/test_ledger.py
+++ b/test/test_ledger.py
@@ -10,7 +10,7 @@ import time
 import unittest
 
 from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
-from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestDisplayAddress, TestGetKeypool, TestSignTx
+from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestDisplayAddress, TestGetKeypool, TestSignMessage, TestSignTx
 
 from hwilib.cli import process_commands
 
@@ -28,12 +28,57 @@ def ledger_test_suite(rpc, userpass):
             break
     assert(path is not None and master_xpub is not None and fingerprint is not None)
 
+    # Ledger specific disabled command tests
+    class TestLedgerDisabledCommands(DeviceTestCase):
+        def test_pin(self):
+            result = process_commands(self.dev_args + ['promptpin'])
+            self.assertIn('error', result)
+            self.assertIn('code', result)
+            self.assertEqual(result['error'], 'The Ledger Nano S does not need a PIN sent from the host')
+            self.assertEqual(result['code'], -9)
+
+            result = process_commands(self.dev_args + ['sendpin', '1234'])
+            self.assertIn('error', result)
+            self.assertIn('code', result)
+            self.assertEqual(result['error'], 'The Ledger Nano S does not need a PIN sent from the host')
+            self.assertEqual(result['code'], -9)
+
+        def test_setup(self):
+            result = process_commands(self.dev_args + ['setup'])
+            self.assertIn('error', result)
+            self.assertIn('code', result)
+            self.assertEqual(result['error'], 'The Ledger Nano S does not support software setup')
+            self.assertEqual(result['code'], -9)
+
+        def test_wipe(self):
+            result = process_commands(self.dev_args + ['wipe'])
+            self.assertIn('error', result)
+            self.assertIn('code', result)
+            self.assertEqual(result['error'], 'The Ledger Nano S does not support wiping via software')
+            self.assertEqual(result['code'], -9)
+
+        def test_restore(self):
+            result = process_commands(self.dev_args + ['restore'])
+            self.assertIn('error', result)
+            self.assertIn('code', result)
+            self.assertEqual(result['error'], 'The Ledger Nano S does not support restoring via software')
+            self.assertEqual(result['code'], -9)
+
+        def test_backup(self):
+            result = process_commands(self.dev_args + ['backup'])
+            self.assertIn('error', result)
+            self.assertIn('code', result)
+            self.assertEqual(result['error'], 'The Ledger Nano S does not support creating a backup via software')
+            self.assertEqual(result['code'], -9)
+
     # Generic Device tests
     suite = unittest.TestSuite()
+    suite.addTest(DeviceTestCase.parameterize(TestLedgerDisabledCommands, rpc, userpass, 'ledger', path, fingerprint, master_xpub))
     suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'ledger', path, fingerprint, master_xpub))
     suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, 'ledger', path, fingerprint, master_xpub))
     suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, 'ledger', path, fingerprint, master_xpub))
     suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, 'ledger', path, fingerprint, master_xpub))
+    suite.addTest(DeviceTestCase.parameterize(TestSignMessage, rpc, userpass, 'ledger', path, fingerprint, master_xpub))
     return suite
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds tests for nearly all commands for all devices and related fixes. Only `restore` for `trezor` and `keepkey` are untested as I could not get them to work. All other commands for all devices have tests and related bug fixes.