### PR TITLE
Create internal and external keypools by default

### DIFF
--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -108,7 +108,7 @@ def process_commands(cli_args):
     getkeypool_parser.add_argument('--sh_wpkh', action='store_true', help='Generate p2sh-nested segwit addresses (default path: m/49h/0h/0h/[0,1]/*)')
     getkeypool_parser.add_argument('--wpkh', action='store_true', help='Generate bech32 addresses (default path: m/84h/0h/0h/[0,1]/*)')
     getkeypool_parser.add_argument('--account', help='BIP43 account (default: 0)', type=int, default=0)
-    getkeypool_parser.add_argument('--path', help='Derivation path, default follows BIP43 convention, e.g. m/84h/0h/0h/1/* with --wpkh --internal')
+    getkeypool_parser.add_argument('--path', help='Derivation path, default follows BIP43 convention, e.g. m/84h/0h/0h/1/* with --wpkh --internal. If this argument and --internal is not given, both internal and external keypools will be returned.')
     getkeypool_parser.add_argument('start', type=int, help='The index to start at.')
     getkeypool_parser.add_argument('end', type=int, help='The index to end at.')
     getkeypool_parser.set_defaults(func=getkeypool_handler)

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -190,11 +190,6 @@ class TestGetKeypool(DeviceTestCase):
         for i in range(0, 21):
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getnewaddress())
             self.assertEqual(addr_info['hdkeypath'], "m/44'/1'/0'/0/{}".format(i))
-
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--keypool', '--internal', '0', '20'])
-        import_result = self.wrpc.importmulti(keypool_desc)
-        self.assertTrue(import_result[0]['success'])
-        for i in range(0, 21):
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress())
             self.assertEqual(addr_info['hdkeypath'], "m/44'/1'/0'/1/{}".format(i))
 
@@ -204,10 +199,6 @@ class TestGetKeypool(DeviceTestCase):
         for i in range(0, 21):
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getnewaddress())
             self.assertEqual(addr_info['hdkeypath'], "m/49'/1'/0'/0/{}".format(i))
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '--internal', '0', '20'])
-        import_result = self.wrpc.importmulti(keypool_desc)
-        self.assertTrue(import_result[0]['success'])
-        for i in range(0, 21):
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress())
             self.assertEqual(addr_info['hdkeypath'], "m/49'/1'/0'/1/{}".format(i))
 
@@ -217,10 +208,6 @@ class TestGetKeypool(DeviceTestCase):
         for i in range(0, 21):
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getnewaddress())
             self.assertEqual(addr_info['hdkeypath'], "m/84'/1'/0'/0/{}".format(i))
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--keypool', '--wpkh', '--internal', '0', '20'])
-        import_result = self.wrpc.importmulti(keypool_desc)
-        self.assertTrue(import_result[0]['success'])
-        for i in range(0, 21):
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress())
             self.assertEqual(addr_info['hdkeypath'], "m/84'/1'/0'/1/{}".format(i))
 
@@ -230,10 +217,6 @@ class TestGetKeypool(DeviceTestCase):
         for i in range(0, 21):
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getnewaddress())
             self.assertEqual(addr_info['hdkeypath'], "m/49'/1'/3'/0/{}".format(i))
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--keypool', '--sh_wpkh', '--internal', '--account', '3', '0', '20'])
-        import_result = self.wrpc.importmulti(keypool_desc)
-        self.assertTrue(import_result[0]['success'])
-        for i in range(0, 21):
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress())
             self.assertEqual(addr_info['hdkeypath'], "m/49'/1'/3'/1/{}".format(i))
         keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--keypool', '--wpkh', '--account', '3', '0', '20'])
@@ -242,10 +225,6 @@ class TestGetKeypool(DeviceTestCase):
         for i in range(0, 21):
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getnewaddress())
             self.assertEqual(addr_info['hdkeypath'], "m/84'/1'/3'/0/{}".format(i))
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--keypool', '--wpkh', '--internal', '--account', '3', '0', '20'])
-        import_result = self.wrpc.importmulti(keypool_desc)
-        self.assertTrue(import_result[0]['success'])
-        for i in range(0, 21):
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress())
             self.assertEqual(addr_info['hdkeypath'], "m/84'/1'/3'/1/{}".format(i))
 


### PR DESCRIPTION
Returns both internal an external chains when `--path` and `--internal` are not given as arguments.