### PR TITLE
Always initialize Trezor One and Keepkey and clear any previous session

### DIFF
--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -28,7 +28,7 @@ def enumerate(password=''):
             if not 'keepkey' in client.client.features.vendor:
                 continue
             d_data['needs_pin_sent'] = client.client.features.pin_protection and not client.client.features.pin_cached
-            d_data['needs_passphrase_sent'] = client.client.features.passphrase_protection and not client.client.features.passphrase_cached
+            d_data['needs_passphrase_sent'] = client.client.features.passphrase_protection # always need the passphrase sent for Keepkey if it has passphrase protection enabled
             if d_data['needs_pin_sent']:
                 raise DeviceNotReadyError('Keepkey is locked. Unlock by using \'promptpin\' and then \'sendpin\'.')
             if d_data['needs_passphrase_sent'] and not password:

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -419,7 +419,10 @@ def enumerate(password=''):
             if not 'trezor' in client.client.features.vendor:
                 continue
             d_data['needs_pin_sent'] = client.client.features.pin_protection and not client.client.features.pin_cached
-            d_data['needs_passphrase_sent'] = client.client.features.passphrase_protection and not client.client.features.passphrase_cached
+            if client.client.features.model == '1':
+                d_data['needs_passphrase_sent'] = client.client.features.passphrase_protection # always need the passphrase sent for Trezor One if it has passphrase protection enabled
+            else:
+                d_data['needs_passphrase_sent'] = client.client.features.passphrase_protection and not client.client.features.passphrase_cached
             if d_data['needs_pin_sent']:
                 raise DeviceNotReadyError('Trezor is locked. Unlock by using \'promptpin\' and then \'sendpin\'.')
             if d_data['needs_passphrase_sent'] and not password:

--- a/hwilib/devices/trezorlib/client.py
+++ b/hwilib/devices/trezorlib/client.py
@@ -185,6 +185,11 @@ class TrezorClient:
         if not isinstance(resp, messages.Features):
             raise exceptions.TrezorException("Unexpected initial response")
         else:
+            # If this is a Trezor One or Keepkey, do Initialize
+            if resp.model == '1' or resp.model == 'K1-14AM':
+                resp = self.call_raw(messages.Initialize())
+                if not isinstance(resp, messages.Features):
+                    raise exceptions.TrezorException("Unexpected initial response")
             self.features = resp
         if self.features.vendor not in VENDORS:
             raise RuntimeError("Unsupported device")

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -268,12 +268,12 @@ class TestKeepkeyManCommands(KeepkeyTestCase):
             if dev['type'] == 'keepkey' and dev['path'] == 'udp:127.0.0.1:21324':
                 self.assertFalse(dev['needs_passphrase_sent'])
                 fpr = dev['fingerprint']
-        # A different passphrase would not change the fingerprint
+        # A different passphrase will change the fingerprint
         result = self.do_command(self.dev_args + ['-p', 'pass2', 'enumerate'])
         for dev in result:
             if dev['type'] == 'keepkey' and dev['path'] == 'udp:127.0.0.1:21324':
                 self.assertFalse(dev['needs_passphrase_sent'])
-                self.assertEqual(dev['fingerprint'], fpr)
+                self.assertNotEqual(dev['fingerprint'], fpr)
 
         # Clearing the session and starting a new one with a new passphrase should change the passphrase
         self.client.call(messages.ClearSession())

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -273,12 +273,21 @@ class TestTrezorManCommands(TrezorTestCase):
             if dev['type'] == 'trezor' and dev['path'] == 'udp:127.0.0.1:21324':
                 self.assertFalse(dev['needs_passphrase_sent'])
                 fpr = dev['fingerprint']
-        # A different passphrase would not change the fingerprint
-        result = self.do_command(self.dev_args + ['-p', 'pass2', 'enumerate'])
-        for dev in result:
-            if dev['type'] == 'trezor' and dev['path'] == 'udp:127.0.0.1:21324':
-                self.assertFalse(dev['needs_passphrase_sent'])
-                self.assertEqual(dev['fingerprint'], fpr)
+
+        if self.emulator.model_t:
+            # Trezor T: A different passphrase would not change the fingerprint
+            result = self.do_command(self.dev_args + ['-p', 'pass2', 'enumerate'])
+            for dev in result:
+                if dev['type'] == 'trezor' and dev['path'] == 'udp:127.0.0.1:21324':
+                    self.assertFalse(dev['needs_passphrase_sent'])
+                    self.assertEqual(dev['fingerprint'], fpr)
+        else:
+            # Trezor 1: A different passphrase will change the fingerprint
+            result = self.do_command(self.dev_args + ['-p', 'pass2', 'enumerate'])
+            for dev in result:
+                if dev['type'] == 'trezor' and dev['path'] == 'udp:127.0.0.1:21324':
+                    self.assertFalse(dev['needs_passphrase_sent'])
+                    self.assertNotEqual(dev['fingerprint'], fpr)
 
         # Clearing the session and starting a new one with a new passphrase should change the passphrase
         self.client.call(messages.Initialize())


### PR DESCRIPTION
#152 Kept Trezor sessions open in between commands which allowed the passphrase to remain cached. This works well for the Trezor T where the user is prompted to enter their password the first time that anything from the device is queried (e.g. during enumerate) as the user has consciously entered the correct password. However on the Trezor One, the password is entered via the `-p` option and it is unintuitive that the password must be entered the first time the device is queried which results in the incorrect password being used.

To fix this, we instead revert to the original behavior of always initializing new sessions, but only for the Trezor One. This will clear the password cache every time a command is run and thus will always use the password provided on the command line for that command.

Also do the same for the Keepkey because it is basically identical to the Trezor One.

Fixes #199 