### PR TITLE
Give Not Initialized error an error code

### DIFF
--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -15,7 +15,7 @@ import sys
 import time
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import ActionCanceledError, BadArgumentError, DeviceFailureError, DeviceAlreadyInitError, DeviceNotReadyError, HWWError, NoPasswordError, UnavailableActionError, UNKNOWN_ERROR, common_err_msgs, handle_errors
+from ..errors import ActionCanceledError, BadArgumentError, DeviceFailureError, DeviceAlreadyInitError, DEVICE_NOT_INITIALIZED, DeviceNotReadyError, HWWError, NoPasswordError, UnavailableActionError, UNKNOWN_ERROR, common_err_msgs, handle_errors
 from ..serializations import CTransaction, PSBT, hash256, hash160, ser_sig_der, ser_sig_compact, ser_compact_size
 from ..base58 import get_xpub_fingerprint, decode, to_address, xpub_main_2_test, get_xpub_fingerprint_hex
 
@@ -600,6 +600,7 @@ def enumerate(password=''):
                 reply = send_encrypt('{"device" : "info"}', password, client.device)
                 if 'error' in reply and reply['error']['code'] == 101:
                     d_data['error'] = 'Not initialized'
+                    d_data['code'] = DEVICE_NOT_INITIALIZED
                 else:
                     master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
                     d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -1,6 +1,6 @@
 # KeepKey interaction script
 
-from ..errors import DeviceNotReadyError, common_err_msgs, handle_errors
+from ..errors import DEVICE_NOT_INITIALIZED, DeviceNotReadyError, common_err_msgs, handle_errors
 from .trezorlib.transport import enumerate_devices
 from .trezor import TrezorClient
 from ..base58 import get_xpub_fingerprint_hex
@@ -39,6 +39,7 @@ def enumerate(password=''):
                 d_data['needs_passphrase_sent'] = False # Passphrase is always needed for the above to have worked, so it's already sent
             else:
                 d_data['error'] = 'Not initialized'
+                d_data['code'] = DEVICE_NOT_INITIALIZED
 
         if client:
             client.close()

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -1,7 +1,7 @@
 # Trezor interaction script
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import ActionCanceledError, BadArgumentError, DeviceAlreadyInitError, DeviceAlreadyUnlockedError, DeviceConnectionError, DeviceNotReadyError, HWWError, UnavailableActionError, UNKNOWN_ERROR, common_err_msgs, handle_errors
+from ..errors import ActionCanceledError, BadArgumentError, DeviceAlreadyInitError, DeviceAlreadyUnlockedError, DeviceConnectionError, DEVICE_NOT_INITIALIZED, DeviceNotReadyError, HWWError, UnavailableActionError, UNKNOWN_ERROR, common_err_msgs, handle_errors
 from .trezorlib.client import TrezorClient as Trezor
 from .trezorlib.debuglink import TrezorClientDebugLink, DebugUI
 from .trezorlib.exceptions import Cancelled
@@ -433,6 +433,7 @@ def enumerate(password=''):
                 d_data['needs_passphrase_sent'] = False # Passphrase is always needed for the above to have worked, so it's already sent
             else:
                 d_data['error'] = 'Not initialized'
+                d_data['code'] = DEVICE_NOT_INITIALIZED
 
         if client:
             client.close()

--- a/hwilib/errors.py
+++ b/hwilib/errors.py
@@ -20,6 +20,7 @@ ACTION_CANCELED = -14
 DEVICE_BUSY = -15
 NEED_TO_BE_ROOT = -16
 HELP_TEXT = -17
+DEVICE_NOT_INITIALIZED = -18
 
 # Exceptions
 class HWWError(Exception):


### PR DESCRIPTION
Adds a DEVICE_NOT_INITIALIZED error code and gives it in `enumerate` output when devices are not initialized.

Fixes #216