### PR TITLE
test: configure a more minimalistic bitcoind

### DIFF
--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -189,6 +189,6 @@ fi
 # Build bitcoind. This is super slow, but it is cached so it runs fairly quickly.
 if [ "$bitcoind_setup_needed" == true ] ; then
     ./autogen.sh
-    ./configure
+    ./configure --with-miniupnpc=no --without-gui --disable-zmq --disable-tests --disable-bench --with-libs=no --with-utils=no
 fi
 make -j$(nproc) src/bitcoind


### PR DESCRIPTION
Closes #177.

The gains here aren't huge, but if all you want to build is `bitcoind`, this `./configure` will achieve that, and skip a couple checks along the way.

Quickly tested using `./test/setup_environment.sh` and `./test/run_tests.py`.