### PR TITLE
Fix bug in keepkey and trezor's enumerate

### DIFF
--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -1,7 +1,7 @@
 # Coldcard interaction script
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import ActionCanceledError, BadArgumentError, DeviceBusyError, DeviceFailureError, HWWError, UnavailableActionError, UNKNOWN_ERROR
+from ..errors import ActionCanceledError, BadArgumentError, DeviceBusyError, DeviceFailureError, HWWError, UnavailableActionError, UNKNOWN_ERROR, common_err_msgs, handle_errors
 from .ckcc.client import ColdcardDevice, COINKITE_VID, CKCC_PID
 from .ckcc.protocol import CCProtocolPacker, CCBusyError, CCProtoError, CCUserRefused
 from .ckcc.constants import MAX_BLK_LEN, AF_P2WPKH, AF_CLASSIC, AF_P2WPKH_P2SH
@@ -227,15 +227,9 @@ def enumerate(password=''):
         d_data['path'] = path
 
         client = None
-        try:
+        with handle_errors(common_err_msgs["enumerate"], d_data):
             client = ColdcardClient(path)
             d_data['fingerprint'] = client._get_fingerprint_hex()
-        except HWWError as e:
-            d_data['error'] = "Could not open client or get fingerprint information: " + e.get_msg()
-            d_data['code'] = e.get_code()
-        except Exception as e:
-            d_data['error'] = "Could not open client or get fingerprint information: " + str(e)
-            d_data['code'] = UNKNOWN_ERROR
 
         if client:
             client.close()

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -15,7 +15,7 @@ import sys
 import time
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import ActionCanceledError, BadArgumentError, DeviceFailureError, DeviceAlreadyInitError, DeviceNotReadyError, HWWError, NoPasswordError, UnavailableActionError, UNKNOWN_ERROR
+from ..errors import ActionCanceledError, BadArgumentError, DeviceFailureError, DeviceAlreadyInitError, DeviceNotReadyError, HWWError, NoPasswordError, UnavailableActionError, UNKNOWN_ERROR, common_err_msgs, handle_errors
 from ..serializations import CTransaction, PSBT, hash256, hash160, ser_sig_der, ser_sig_compact, ser_compact_size
 from ..base58 import get_xpub_fingerprint, decode, to_address, xpub_main_2_test, get_xpub_fingerprint_hex
 
@@ -593,7 +593,7 @@ def enumerate(password=''):
             d_data['path'] = path
 
             client = None
-            try:
+            with handle_errors(common_err_msgs["enumerate"], d_data):
                 client = DigitalbitboxClient(path, password)
 
                 # Check initialized
@@ -603,12 +603,6 @@ def enumerate(password=''):
                 else:
                     master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
                     d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
-            except HWWError as e:
-                d_data['error'] = "Could not open client or get fingerprint information: " + e.get_msg()
-                d_data['code'] = e.get_code()
-            except Exception as e:
-                d_data['error'] = "Could not open client or get fingerprint information: " + str(e)
-                d_data['code'] = UNKNOWN_ERROR
 
             if client:
                 client.close()

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -25,7 +25,7 @@ def enumerate(password=''):
         with handle_errors(common_err_msgs["enumerate"], d_data):
             client = KeepkeyClient(d_data['path'], password)
             client.client.init_device()
-            if not 'keepkey' in client.client.features.vendor:
+            if 'keepkey' not in client.client.features.vendor:
                 continue
             if client.client.features.initialized:
                 master_xpub = client.get_pubkey_at_path('m/0h')['xpub']

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -1,6 +1,6 @@
 # KeepKey interaction script
 
-from ..errors import HWWError, UNKNOWN_ERROR
+from ..errors import HWWError, UNKNOWN_ERROR, common_err_msgs, handle_errors
 from .trezorlib.transport import enumerate_devices
 from .trezor import TrezorClient
 from ..base58 import get_xpub_fingerprint_hex
@@ -21,7 +21,8 @@ def enumerate(password=''):
         d_data['path'] = dev.get_path()
 
         client = None
-        try:
+
+        with handle_errors(common_err_msgs["enumerate"], d_data):
             client = KeepkeyClient(d_data['path'], password)
             client.client.init_device()
             if not 'keepkey' in client.client.features.vendor:
@@ -31,12 +32,6 @@ def enumerate(password=''):
                 d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
             else:
                 d_data['error'] = 'Not initialized'
