### PR TITLE
Only allow udevinstaller on linux

### DIFF
--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -3,14 +3,13 @@
 # Hardware wallet interaction script
 
 import importlib
+import platform
 
 from .serializations import PSBT, Base64ToHex, HexToBase64, hash160
 from .base58 import get_xpub_fingerprint_as_id, get_xpub_fingerprint_hex, xpub_to_pub_hex
 from .errors import NoPasswordError, UnavailableActionError, DeviceAlreadyInitError, DeviceAlreadyUnlockedError, UnknownDeviceError, BAD_ARGUMENT, NOT_IMPLEMENTED
 from .descriptor import Descriptor
 from .devices import __all__ as all_devs
-from .udevinstaller import UDevInstaller
-
 
 # Get the client for the device
 def get_client(device_type, device_path, password=''):
@@ -207,4 +206,7 @@ def send_pin(client, pin):
     return client.send_pin(pin)
 
 def install_udev_rules(source, location):
-    return UDevInstaller.install(source, location);
+    if platform.system() == "Linux":
+        from .udevinstaller import UDevInstaller
+        return UDevInstaller.install(source, location);
+    return {'error': 'udev rules are not needed on your platform', 'code': NOT_IMPLEMENTED}


### PR DESCRIPTION
Udev rules are only need on linux. Additionally, attempting to install them on any other platform will probably fail. So don't let that happen.

Fixes #208 