### PR TITLE
Document how to handle binary format files from command line with bas…

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -135,3 +135,9 @@ bitcoin-cli scantxoutset start '[{"desc":"wpkh(xpub6DP9afdc7qsz7s7mwAvciAR2dV6vP
   "total_amount": 0.00000000
 }
 ```
+
+### Binary format handling
+
+The input and output format supported by HWI is base64, which is prescribed by BIP174 as the string format. Note that the PSBT standard also allows for binary formatting when stored as a file. There is no direct support within HWI, but this can be easily accomplished using common utilities. A bash command-line example is detailed below, where the PSBT binary file is stored in `example.psbt` and only the common utilities `base64` and `jq` are required:
+
+cat example.psbt | base64 --wrap=0 | ./hwi.py -t ledger --stdin signtx | jq .[] --raw-output | base64 -d > example_result.psbt


### PR DESCRIPTION
…h example

Since these are quite standard utilities, we may want to take the unix philosophy and let other utils take care of these common conversions.