### PR TITLE
keepkey: fix missing error import

### DIFF
--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -1,6 +1,6 @@
 # KeepKey interaction script
 
-from ..errors import HWWError, UNKNOWN_ERROR, common_err_msgs, handle_errors
+from ..errors import DeviceNotReadyError, common_err_msgs, handle_errors
 from .trezorlib.transport import enumerate_devices
 from .trezor import TrezorClient
 from ..base58 import get_xpub_fingerprint_hex


### PR DESCRIPTION
DeviceNotReadyError was missing from the import list. lint caught this
as a missing name error.

This was missed because the keepkey tests seem to be testing TrezorClient instead?

See #190

Signed-off-by: William Casarin <jb55@jb55.com>