### PR TITLE
Add type hints for base58.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ hwi.egg-info/
 test/emulator.img
 test/work
 pip-wheel-metadata
+.mypy_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,11 @@ jobs:
             install:
                 - pip install flake8
             script: flake8
+        -   name: Type annotation checking
+            stage: lint
+            install:
+                - pip install mypy
+            script: mypy hwilib/base58.py
         -   name: Run non-device tests only
             stage: test
             script: cd test; poetry run ./run_tests.py

--- a/hwilib/base58.py
+++ b/hwilib/base58.py
@@ -28,11 +28,7 @@ def encode(b):
     res = ''.join(res[::-1])
 
     # Encode leading zeros as base58 zeros
-    import sys
-    czero = b'\x00'
-    if sys.version > '3':
-        # In Python3 indexing a bytes returns numbers, not characters.
-        czero = 0
+    czero = 0
     pad = 0
     for c in b:
         if c == czero:

--- a/hwilib/base58.py
+++ b/hwilib/base58.py
@@ -11,25 +11,25 @@
 from .serializations import hash256
 import struct
 from binascii import hexlify, unhexlify
-b58_digits = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+from typing import List
+b58_digits: str = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 
-
-def encode(b):
+def encode(b: bytes) -> str:
     """Encode bytes to a base58-encoded string"""
 
     # Convert big-endian bytes to integer
-    n = int('0x0' + hexlify(b).decode('utf8'), 16)
+    n: int = int('0x0' + hexlify(b).decode('utf8'), 16)
 
-    # Divide that integer into bas58
-    res = []
+    # Divide that integer into base58
+    temp: List[str] = []
     while n > 0:
         n, r = divmod(n, 58)
-        res.append(b58_digits[r])
-    res = ''.join(res[::-1])
+        temp.append(b58_digits[r])
+    res: str = ''.join(temp[::-1])
 
     # Encode leading zeros as base58 zeros
-    czero = 0
-    pad = 0
+    czero: int = 0
+    pad: int = 0
     for c in b:
         if c == czero:
             pad += 1
@@ -37,13 +37,13 @@ def encode(b):
             break
     return b58_digits[0] * pad + res
 
-def decode(s):
+def decode(s: str) -> bytes:
     """Decode a base58-encoding string, returning bytes"""
     if not s:
         return b''
 
     # Convert the string to an integer
-    n = 0
+    n: int = 0
     for c in s:
         n *= 58
         if c not in b58_digits:
@@ -52,7 +52,7 @@ def decode(s):
         n += digit
 
     # Convert the integer to bytes
-    h = '%x' % n
+    h: str = '%x' % n
     if len(h) % 2:
         h = '0' + h
     res = unhexlify(h.encode('utf8'))
@@ -66,33 +66,33 @@ def decode(s):
             break
     return b'\x00' * pad + res
 
-def get_xpub_fingerprint(s):
+def get_xpub_fingerprint(s: str) -> str:
     data = decode(s)
     fingerprint = data[5:9]
     return struct.unpack("<I", fingerprint)[0]
 
-def get_xpub_fingerprint_hex(xpub):
+def get_xpub_fingerprint_hex(xpub: str) -> str:
     data = decode(xpub)
     fingerprint = data[5:9]
     return hexlify(fingerprint).decode()
 
-def get_xpub_fingerprint_as_id(xpub):
+def get_xpub_fingerprint_as_id(xpub: str) -> str:
     data = decode(xpub)
     fingerprint = data[5:9]
     return hexlify(fingerprint).decode()
 
-def to_address(b, version):
+def to_address(b: bytes, version: bytes) -> str:
     data = version + b
     checksum = hash256(data)[0:4]
     data += checksum
     return encode(data)
 
-def xpub_to_pub_hex(xpub):
+def xpub_to_pub_hex(xpub: str) -> str:
     data = decode(xpub)
     pubkey = data[-37:-4]
     return hexlify(pubkey).decode()
 
-def xpub_main_2_test(xpub):
+def xpub_main_2_test(xpub: str) -> str:
     data = decode(xpub)
     test_data = b'\x04\x35\x87\xCF' + data[4:-4]
     checksum = hash256(test_data)[0:4]

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 import unittest
 
