### PR TITLE
Add a switch for interactivity and make setup and restore interactive only commands

### DIFF
--- a/hwilib/devices/trezorlib/ui.py
+++ b/hwilib/devices/trezorlib/ui.py
@@ -50,8 +50,12 @@ PIN_CONFIRM = PinMatrixRequestType.NewSecond
 def echo(msg):
     print(msg, file=sys.stderr)
 
-def prompt(msg):
-    return input(msg)
+def prompt(msg, hide_input=False):
+    if hide_input:
+        import getpass
+        return getpass.getpass(msg + ' :\n')
+    else:
+        return input(msg + ':\n')
 
 class PassphraseUI:
     def __init__(self, passphrase):

--- a/test/test_coldcard.py
+++ b/test/test_coldcard.py
@@ -30,7 +30,7 @@ def coldcard_test_suite(simulator, rpc, userpass, interface):
     # Coldcard specific management command tests
     class TestColdcardManCommands(DeviceTestCase):
         def test_setup(self):
-            result = self.do_command(self.dev_args + ['setup'])
+            result = self.do_command(self.dev_args + ['-i', 'setup'])
             self.assertIn('error', result)
             self.assertIn('code', result)
             self.assertEqual(result['error'], 'The Coldcard does not support software setup')
@@ -44,7 +44,7 @@ def coldcard_test_suite(simulator, rpc, userpass, interface):
             self.assertEqual(result['code'], -9)
 
         def test_restore(self):
-            result = self.do_command(self.dev_args + ['restore'])
+            result = self.do_command(self.dev_args + ['-i', 'restore'])
             self.assertIn('error', result)
             self.assertIn('code', result)
             self.assertEqual(result['error'], 'The Coldcard does not support restoring via software')

--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -44,7 +44,7 @@ def digitalbitbox_test_suite(rpc, userpass, simulator, interface):
     # DigitalBitbox specific management command tests
     class TestDBBManCommands(DeviceTestCase):
         def test_restore(self):
-            result = self.do_command(self.dev_args + ['restore'])
+            result = self.do_command(self.dev_args + ['-i', 'restore'])
             self.assertIn('error', result)
             self.assertIn('code', result)
             self.assertEqual(result['error'], 'The Digital Bitbox does not support restoring via software')
@@ -72,7 +72,7 @@ def digitalbitbox_test_suite(rpc, userpass, simulator, interface):
 
         def test_setup_wipe(self):
             # Device is init, setup should fail
-            result = self.do_command(self.dev_args + ['setup', '--label', 'setup_test', '--backup_passphrase', 'testpass'])
+            result = self.do_command(self.dev_args + ['-i', 'setup', '--label', 'setup_test', '--backup_passphrase', 'testpass'])
             self.assertEquals(result['code'], -10)
             self.assertEquals(result['error'], 'Device is already initialized. Use wipe first and try again')
 
@@ -81,15 +81,15 @@ def digitalbitbox_test_suite(rpc, userpass, simulator, interface):
             self.assertTrue(result['success'])
 
             # Check arguments
-            result = self.do_command(self.dev_args + ['setup', '--label', 'setup_test'])
+            result = self.do_command(self.dev_args + ['-i', 'setup', '--label', 'setup_test'])
             self.assertEquals(result['code'], -7)
             self.assertEquals(result['error'], 'The label and backup passphrase for a new Digital Bitbox wallet must be specified and cannot be empty')
-            result = self.do_command(self.dev_args + ['setup', '--backup_passphrase', 'testpass'])
+            result = self.do_command(self.dev_args + ['-i', 'setup', '--backup_passphrase', 'testpass'])
             self.assertEquals(result['code'], -7)
             self.assertEquals(result['error'], 'The label and backup passphrase for a new Digital Bitbox wallet must be specified and cannot be empty')
 
             # Setup
-            result = self.do_command(self.dev_args + ['setup', '--label', 'setup_test', '--backup_passphrase', 'testpass'])
+            result = self.do_command(self.dev_args + ['-i', 'setup', '--label', 'setup_test', '--backup_passphrase', 'testpass'])
             self.assertTrue(result['success'])
 
             # Reset back to original
