### PR TITLE
Raise an ImportError if hwi.py is being imported

### DIFF
--- a/hwi.py
+++ b/hwi.py
@@ -2,6 +2,8 @@
 
 # Hardware wallet interaction script
 
-from hwilib.cli import main
-
-main()
+if __name__ == '__main__':
+    from hwilib.cli import main
+    main()
+else:
+    raise ImportError('hwi is not importable. Import hwilib instead')


### PR DESCRIPTION
hwilib is the thing to import, not hwi. So give an error if that happens.

Fixes #213