### PR TITLE
Add packages to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup_kwargs = {
     'author_email': 'andrew@achow101.com',
     'url': 'https://github.com/bitcoin-core/HWI',
     'py_modules': modules,
+    'packages': [ 'hwilib', 'hwilib.devices', 'hwilib.devices.btchip', 'hwilib.devices.ckcc', 'hwilib.devices.trezorlib' ],
     'install_requires': install_requires,
     'extras_require': extras_require,
     'entry_points': entry_points,


### PR DESCRIPTION
I'm packaging HWI for nix and therefore I need a normal install method using setup.py which doesn't require poetry. I don't know anything about python setup tooling, but just adding a list of packages allows me to both install it via `python setup.py install` as well as creating a nix package (WIP: https://github.com/fort-nix/nix-bitcoin/blob/3650198107e82352ffad0b46415b2e37d9bdfea7/pkgs/hwi/default.nix ).