### PR TITLE
Get udev rules from correct folder

### DIFF
--- a/hwilib/udevinstaller.py
+++ b/hwilib/udevinstaller.py
@@ -50,7 +50,7 @@ class UDevInstaller(object):
 
     def copy_udev_rule_files(self, source, location):
         src_dir_path = source
-        for rules_file_name in listdir(src_dir_path):
+        for rules_file_name in listdir(_resource_path(src_dir_path)):
             rules_file_path = _resource_path(path.join(src_dir_path, rules_file_name))
             copy(rules_file_path, location)
     


### PR DESCRIPTION
The udev rule files were taken from the udev folder source but that folder is not present when it is distributed in binary form.  