@@ -99,7 +99,7 @@ def digitalbitbox_test_suite(rpc, userpass, simulator, interface):
             send_encrypt(json.dumps({"seed":{"source":"backup","filename":"test_backup.pdf","key":"key"}}), '0000', dev)
 
             # Make sure device is init, setup should fail
-            result = self.do_command(self.dev_args + ['setup', '--label', 'setup_test', '--backup_passphrase', 'testpass'])
+            result = self.do_command(self.dev_args + ['-i', 'setup', '--label', 'setup_test', '--backup_passphrase', 'testpass'])
             self.assertEquals(result['code'], -10)
             self.assertEquals(result['error'], 'Device is already initialized. Use wipe first and try again')
 
@@ -117,7 +117,7 @@ def digitalbitbox_test_suite(rpc, userpass, simulator, interface):
             self.assertTrue(result['success'])
 
             # Setup
-            result = self.do_command(self.dev_args + ['setup', '--label', 'backup_test', '--backup_passphrase', 'testpass'])
+            result = self.do_command(self.dev_args + ['-i', 'setup', '--label', 'backup_test', '--backup_passphrase', 'testpass'])
             self.assertTrue(result['success'])
 
             # make the backup

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -141,7 +141,7 @@ class TestKeepkeyManCommands(KeepkeyTestCase):
 
     def test_setup_wipe(self):
         # Device is init, setup should fail
-        result = self.do_command(self.dev_args + ['setup'])
+        result = self.do_command(self.dev_args + ['-i', 'setup'])
         self.assertEquals(result['code'], -10)
         self.assertEquals(result['error'], 'Device is already initialized. Use wipe first and try again')
 
@@ -157,7 +157,7 @@ class TestKeepkeyManCommands(KeepkeyTestCase):
         self.assertTrue(result['success'])
 
         # Make sure device is init, setup should fail
-        result = self.do_command(self.dev_args + ['setup'])
+        result = self.do_command(self.dev_args + ['-i', 'setup'])
         self.assertEquals(result['code'], -10)
         self.assertEquals(result['error'], 'Device is already initialized. Use wipe first and try again')
 

--- a/test/test_ledger.py
+++ b/test/test_ledger.py
@@ -44,7 +44,7 @@ def ledger_test_suite(rpc, userpass, interface):
             self.assertEqual(result['code'], -9)
 
         def test_setup(self):
-            result = self.do_command(self.dev_args + ['setup'])
+            result = self.do_command(self.dev_args + ['-i', 'setup'])
             self.assertIn('error', result)
             self.assertIn('code', result)
             self.assertEqual(result['error'], 'The Ledger Nano S does not support software setup')
@@ -58,7 +58,7 @@ def ledger_test_suite(rpc, userpass, interface):
             self.assertEqual(result['code'], -9)
 
         def test_restore(self):
-            result = self.do_command(self.dev_args + ['restore'])
+            result = self.do_command(self.dev_args + ['-i', 'restore'])
             self.assertIn('error', result)
             self.assertIn('code', result)
             self.assertEqual(result['error'], 'The Ledger Nano S does not support restoring via software')

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -141,7 +141,7 @@ class TestTrezorManCommands(TrezorTestCase):
 
     def test_setup_wipe(self):
         # Device is init, setup should fail
-        result = self.do_command(self.dev_args + ['setup'])
+        result = self.do_command(self.dev_args + ['-i', 'setup'])
         self.assertEquals(result['code'], -10)
         self.assertEquals(result['error'], 'Device is already initialized. Use wipe first and try again')
 
@@ -157,7 +157,7 @@ class TestTrezorManCommands(TrezorTestCase):
         self.assertTrue(result['success'])
 
         # Make sure device is init, setup should fail
-        result = self.do_command(self.dev_args + ['setup'])
+        result = self.do_command(self.dev_args + ['-i', 'setup'])
         self.assertEquals(result['code'], -10)
         self.assertEquals(result['error'], 'Device is already initialized. Use wipe first and try again')
 


### PR DESCRIPTION
Currently using setup and restore on the Trezor and Keepkey (which are basically the only devices that support setup and restore) are broken. They require user interaction. Instead of removing them entirely, move those commands behind a switch, `--interactive`.