### PR TITLE
Keep Trezor sessions open unless state becomes inconsistent

### DIFF
--- a/hwilib/devices/trezorlib/client.py
+++ b/hwilib/devices/trezorlib/client.py
@@ -178,7 +178,10 @@ class TrezorClient:
 
     @tools.session
     def init_device(self):
-        resp = self.call_raw(messages.Initialize(state=self.state))
+        resp = self.call_raw(messages.GetFeatures())
+        # If GetFeatures fails, try initializing and clearing inconsistent state on the device
+        if isinstance(resp, messages.Failure):
+            resp = self.call_raw(messages.Initialize())
         if not isinstance(resp, messages.Features):
             raise exceptions.TrezorException("Unexpected initial response")
         else:


### PR DESCRIPTION
When the client is opened, we would send an `Initialize` message. However because a client may end up being opened many times in the process of executing one command, the saved state (in particular cached passphrases) would be lost each time the client is opened due to `Initialize` being sent. In order to have it keep that state, we don't want to send `Initialize` every time. Instead we will send `GetFeatures` which does the other part of what `Initialize` does (get the features for the device). `GetFeatures` failing would indicate that the state is inconsistent (which can be caused by command abort, exceptions, etc.), so in that case, `Initialize` is sent to clear the inconsistent state.

I tested this using the Trezor T emulator and the password prompt does not appear multiple times per command. Additionally the password prompt does not appear for every command.

Fixes #151