### PR TITLE
test: add an explicit --all argument to run_tests.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ install:
     - poetry install
 jobs:
     include:
+        -   name: Run non-device tests only
+            script: cd test; poetry run ./run_tests.py
         -   name: With process_commands interface
             script: cd test; poetry run ./run_tests.py --all --interface=library
         -   name: With command line interface

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,11 +52,11 @@ install:
 jobs:
     include:
         -   name: With process_commands interface
-            script: cd test; poetry run ./run_tests.py --interface=library
+            script: cd test; poetry run ./run_tests.py --all --interface=library
         -   name: With command line interface
-            script: cd test; poetry run ./run_tests.py --interface=cli
+            script: cd test; poetry run ./run_tests.py --all --interface=cli
         -   name: With stdin interface
-            script: cd test; poetry run ./run_tests.py --interface=stdin
+            script: cd test; poetry run ./run_tests.py --all --interface=stdin
         -   name: With linux binary distribution command line interface
             services: docker
             before_script:
@@ -64,7 +64,7 @@ jobs:
             script:
                 - docker run -it --name hwi-builder -v $PWD:/opt/hwi --rm  --workdir /opt/hwi hwi-builder /bin/bash -c "contrib/build_bin.sh && contrib/build_wine.sh && contrib/build_dist.sh"
                 - sudo chown -R `whoami`:`whoami` dist/
