### PR TITLE
Fix places that output incorrect error messages and codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Once the device type and device path is known, issue commands to it like so:
 ./hwi.py -t <type> -d <path> <command> <command args>
 ```
 
+All output will be in JSON form and sent to `stdout`.
+Additional information or prompts will be sent to `stderr` and will not necessarily be in JSON.
+This additional information is for debugging purposes.
+
 ## Device Support
 
 The below table lists what devices and features are supported for each device.

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -5,13 +5,15 @@ from .commands import backup_device, displayaddress, enumerate, find_device, \
     signmessage, signtx, wipe_device, install_udev_rules
 from .errors import (
     handle_errors,
-    HWWError,
-    NO_DEVICE_TYPE,
     DEVICE_CONN_ERROR,
+    HELP_TEXT,
+    HWWError,
+    MISSING_ARGUMENTS,
+    NO_DEVICE_TYPE,
     NO_PASSWORD,
+    UNAVAILABLE_ACTION,
     UNKNWON_DEVICE_TYPE,
-    UNKNOWN_ERROR,
-    UNAVAILABLE_ACTION
+    UNKNOWN_ERROR
 )
 from . import __version__
 
@@ -67,8 +69,28 @@ def send_pin_handler(args, client):
 def install_udev_rules_handler(args):
     return install_udev_rules(args.source, args.location)
 
+class HWIArgumentParser(argparse.ArgumentParser):
+    def print_usage(self, file=None):
+        if file is None:
+            file = sys.stderr
+        super().print_usage(file)
+
+    def print_help(self, file=None):
+        if file is None:
+            file = sys.stderr
+        super().print_help(file)
+        error = {'error': 'Help text requested', 'code': HELP_TEXT}
+        print(json.dumps(error))
+
+    def error(self, message):
+        self.print_usage(sys.stderr)
+        args = {'prog': self.prog, 'message': message}
+        error = {'error': '%(prog)s: error: %(message)s' % args, 'code': MISSING_ARGUMENTS}
+        print(json.dumps(error))
+        self.exit(2)
+
 def process_commands(cli_args):
-    parser = argparse.ArgumentParser(description='Hardware Wallet Interface, version {}.\nAccess and send commands to a hardware wallet device. Responses are in JSON format.'.format(__version__), formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = HWIArgumentParser(description='Hardware Wallet Interface, version {}.\nAccess and send commands to a hardware wallet device. Responses are in JSON format.'.format(__version__), formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('--device-path', '-d', help='Specify the device path of the device to connect to')
     parser.add_argument('--device-type', '-t', help='Specify the type of device that will be connected. If `--device-path` not given, the first device of this type enumerated is used.')
     parser.add_argument('--password', '-p', help='Device password if it has one (e.g. DigitalBitbox)', default='')

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -6,7 +6,7 @@ from .commands import backup_device, displayaddress, enumerate, find_device, \
 from .errors import (
     handle_errors,
     HWWError,
-    NO_DEVICE_PATH,
+    NO_DEVICE_TYPE,
     DEVICE_CONN_ERROR,
     NO_PASSWORD,
     UNKNWON_DEVICE_TYPE,
@@ -206,7 +206,7 @@ def process_commands(cli_args):
         if 'error' in result:
             return result
     else:
-        return {'error':'You must specify a device type or fingerprint for all commands except enumerate','code':NO_DEVICE_PATH}
+        return {'error':'You must specify a device type or fingerprint for all commands except enumerate','code': NO_DEVICE_TYPE}
 
     client.is_testnet = args.testnet
 

--- a/hwilib/errors.py
+++ b/hwilib/errors.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 
 # Error codes
 NO_DEVICE_TYPE = -1
-UNUSED_ERROR_CODE = -2
+MISSING_ARGUMENTS = -2
 DEVICE_CONN_ERROR = -3
 UNKNWON_DEVICE_TYPE = -4
 INVALID_TX = -5
@@ -19,6 +19,7 @@ UNKNOWN_ERROR = -13
 ACTION_CANCELED = -14
 DEVICE_BUSY = -15
 NEED_TO_BE_ROOT = -16
+HELP_TEXT = -17
 
 # Exceptions
 class HWWError(Exception):

--- a/hwilib/errors.py
+++ b/hwilib/errors.py
@@ -3,8 +3,8 @@
 from contextlib import contextmanager
 
 # Error codes
-NO_DEVICE_PATH = -1
-NO_DEVICE_TYPE = -2
+NO_DEVICE_TYPE = -1
+UNUSED_ERROR_CODE = -2
 DEVICE_CONN_ERROR = -3
 UNKNWON_DEVICE_TYPE = -4
 INVALID_TX = -5


### PR DESCRIPTION
This PR adds our own `HWIArgumentParser` class in order to override the `print_usage`, `print_help`, and `error` functions to re-format and direct output to the correct files. We direct the standard usage and help text to stderr, and output an error message and code using JSON to stdout. Two additional error codes and messages are added for help requested and missing arguments. We also clarify in the readme that stderr is for extra information generally for debugging, and stdout is always JSON.

For example:
```sh
> ./hwi.py --help
usage: hwi.py [-h] [--device-path DEVICE_PATH] [--device-type DEVICE_TYPE]
              [--password PASSWORD] [--stdinpass] [--testnet] [--debug]
              [--fingerprint FINGERPRINT] [--version] [--stdin]
              [--interactive]
              {enumerate,getmasterxpub,signtx,getxpub,signmessage,getkeypool,displayaddress,setup,wipe,restore,backup,promptpin,sendpin,installudevrules}
              ...

