### PR TITLE
Coldcard v2.1.0 and above does multisig

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ Please also see [docs](docs/) for additional information about each device.
 | P2PKH Inputs | Yes | Yes | Yes | Yes | Yes | Yes |
 | P2SH-P2WPKH Inputs | Yes | Yes | Yes | Yes | Yes | Yes |
 | P2WPKH Inputs | Yes | Yes | Yes | Yes | Yes | Yes |
-| P2SH Multisig Inputs | Yes | Yes | Yes | Yes | Yes | N/A |
-| P2SH-P2WSH Multisig Inputs | Yes | Yes | Yes | Yes | No | N/A |
-| P2WSH Multisig Inputs | Yes | Yes | Yes | Yes | Yes | N/A |
+| P2SH Multisig Inputs | Yes | Yes | Yes | Yes | Yes | Yes |
+| P2SH-P2WSH Multisig Inputs | Yes | Yes | Yes | Yes | No | Yes |
+| P2WSH Multisig Inputs | Yes | Yes | Yes | Yes | Yes | Yes |
 | Bare Multisig Inputs | Yes | N/A | N/A | Yes | N/A | N/A |
 | Aribtrary scriptPubKey Inputs | Yes | N/A | N/A | Yes | N/A | N/A |
 | Aribtrary redeemScript Inputs | Yes | N/A | N/A | Yes | N/A | N/A |


### PR DESCRIPTION
If you give us the PSBT, perhaps with XPUB values in global section, we can sign it.

However, to support "display_address" we'll need a redeem script and paths for each co-signer. To achieve that, descriptor parsing needs major additions, and some API changes would be needed which would affect other devices.