### PR TITLE
Fix Digital Bitbox tests for API changes

### DIFF
--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -93,6 +93,9 @@ def digitalbitbox_test_suite(rpc, userpass, simulator):
             self.assertTrue(result['success'])
 
             # Reset back to original
+            result = process_commands(self.dev_args + ['wipe'])
+            self.assertTrue(result['success'])
+            send_plain(b'{"password":"0000"}', dev)
             send_encrypt(json.dumps({"seed":{"source":"backup","filename":"test_backup.pdf","key":"key"}}), '0000', dev)
 
             # Make sure device is init, setup should fail


### PR DESCRIPTION
The Digital Bitbox API changed slightly which broke our tests due to the ordering of some operations. Normal usage is still fine. This fixes the test.