### PR TITLE
travis: fix bitcoind update

### DIFF
--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -164,8 +164,8 @@ else
 
     if [ $LOCAL = $REMOTE ]; then
         echo "Up-to-date"
-    else
-        git reset --hard origin/hww
+    elif [ $LOCAL = $BASE ]; then
+        git pull
         bitcoind_setup_needed=true
     fi
 fi


### PR DESCRIPTION
Currently travis is not working correctly because it isn't updating bitcoind when upstream changes. This fixes that.