### PR TITLE
 Enable trezor and keepkey change detection for standard single key ouputs

### DIFF
--- a/docs/trezor.md
+++ b/docs/trezor.md
@@ -19,6 +19,7 @@ Due to the limitations of the Trezor, some transactions cannot be signed by a Tr
 
 - Multisig inputs are limited to at most n-of-15 multisigs. This is a firmware limitation.
 * Transactions with arbitrary input scripts (scriptPubKey, redeemScript, or witnessScript) and arbitrary output scripts cannot be signed. This is a firmware limitation.
+* Send-to-self transactions will result in no prompt for outputs as all outputs will be detected as change.
 
 ## Note on `backup`
 


### PR DESCRIPTION
Enable change detection for p2pkh, p2sh-p2wpk, and p2wpkh on the Trezor and Keepkey

Fixes #170