-        except HWWError as e:
-            d_data['error'] = "Could not open client or get fingerprint information: " + e.get_msg()
-            d_data['code'] = e.get_code()
-        except Exception as e:
-            d_data['error'] = "Could not open client or get fingerprint information: " + str(e)
-            d_data['code'] = UNKNOWN_ERROR
 
         if client:
             client.close()

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -1,7 +1,7 @@
 # Ledger interaction script
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import ActionCanceledError, BadArgumentError, DeviceConnectionError, DeviceFailureError, HWWError, UnavailableActionError, UNKNOWN_ERROR
+from ..errors import ActionCanceledError, BadArgumentError, DeviceConnectionError, DeviceFailureError, HWWError, UnavailableActionError, UNKNOWN_ERROR, common_err_msgs, handle_errors
 from .btchip.btchip import *
 from .btchip.btchipUtils import *
 import base64
@@ -346,16 +346,10 @@ def enumerate(password=''):
             d_data['path'] = path
 
             client = None
-            try:
+            with handle_errors(common_err_msgs["enumerate"], d_data):
                 client = LedgerClient(path, password)
                 master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
                 d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
-            except HWWError as e:
-                d_data['error'] = "Could not open client or get fingerprint information: " + e.get_msg()
-                d_data['code'] = e.get_code()
-            except Exception as e:
-                d_data['error'] = "Could not open client or get fingerprint information: " + str(e)
-                d_data['code'] = UNKNOWN_ERROR
 
             if client:
                 client.close()

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -1,7 +1,7 @@
 # Trezor interaction script
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import ActionCanceledError, BadArgumentError, DeviceAlreadyInitError, DeviceAlreadyUnlockedError, DeviceConnectionError, DeviceNotReadyError, HWWError, UnavailableActionError, UNKNOWN_ERROR
+from ..errors import ActionCanceledError, BadArgumentError, DeviceAlreadyInitError, DeviceAlreadyUnlockedError, DeviceConnectionError, DeviceNotReadyError, HWWError, UnavailableActionError, UNKNOWN_ERROR, common_err_msgs, handle_errors
 from .trezorlib.client import TrezorClient as Trezor
 from .trezorlib.debuglink import TrezorClientDebugLink, DebugUI
 from .trezorlib.exceptions import Cancelled
@@ -416,7 +416,7 @@ def enumerate(password=''):
         d_data['path'] = dev.get_path()
 
         client = None
-        try:
+        with handle_errors(common_err_msgs["enumerate"], d_data):
             client = TrezorClient(d_data['path'], password)
             client.client.init_device()
             if not 'trezor' in client.client.features.vendor:
@@ -426,12 +426,6 @@ def enumerate(password=''):
                 d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
             else:
                 d_data['error'] = 'Not initialized'
-        except HWWError as e:
-            d_data['error'] = "Could not open client or get fingerprint information: " + e.get_msg()
-            d_data['code'] = e.get_code()
-        except Exception as e:
-            d_data['error'] = "Could not open client or get fingerprint information: " + str(e)
-            d_data['code'] = UNKNOWN_ERROR
 
         if client:
             client.close()

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -419,7 +419,7 @@ def enumerate(password=''):
         with handle_errors(common_err_msgs["enumerate"], d_data):
             client = TrezorClient(d_data['path'], password)
             client.client.init_device()
-            if not 'trezor' in client.client.features.vendor:
+            if 'trezor' not in client.client.features.vendor:
                 continue
             if client.client.features.initialized:
                 master_xpub = client.get_pubkey_at_path('m/0h')['xpub']

--- a/hwilib/errors.py
+++ b/hwilib/errors.py
@@ -1,5 +1,7 @@
 # Defines errors and error codes
 
+from contextlib import contextmanager
+
 # Error codes
 NO_DEVICE_PATH = -1
 NO_DEVICE_TYPE = -2
@@ -84,3 +86,20 @@ class DeviceConnectionError(HWWError):
 class DeviceBusyError(HWWError):
     def __init__(self, msg):
         HWWError.__init__(self, msg, DEVICE_BUSY)
+
+@contextmanager
+def handle_errors(msg, res):
+    try:
+        yield
+    except HWWError as e:
+        res['error'] = msg + " " + e.get_msg()
+        res['code'] = e.get_code()
+    except Exception as e:
+        res['error'] = msg + " " + str(e)
+        res['code'] = UNKNOWN_ERROR
+    return res
+
+
+common_err_msgs = {
+    "enumerate": "Could not open client or get fingerprint information:"
+}


### PR DESCRIPTION
Continued from #184. The commit to review is 1d25bab.

`not 'trezor'` would always evaluate to False, which wouldn't be in the list. So this should never continue here?