### PR TITLE
Add option to enter commands over stdin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,8 @@ jobs:
             script: cd test; poetry run ./run_tests.py --interface=library
         -   name: With command line interface
             script: cd test; poetry run ./run_tests.py --interface=cli
+        -   name: With stdin interface
+            script: cd test; ./run_tests.py --interface=stdin
         -   name: With linux binary distribution command line interface
             services: docker
             before_script:

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -32,7 +32,7 @@ dbb_group.add_argument('--no_bitbox', help='Do not run Digital Bitbox test with 
 dbb_group.add_argument('--bitbox', help='Path to Digital bitbox simulator.', default='work/mcu/build/bin/simulator')
 
 parser.add_argument('--bitcoind', help='Path to bitcoind.', default='work/bitcoin/src/bitcoind')
-parser.add_argument('--interface', help='Which interface to send commands over', choices=['library', 'cli', 'bindist'], default='library')
+parser.add_argument('--interface', help='Which interface to send commands over', choices=['library', 'cli', 'bindist', 'stdin'], default='library')
 args = parser.parse_args()
 
 # Run tests

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -87,6 +87,11 @@ class DeviceTestCase(unittest.TestCase):
             proc = subprocess.Popen(['../dist/hwi ' + ' '.join(args)], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, shell=True)
             result = proc.communicate()
             return json.loads(result[0].decode())
+        elif self.interface == 'stdin':
+            input_str = '\n'.join(args) + '\n'
+            proc = subprocess.Popen(['hwi', '--stdin'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+            result = proc.communicate(input_str.encode())
+            return json.loads(result[0].decode())
         else:
             return process_commands(args)
 

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -90,6 +90,11 @@ class KeepkeyTestCase(unittest.TestCase):
             proc = subprocess.Popen(['../dist/hwi ' + ' '.join(args)], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, shell=True)
             result = proc.communicate()
             return json.loads(result[0].decode())
+        elif self.interface == 'stdin':
+            input_str = '\n'.join(args) + '\n'
+            proc = subprocess.Popen(['hwi', '--stdin'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+            result = proc.communicate(input_str.encode())
+            return json.loads(result[0].decode())
         else:
             return process_commands(args)
 

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -90,6 +90,11 @@ class TrezorTestCase(unittest.TestCase):
             proc = subprocess.Popen(['../dist/hwi ' + ' '.join(args)], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, shell=True)
             result = proc.communicate()
             return json.loads(result[0].decode())
+        elif self.interface == 'stdin':
+            input_str = '\n'.join(args) + '\n'
+            proc = subprocess.Popen(['hwi', '--stdin'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+            result = proc.communicate(input_str.encode())
+            return json.loads(result[0].decode())
         else:
             return process_commands(args)
 


### PR DESCRIPTION
This PR adds a `--stdin` option which allows arguments to be entered over stdin in a way similar to bitcoin-cli's `--stdin` option.

Built on #125 and to test the `stdin` interface