-                - cd test; poetry run ./run_tests.py --interface=bindist
+                - cd test; poetry run ./run_tests.py --all --interface=bindist
                 - cd ..; sha256sum dist/*
         -   name: macOS binary distribution (no tests)
             os: osx

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -18,25 +18,39 @@ from test_udevrules import TestUdevRulesInstaller
 
 parser = argparse.ArgumentParser(description='Setup the testing environment and run automated tests')
 trezor_group = parser.add_mutually_exclusive_group()
-trezor_group.add_argument('--no_trezor', help='Do not run Trezor test with emulator', action='store_true')
-trezor_group.add_argument('--trezor', help='Path to Trezor emulator.', default='work/trezor-firmware/legacy/firmware/trezor.elf')
+trezor_group.add_argument('--no-trezor', dest='trezor', help='Do not run Trezor test with emulator', action='store_false')
+trezor_group.add_argument('--trezor', dest='trezor', help='Run Trezor test with emulator', action='store_true')
+
 trezor_t_group = parser.add_mutually_exclusive_group()
-trezor_t_group.add_argument('--no_trezor_t', help='Do not run Trezor T test with emulator', action='store_true')
-trezor_t_group.add_argument('--trezor_t', help='Path to Trezor T emulator.', default='work/trezor-firmware/core/emu.sh')
+trezor_t_group.add_argument('--no-trezor-t', dest='trezor_t', help='Do not run Trezor T test with emulator', action='store_false')
+trezor_t_group.add_argument('--trezor-t', dest='trezor_t', help='Run Trezor T test with emulator', action='store_true')
+
 coldcard_group = parser.add_mutually_exclusive_group()
-coldcard_group.add_argument('--no_coldcard', help='Do not run Coldcard test with simulator', action='store_true')
-coldcard_group.add_argument('--coldcard', help='Path to Coldcard simulator.', default='work/firmware/unix/headless.py')
+coldcard_group.add_argument('--no-coldcard', dest='coldcard', help='Do not run Coldcard test with simulator', action='store_false')
+coldcard_group.add_argument('--coldcard', dest='coldcard', help='Run Coldcard test with simulator', action='store_true')
+
 ledger_group = parser.add_mutually_exclusive_group()
 ledger_group.add_argument('--ledger', help='Run physical Ledger Nano S/X tests.', action='store_true')
-keepkey_group = parser.add_mutually_exclusive_group()
-keepkey_group.add_argument('--no_keepkey', help='Do not run Keepkey test with emulator', action='store_true')
-keepkey_group.add_argument('--keepkey', help='Path to Keepkey emulator.', default='work/keepkey-firmware/bin/kkemu')
-dbb_group = parser.add_mutually_exclusive_group()
-dbb_group.add_argument('--no_bitbox', help='Do not run Digital Bitbox test with simulator', action='store_true')
-dbb_group.add_argument('--bitbox', help='Path to Digital bitbox simulator.', default='work/mcu/build/bin/simulator')
 
-parser.add_argument('--bitcoind', help='Path to bitcoind.', default='work/bitcoin/src/bitcoind')
+keepkey_group = parser.add_mutually_exclusive_group()
+keepkey_group.add_argument('--no-keepkey', dest='keepkey', help='Do not run Keepkey test with emulator', action='store_false')
+keepkey_group.add_argument('--keepkey', dest='keepkey', help='Run Keepkey test with emulator', action='store_true')
+
+dbb_group = parser.add_mutually_exclusive_group()
+dbb_group.add_argument('--no_bitbox', dest='bitbox', help='Do not run Digital Bitbox test with simulator', action='store_false')
+dbb_group.add_argument('--bitbox', dest='bitbox', help='Run Digital Bitbox test with simulator', action='store_true')
+
+parser.add_argument('--trezor-path', dest='trezor_path', help='Path to Trezor emulator', default='work/trezor-firmware/legacy/firmware/trezor.elf')
+parser.add_argument('--trezor-t-path', dest='trezor_t_path', help='Path to Trezor T emulator', default='work/trezor-firmware/core/emu.sh')
+parser.add_argument('--coldcard-path', dest='coldcard_path', help='Path to Coldcar simulator', default='work/firmware/unix/headless.py')
+parser.add_argument('--keepkey-path', dest='keepkey_path', help='Path to Keepkey emulator', default='work/keepkey-firmware/bin/kkemu')
+parser.add_argument('--bitbox-path', dest='bitbox_path', help='Path to Digital Bitbox simulator', default='work/mcu/build/bin/simulator')
+
+parser.add_argument('--all', help='Run tests on all existing simulators', default=False, action='store_true')
+parser.add_argument('--bitcoind', help='Path to bitcoind', default='work/bitcoin/src/bitcoind')
 parser.add_argument('--interface', help='Which interface to send commands over', choices=['library', 'cli', 'bindist', 'stdin'], default='library')
+
+parser.set_defaults(trezor=False, trezor_t=False, coldcard=False, keepkey=False, bitbox=False)
 args = parser.parse_args()
 
 # Run tests
@@ -47,22 +61,30 @@ suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestPSBT))
 if sys.platform.startswith("linux"):
     suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestUdevRulesInstaller))
 
+if args.all:
+    args.trezor = True
+    args.trezor_t = True
+    args.coldcard = True
+    args.keepkey = True
+    args.bitbox = True
 
-if not args.no_trezor or not args.no_coldcard or args.ledger or not args.no_bitbox or not args.no_keepkey or not args.no_trezor_t:
+if args.trezor or args.trezor_t or args.coldcard or args.ledger or args.keepkey or args.bitbox:
     # Start bitcoind
     rpc, userpass = start_bitcoind(args.bitcoind)
 
-if not args.no_bitbox:
-    suite.addTest(digitalbitbox_test_suite(rpc, userpass, args.bitbox, args.interface))
-if not args.no_coldcard:
-    suite.addTest(coldcard_test_suite(args.coldcard, rpc, userpass, args.interface))
-if not args.no_trezor:
-    suite.addTest(trezor_test_suite(args.trezor, rpc, userpass, args.interface))
-if not args.no_trezor_t:
-    suite.addTest(trezor_test_suite(args.trezor_t, rpc, userpass, args.interface, True))
-if not args.no_keepkey:
-    suite.addTest(keepkey_test_suite(args.keepkey, rpc, userpass, args.interface))
-if args.ledger:
-    suite.addTest(ledger_test_suite(rpc, userpass, args.interface))
+    if args.bitbox:
+        suite.addTest(digitalbitbox_test_suite(args.bitbox_path, rpc, userpass, args.interface))
+    if args.coldcard:
+        suite.addTest(coldcard_test_suite(args.coldcard_path, rpc, userpass, args.interface))
+    if args.trezor:
+        suite.addTest(trezor_test_suite(args.trezor_path, rpc, userpass, args.interface))
+    if args.trezor_t:
+        suite.addTest(trezor_test_suite(args.trezor_t_path, rpc, userpass, args.interface, True))
+    if args.keepkey:
+        suite.addTest(keepkey_test_suite(args.keepkey_path, rpc, userpass, args.interface))
+
+    if args.ledger:
+        suite.addTest(ledger_test_suite(rpc, userpass, args.interface))
+
 result = unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)
 sys.exit(not result.wasSuccessful())

--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -13,7 +13,7 @@ from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestG
 from hwilib.cli import process_commands
 from hwilib.devices.digitalbitbox import BitboxSimulator, send_plain, send_encrypt
 
-def digitalbitbox_test_suite(rpc, userpass, simulator, interface):
+def digitalbitbox_test_suite(simulator, rpc, userpass, interface):
     # Start the Digital bitbox simulator
     simulator_proc = subprocess.Popen(['./' + os.path.basename(simulator), '../../tests/sd_files/'], cwd=os.path.dirname(simulator), stderr=subprocess.DEVNULL)
     # Wait for simulator to be up
@@ -144,5 +144,5 @@ if __name__ == '__main__':
     # Start bitcoind
     rpc, userpass = start_bitcoind(args.bitcoind)
 
-    suite = digitalbitbox_test_suite(rpc, userpass, args.simulator, args.interface)
+    suite = digitalbitbox_test_suite(args.simulator, rpc, userpass, args.interface)
     unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
**Problem**:
- Have to pass in a long list of arguments if you want to run tests against a specific device (Issue https://github.com/bitcoin-core/HWI/issues/178 raised by @Sjors).

**Suggested solution**:
A few minor changes to run_tests.py's argument parser:

- Add an explicit '--all' argument. Passing this in is equivalent to running ./run_tests.py currently.
- Calling ./run_tests.py now will only execute non-device tests.
- To test against a specific device, pass in the appropriate flag. E.g. --trezor, --trezor-t, --coldcard, --keepkey, --bitbox, --ledger
- Simulator paths are now passed via [DEVICE-NAME]-path args. E.g. --trezor-t-path [PATH]

**Tested**:
`./run_tests.py --all`
`./run_tests.py`
`./run_tests.py --trezor`
`./run_tests.py --trezor-t`
`./run_tests.py --coldcard`
`./run_tests.py --keepkey`
`./run_tests.py --ledger` (against a physical Nano S)
`./run_tests.py --trezor-t --trezor-t-path [PATH]`
