### PR TITLE
trivial: .gitignore pip-wheel-metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 hwi.egg-info/
 test/emulator.img
 test/work
+pip-wheel-metadata


### PR DESCRIPTION
This was left in the repo after installing test dependencies. 
I'd assume from running the `pip install -e .[tests]` command.