### PR TITLE
Make versioned compressed packages for releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
             before_script:
                 - docker build -t hwi-builder -f contrib/build.Dockerfile .
             script:
-                - docker run -it --name hwi-builder -v $PWD:/opt/hwi --rm  --workdir /opt/hwi hwi-builder /bin/bash -c "contrib/build_bin.sh && contrib/build_dist.sh"
+                - docker run -it --name hwi-builder -v $PWD:/opt/hwi --rm  --workdir /opt/hwi hwi-builder /bin/bash -c "contrib/build_bin.sh && contrib/build_wine.sh && contrib/build_dist.sh"
                 - sudo chown -R `whoami`:`whoami` dist/
                 - cd test; poetry run ./run_tests.py --interface=bindist
                 - cd ..; sha256sum dist/*

--- a/contrib/build.Dockerfile
+++ b/contrib/build.Dockerfile
@@ -25,7 +25,9 @@ RUN apt-get install -y \
     liblzma-dev \
     libusb-1.0-0-dev \
     libudev-dev \
-    faketime
+    faketime \
+    zip \
+    dos2unix
 
 RUN curl https://pyenv.run | bash
 ENV PATH="/root/.pyenv/bin:$PATH"

--- a/contrib/build_bin.sh
+++ b/contrib/build_bin.sh
@@ -24,3 +24,13 @@ TZ=UTC find ${lib_dir} -name '*.py' -type f -execdir touch -t "201901010000.00" 
 export PYTHONHASHSEED=42
 poetry run pyinstaller hwi.spec
 unset PYTHONHASHSEED
+
+# Make the final compressed package
+pushd dist
+VERSION=`poetry run hwi --version | cut -d " " -f 2`
+OS=`uname | tr '[:upper:]' '[:lower:]'`
+if [[ $OS == "darwin" ]]; then
+    OS="mac"
+fi
+tar -czf "hwi-${VERSION}-${OS}-amd64.tar.gz" hwi
+popd

--- a/contrib/build_wine.sh
+++ b/contrib/build_wine.sh
@@ -68,3 +68,9 @@ $POETRY install -E windist
 export PYTHONHASHSEED=42
 $POETRY run pyinstaller hwi.spec
 unset PYTHONHASHSEED
+
+# Make the final compressed package
+pushd dist
+VERSION=`$POETRY run hwi --version | cut -d " " -f 2 | dos2unix`
+zip "hwi-${VERSION}-windows-amd64.zip" hwi.exe
+popd


### PR DESCRIPTION
The current build scripts produce binary files named `hwi` and `hwi.exe` which is both unversioned and conflicting for the Linux and MacOS binaries. For the 1.0.0 binaries, I had compressed these and named them myself before uploading. This PR changes the build scripts to compress and name the packages too. Additionally the names will include the version number which I forgot to do for 1.0.0.