Hardware Wallet Interface, version 1.0.1.
Access and send commands to a hardware wallet device. Responses are in JSON format.

optional arguments:
  -h, --help            show this help message and exit
  --device-path DEVICE_PATH, -d DEVICE_PATH
                        Specify the device path of the device to connect to
  --device-type DEVICE_TYPE, -t DEVICE_TYPE
                        Specify the type of device that will be connected. If
                        `--device-path` not given, the first device of this
                        type enumerated is used.
  --password PASSWORD, -p PASSWORD
                        Device password if it has one (e.g. DigitalBitbox)
  --stdinpass           Enter the device password on the command line
  --testnet             Use testnet prefixes
  --debug               Print debug statements
  --fingerprint FINGERPRINT, -f FINGERPRINT
                        Specify the device to connect to using the first 4
                        bytes of the hash160 of the master public key. It will
                        connect to the first device that matches this
                        fingerprint.
  --version             show program's version number and exit
  --stdin               Enter commands and arguments via stdin
  --interactive, -i     Use some commands interactively. Currently required
                        for all device configuration commands

subcommands:
  Commands

  {enumerate,getmasterxpub,signtx,getxpub,signmessage,getkeypool,displayaddress,setup,wipe,restore,backup,promptpin,sendpin,installudevrules}
    enumerate           List all available devices
    getmasterxpub       Get the extended public key at m/44'/0'/0'
    signtx              Sign a PSBT
    getxpub             Get an extended public key
    signmessage         Sign a message
    getkeypool          Get JSON array of keys that can be imported to Bitcoin
                        Core with importmulti
    displayaddress      Display an address
    setup               Setup a device. Passphrase protection uses the
                        password given by -p. Requires interactive mode
    wipe                Wipe a device
    restore             Initiate the device restoring process. Requires
                        interactive mode
    backup              Initiate the device backup creation process
    promptpin           Have the device prompt for your PIN
    sendpin             Send the numeric positions for your PIN to the device
    installudevrules    Install and load the udev rule files for the hardware
                        wallet devices
{"error": "Help text requested", "code": -18}
> ./hwi.py --help 2> /dev/null
{"error": "Help text requested", "code": -18}
> ./hwi.py signmessage
usage: hwi.py signmessage [-h] message path
{"error": "hwi.py signmessage: error: the following arguments are required: message, path", "code": -17}
> ./hwi.py signmessage 2> /dev/null
{"error": "hwi.py signmessage: error: the following arguments are required: message, path", "code": -17}
```

Also changes a `NO_DEVICE_PATH` error to `NO_DEVICE_TYPE` error.

Fixes #207 
Fixes #209