+from test_base58 import TestBase58
 from test_bech32 import TestSegwitAddress
 from test_coldcard import coldcard_test_suite
 from test_descriptor import TestDescriptor
@@ -60,6 +61,7 @@ suite = unittest.TestSuite()
 suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestDescriptor))
 suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestSegwitAddress))
 suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestPSBT))
+suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestBase58))
 if sys.platform.startswith("linux"):
     suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestUdevRulesInstaller))
 

--- a/test/test_base58.py
+++ b/test/test_base58.py
@@ -1,0 +1,49 @@
+#! /usr/bin/env python3
+
+"""Reference tests for base58"""
+
+from binascii import unhexlify
+from typing import List, Tuple
+import unittest
+import hwilib.base58 as base58
+
+# Taken from Bitcoin Core
+# https://github.com/bitcoin/bitcoin/blob/master/src/test/data/base58_encode_decode.json
+TEST_VECTORS: List[Tuple[str, str]] = [
+    ("", ""),
+    ("61", "2g"),
+    ("626262", "a3gV"),
+    ("636363", "aPEr"),
+    ("73696d706c792061206c6f6e6720737472696e67", "2cFupjhnEsSn59qHXstmK2ffpLv2"),
+    ("00eb15231dfceb60925886b67d065299925915aeb172c06647", "1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L"),
+    ("516b6fcd0f", "ABnLTmg"),
+    ("bf4f89001e670274dd", "3SEo3LWLoPntC"),
+    ("572e4794", "3EFU7m"),
+    ("ecac89cad93923c02321", "EJDM8drfXA6uyA"),
+    ("10c8511e", "Rt5zm"),
+    ("00000000000000000000", "1111111111"),
+    ("000111d38e5fc9071ffcd20b4a763cc9ae4f252bb4e48fd66a835e252ada93ff480d6dd43dc62a641155a5",
+        "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"),
+    ("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+        "1cWB5HCBdLjAuqGGReWE3R3CguuwSjw6RHn39s2yuDRTS5NsBgNiFpWgAnEx6VQi8csexkgYw3mdYrMHr8x9i7aEwP8kZ7vccXWqKDvGv3u1GxFKPuAkn8JCPPGDMf3vMMnbzm6Nh9zh1gcNsMvH3ZNLmP5fSG6DGbbi2tuwMWPthr4boWwCxf7ewSgNQeacyozhKDDQQ1qL5fQFUW52QKUZDZ5fw3KXNQJMcNTcaB723LchjeKun7MuGW5qyCBZYzA1KjofN1gYBV3NqyhQJ3Ns746GNuf9N2pQPmHz4xpnSrrfCvy6TVVz5d4PdrjeshsWQwpZsZGzvbdAdN8MKV5QsBDY")
+]
+
+class TestBase58(unittest.TestCase):
+    """Unit test class for base58 encoding and decoding."""
+
+    def test_decoding(self):
+        """Test base58 decoding"""
+
+        for pair in TEST_VECTORS:
+            decoded: bytes = base58.decode(pair[1])
+            self.assertEqual(decoded, unhexlify(pair[0]))
+
+    def test_encoding(self):
+        """Test base58 encoding"""
+
+        for pair in TEST_VECTORS:
+            encoded: str = base58.encode(unhexlify(pair[0]))
+            self.assertEqual(encoded, pair[1])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
TLDR: This add type hints to base58.py, as well as some basic tests and a Travis job that runs [`mypy`](http://mypy-lang.org). 

This adds some simple base58 tests (copied from the Bitcoin Core repo), [type hints](https://docs.python.org/3.6/library/typing.html) for base58.py and a Travis job that runs `mypy` on base58.py. I started with base58.py to keep everything self contained.

`mypy` was added as a dev dependency using `poetry add mypy --dev`.

Given that the project is using > Python 3.6, we can also take advantage [variable type annotations](https://www.python.org/dev/peps/pep-0526/).

Just opening as a draft for some concept level discussion. If there is interested then more anntotations can be added, and the Travis `mypy` scope increased. If we are happy to add type annotations here, then I'll PR the same changes to any upstream libraries, i.e [`bech32.py`](https://github.com/sipa/bech32/blob/master/ref/python/segwit_addr.py).

Another good reference for type hints is: https://mypy.readthedocs.io/en/latest/cheat_sheet_py3.html