### PR TITLE
Clean up keepkey/trezor emulator image after each test

### DIFF
--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -67,6 +67,11 @@ class KeepkeyEmulator(DeviceEmulator):
         self.emulator_proc.kill()
         self.emulator_proc.wait()
 
+        # Clean up emulator image
+        emulator_img = os.path.dirname(self.emulator_path) + "/emulator.img"
+        if os.path.isfile(emulator_img):
+            os.unlink(emulator_img)
+
 class KeepkeyTestCase(unittest.TestCase):
     def __init__(self, emulator, interface='library', methodName='runTest'):
         super(KeepkeyTestCase, self).__init__(methodName)

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -31,9 +31,10 @@ def get_pin(self, code=None):
         return self.debuglink.read_pin_encoded()
 
 class TrezorEmulator(DeviceEmulator):
-    def __init__(self, path):
+    def __init__(self, path, model_t):
         self.emulator_path = path
         self.emulator_proc = None
+        self.model_t = model_t
 
     def start(self):
         # Start the Trezor emulator
@@ -67,6 +68,15 @@ class TrezorEmulator(DeviceEmulator):
     def stop(self):
         os.killpg(os.getpgid(self.emulator_proc.pid), signal.SIGINT)
         os.waitpid(self.emulator_proc.pid, 0)
+
+        # Clean up emulator image
+        if self.model_t:
+            emulator_img = "/var/tmp/trezor.flash"
+        else:
+            emulator_img = os.path.dirname(self.emulator_path) + "/emulator.img"
+
+        if os.path.isfile(emulator_img):
+            os.unlink(emulator_img)
 
 class TrezorTestCase(unittest.TestCase):
     def __init__(self, emulator, interface='library', methodName='runTest'):
@@ -287,7 +297,7 @@ def trezor_test_suite(emulator, rpc, userpass, interface, model_t=False):
     path = 'udp:127.0.0.1:21324'
     fingerprint = '95d8f670'
     master_xpub = 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH'
-    dev_emulator = TrezorEmulator(emulator)
+    dev_emulator = TrezorEmulator(emulator, model_t)
 
     if model_t:
         full_type = 'trezor_t'


### PR DESCRIPTION
**Problem**:
On my Mac, the Keepkey test suite succeeds the 1st time it is run, but starts hanging from the 2nd time onward:
`./run_tests.py --no_trezor_t --no_trezor --no_coldcard --no_bitbox`
`keepkey: test_enumerate (test_device.TestDeviceConnect) ... [HANG HERE]`

The reason is emulator.img, which is generated by the Keepkey emulator (kkemu), is not cleaned up afterwards which leaves the emulator in a bad state. Ideally, tests should leave their environment unchanged after they are run.

**Solution**:
Remove emulator.img from /bin after each Keepkey run.

