### PR TITLE
Add flake8 linter and do style fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+exclude = *.pyc,__pycache__,hwilib/devices/btchip/,hwilib/devices/ckcc/,hwilib/devices/trezorlib/,test/work/
+ignore = E261,E302,E305,E501,E722,W5
+per-file-ignores = setup.py:E122

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,15 +51,23 @@ install:
     - poetry install
 jobs:
     include:
+        -   name: lint
+            stage: lint
+            script: flake8
         -   name: Run non-device tests only
+            stage: test
             script: cd test; poetry run ./run_tests.py
         -   name: With process_commands interface
+            stage: test
             script: cd test; poetry run ./run_tests.py --all --interface=library
         -   name: With command line interface
+            stage: test
             script: cd test; poetry run ./run_tests.py --all --interface=cli
         -   name: With stdin interface
+            stage: test
             script: cd test; poetry run ./run_tests.py --all --interface=stdin
         -   name: With wheel command line interface
+            stage: test
             services: docker
             before_script:
                 - docker build -t hwi-builder -f contrib/build.Dockerfile .
@@ -69,6 +77,7 @@ jobs:
                 - pip install dist/*.whl
                 - cd test; ./run_tests.py --all --interface=cli
         -   name: With sdist command line interface
+            stage: test
             services: docker
             before_script:
                 - docker build -t hwi-builder -f contrib/build.Dockerfile .
@@ -78,6 +87,7 @@ jobs:
                 - pip install dist/*.tar.gz
                 - cd test; ./run_tests.py --all --interface=cli
         -   name: With linux binary distribution command line interface
+            stage: test
             services: docker
             before_script:
                 - docker build -t hwi-builder -f contrib/build.Dockerfile .
@@ -87,6 +97,7 @@ jobs:
                 - cd test; poetry run ./run_tests.py --all --interface=bindist
                 - cd ..; sha256sum dist/*
         -   name: macOS binary distribution (no tests)
+            stage: test
             os: osx
             osx_image: xcode7.3
             language: generic

--- a/contrib/autopep8.sh
+++ b/contrib/autopep8.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+# Script for running autopep8
+
+autopep8 --in-place test/*.py hwilib/*.py hwilib/devices/*.py hwi.py

--- a/hwilib/base58.py
+++ b/hwilib/base58.py
@@ -51,7 +51,7 @@ def decode(s):
     for c in s:
         n *= 58
         if c not in b58_digits:
-            raise InvalidBase58Error('Character %r is not a valid base58 character' % c)
+            raise ValueError('Character %r is not a valid base58 character' % c)
         digit = b58_digits.index(c)
         n += digit
 

--- a/hwilib/base58.py
+++ b/hwilib/base58.py
@@ -8,11 +8,11 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
 
+from .serializations import hash256, hash160
+import struct
+from binascii import hexlify, unhexlify
 b58_digits = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 
-from binascii import hexlify, unhexlify
-import struct
-from .serializations import hash256, hash160
 
 def encode(b):
     """Encode bytes to a base58-encoded string"""

--- a/hwilib/base58.py
+++ b/hwilib/base58.py
@@ -23,7 +23,7 @@ def encode(b):
     # Divide that integer into bas58
     res = []
     while n > 0:
-        n, r = divmod (n, 58)
+        n, r = divmod(n, 58)
         res.append(b58_digits[r])
     res = ''.join(res[::-1])
 

--- a/hwilib/base58.py
+++ b/hwilib/base58.py
@@ -8,7 +8,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
 
-from .serializations import hash256, hash160
+from .serializations import hash256
 import struct
 from binascii import hexlify, unhexlify
 b58_digits = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'

--- a/hwilib/base58.py
+++ b/hwilib/base58.py
@@ -35,8 +35,10 @@ def encode(b):
         czero = 0
     pad = 0
     for c in b:
-        if c == czero: pad += 1
-        else: break
+        if c == czero:
+            pad += 1
+        else:
+            break
     return b58_digits[0] * pad + res
 
 def decode(s):
@@ -62,8 +64,10 @@ def decode(s):
     # Add padding back.
     pad = 0
     for c in s[:-1]:
-        if c == b58_digits[0]: pad += 1
-        else: break
+        if c == b58_digits[0]:
+            pad += 1
+        else:
+            break
     return b'\x00' * pad + res
 
 def get_xpub_fingerprint(s):

--- a/hwilib/bech32.py
+++ b/hwilib/bech32.py
@@ -68,10 +68,10 @@ def bech32_decode(bech):
     pos = bech.rfind('1')
     if pos < 1 or pos + 7 > len(bech) or len(bech) > 90:
         return (None, None)
-    if not all(x in CHARSET for x in bech[pos+1:]):
+    if not all(x in CHARSET for x in bech[pos + 1:]):
         return (None, None)
     hrp = bech[:pos]
-    data = [CHARSET.find(x) for x in bech[pos+1:]]
+    data = [CHARSET.find(x) for x in bech[pos + 1:]]
     if not bech32_verify_checksum(hrp, data):
         return (None, None)
     return (hrp, data[:-6])

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -181,7 +181,6 @@ def process_commands(cli_args):
         udevrules_parser.set_defaults(func=install_udev_rules_handler)
 
     if any(arg == '--stdin' for arg in cli_args):
-        blank_count = 0
         while True:
             try:
                 line = input()

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -7,13 +7,9 @@ from .errors import (
     handle_errors,
     DEVICE_CONN_ERROR,
     HELP_TEXT,
-    HWWError,
     MISSING_ARGUMENTS,
     NO_DEVICE_TYPE,
-    NO_PASSWORD,
-    UNAVAILABLE_ACTION,
-    UNKNWON_DEVICE_TYPE,
-    UNKNOWN_ERROR
+    UNAVAILABLE_ACTION
 )
 from . import __version__
 

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -227,14 +227,14 @@ def process_commands(cli_args):
     if args.fingerprint or (args.device_type and not args.device_path):
         client = find_device(args.device_path, args.password, args.device_type, args.fingerprint)
         if not client:
-            return {'error':'Could not find device with specified fingerprint','code':DEVICE_CONN_ERROR}
+            return {'error': 'Could not find device with specified fingerprint', 'code': DEVICE_CONN_ERROR}
     elif args.device_type and args.device_path:
         with handle_errors(result=result, code=DEVICE_CONN_ERROR):
             client = get_client(device_type, device_path, password)
         if 'error' in result:
             return result
     else:
-        return {'error':'You must specify a device type or fingerprint for all commands except enumerate','code': NO_DEVICE_TYPE}
+        return {'error': 'You must specify a device type or fingerprint for all commands except enumerate', 'code': NO_DEVICE_TYPE}
 
     client.is_testnet = args.testnet
 

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -180,7 +180,6 @@ def process_commands(cli_args):
         udevrules_parser.add_argument('--location', help='The path where the udev rules files will be copied', default='/etc/udev/rules.d/')
         udevrules_parser.set_defaults(func=install_udev_rules_handler)
 
-
     if any(arg == '--stdin' for arg in cli_args):
         blank_count = 0
         while True:

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -85,7 +85,7 @@ def signmessage(client, message, path):
 
 def getkeypool_inner(client, path, start, end, internal=False, keypool=False, account=0, sh_wpkh=False, wpkh=True):
     if sh_wpkh == True and wpkh == True:
-        return {'error':'Both `--wpkh` and `--sh_wpkh` can not be selected at the same time.','code':BAD_ARGUMENT}
+        return {'error': 'Both `--wpkh` and `--sh_wpkh` can not be selected at the same time.', 'code': BAD_ARGUMENT}
 
     try:
         master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
@@ -139,12 +139,12 @@ def getdescriptor(client, master_xpub, testnet=False, path=None, internal=False,
             path += "0/*"
     else:
         if path[0] != "m":
-            return {'error':'Path must start with m/','code':BAD_ARGUMENT}
+            return {'error': 'Path must start with m/', 'code': BAD_ARGUMENT}
         if path[-1] != "*":
-            return {'error':'Path must end with /*','code':BAD_ARGUMENT}
+            return {'error': 'Path must end with /*', 'code': BAD_ARGUMENT}
 
     # Find the last hardened derivation:
-    path = path.replace('\'','h')
+    path = path.replace('\'', 'h')
     path_suffix = ''
     for component in path.split("/")[::-1]:
         if component[-1] == 'h' or component[-1] == 'm':
@@ -200,7 +200,7 @@ def getdescriptors(client, account=0):
 def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False):
     if path is not None:
         if sh_wpkh == True and wpkh == True:
-            return {'error':'Both `--wpkh` and `--sh_wpkh` can not be selected at the same time.','code':BAD_ARGUMENT}
+            return {'error': 'Both `--wpkh` and `--sh_wpkh` can not be selected at the same time.', 'code': BAD_ARGUMENT}
         return client.display_address(path, sh_wpkh, wpkh)
     elif desc is not None:
         if client.fingerprint is None:
@@ -208,17 +208,17 @@ def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False):
             client.fingerprint = get_xpub_fingerprint_hex(master_xpub)
 
         if sh_wpkh == True or wpkh == True:
-            return {'error':' `--wpkh` and `--sh_wpkh` can not be combined with --desc','code':BAD_ARGUMENT}
+            return {'error': ' `--wpkh` and `--sh_wpkh` can not be combined with --desc', 'code': BAD_ARGUMENT}
         descriptor = Descriptor.parse(desc, client.is_testnet)
         if descriptor is None:
-            return {'error':'Unable to parse descriptor: ' + desc,'code':BAD_ARGUMENT}
+            return {'error': 'Unable to parse descriptor: ' + desc, 'code': BAD_ARGUMENT}
         if descriptor.m_path is None:
-            return {'error':'Descriptor missing origin info: ' + desc,'code':BAD_ARGUMENT}
+            return {'error': 'Descriptor missing origin info: ' + desc, 'code': BAD_ARGUMENT}
         if descriptor.origin_fingerprint != client.fingerprint:
-            return {'error':'Descriptor fingerprint does not match device: ' + desc,'code':BAD_ARGUMENT}
+            return {'error': 'Descriptor fingerprint does not match device: ' + desc, 'code': BAD_ARGUMENT}
         xpub = client.get_pubkey_at_path(descriptor.m_path_base)['xpub']
         if descriptor.base_key != xpub and descriptor.base_key != xpub_to_pub_hex(xpub):
-            return {'error':'Key in descriptor does not match device: ' + desc,'code':BAD_ARGUMENT}
+            return {'error': 'Key in descriptor does not match device: ' + desc, 'code': BAD_ARGUMENT}
         return client.display_address(descriptor.m_path, descriptor.sh_wpkh, descriptor.wpkh)
 
 def setup_device(client, label='', backup_passphrase=''):

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -242,5 +242,5 @@ def send_pin(client, pin):
 def install_udev_rules(source, location):
     if platform.system() == "Linux":
         from .udevinstaller import UDevInstaller
-        return UDevInstaller.install(source, location);
+        return UDevInstaller.install(source, location)
     return {'error': 'udev rules are not needed on your platform', 'code': NOT_IMPLEMENTED}

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -5,9 +5,9 @@
 import importlib
 import platform
 
-from .serializations import PSBT, Base64ToHex, HexToBase64, hash160
+from .serializations import PSBT
 from .base58 import get_xpub_fingerprint_as_id, get_xpub_fingerprint_hex, xpub_to_pub_hex
-from .errors import NoPasswordError, UnavailableActionError, DeviceAlreadyInitError, DeviceAlreadyUnlockedError, UnknownDeviceError, BAD_ARGUMENT, NOT_IMPLEMENTED
+from .errors import UnknownDeviceError, BAD_ARGUMENT, NOT_IMPLEMENTED
 from .descriptor import Descriptor
 from .devices import __all__ as all_devs
 

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -112,44 +112,44 @@ def getdescriptor(client, master_xpub, testnet=False, path=None, internal=False,
     testnet = client.is_testnet
 
     if not path:
-      # Master key:
-      path = "m/"
+        # Master key:
+        path = "m/"
 
-      # Purpose
-      if wpkh == True:
-        path += "84'/"
-      elif sh_wpkh == True:
-        path += "49'/"
-      else:
-        path += "44'/"
+        # Purpose
+        if wpkh == True:
+            path += "84'/"
+        elif sh_wpkh == True:
+            path += "49'/"
+        else:
+            path += "44'/"
 
-      # Coin type
-      if testnet == True:
-        path += "1'/"
-      else:
-        path += "0'/"
+        # Coin type
+        if testnet == True:
+            path += "1'/"
+        else:
+            path += "0'/"
 
-      # Account
-      path += str(account) + '\'/'
+        # Account
+        path += str(account) + '\'/'
 
-      # Receive or change
-      if internal == True:
-        path += "1/*"
-      else:
-        path += "0/*"
+        # Receive or change
+        if internal == True:
+            path += "1/*"
+        else:
+            path += "0/*"
     else:
-      if path[0] != "m":
-        return {'error':'Path must start with m/','code':BAD_ARGUMENT}
-      if path[-1] != "*":
-        return {'error':'Path must end with /*','code':BAD_ARGUMENT}
+        if path[0] != "m":
+            return {'error':'Path must start with m/','code':BAD_ARGUMENT}
+        if path[-1] != "*":
+            return {'error':'Path must end with /*','code':BAD_ARGUMENT}
 
     # Find the last hardened derivation:
     path = path.replace('\'','h')
     path_suffix = ''
     for component in path.split("/")[::-1]:
-      if component[-1] == 'h' or component[-1] == 'm':
-        break
-      path_suffix = '/' + component + path_suffix
+        if component[-1] == 'h' or component[-1] == 'm':
+            break
+        path_suffix = '/' + component + path_suffix
     path_base = path.rsplit(path_suffix)[0]
 
     # Get the key at the base

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -22,7 +22,7 @@ def get_client(device_type, device_path, password=''):
         imported_dev = importlib.import_module('.devices.' + module, __package__)
         client_constructor = getattr(imported_dev, class_name + 'Client')
         client = client_constructor(device_path, password)
-    except ImportError as e:
+    except ImportError:
         if client:
             client.close()
         raise UnknownDeviceError('Unknown device type specified')
@@ -37,7 +37,7 @@ def enumerate(password=''):
         try:
             imported_dev = importlib.import_module('.devices.' + module, __package__)
             result.extend(imported_dev.enumerate(password))
-        except ImportError as e:
+        except ImportError:
             pass # Ignore ImportErrors, the user may not have all device dependencies installed
     return result
 

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -84,7 +84,7 @@ def signmessage(client, message, path):
     return client.sign_message(message, path)
 
 def getkeypool_inner(client, path, start, end, internal=False, keypool=False, account=0, sh_wpkh=False, wpkh=True):
-    if sh_wpkh == True and wpkh == True:
+    if sh_wpkh and wpkh:
         return {'error': 'Both `--wpkh` and `--sh_wpkh` can not be selected at the same time.', 'code': BAD_ARGUMENT}
 
     try:
@@ -116,15 +116,15 @@ def getdescriptor(client, master_xpub, testnet=False, path=None, internal=False,
         path = "m/"
 
         # Purpose
-        if wpkh == True:
+        if wpkh:
             path += "84'/"
-        elif sh_wpkh == True:
+        elif sh_wpkh:
             path += "49'/"
         else:
             path += "44'/"
 
         # Coin type
-        if testnet == True:
+        if testnet:
             path += "1'/"
         else:
             path += "0'/"
@@ -133,7 +133,7 @@ def getdescriptor(client, master_xpub, testnet=False, path=None, internal=False,
         path += str(account) + '\'/'
 
         # Receive or change
-        if internal == True:
+        if internal:
             path += "1/*"
         else:
             path += "0/*"
@@ -199,7 +199,7 @@ def getdescriptors(client, account=0):
 
 def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False):
     if path is not None:
-        if sh_wpkh == True and wpkh == True:
+        if sh_wpkh and wpkh:
             return {'error': 'Both `--wpkh` and `--sh_wpkh` can not be selected at the same time.', 'code': BAD_ARGUMENT}
         return client.display_address(path, sh_wpkh, wpkh)
     elif desc is not None:
@@ -207,7 +207,7 @@ def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False):
             master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
             client.fingerprint = get_xpub_fingerprint_hex(master_xpub)
 
-        if sh_wpkh == True or wpkh == True:
+        if sh_wpkh or wpkh:
             return {'error': ' `--wpkh` and `--sh_wpkh` can not be combined with --desc', 'code': BAD_ARGUMENT}
         descriptor = Descriptor.parse(desc, client.is_testnet)
         if descriptor is None:

--- a/hwilib/descriptor.py
+++ b/hwilib/descriptor.py
@@ -18,8 +18,8 @@ def PolyMod(c, val):
     return c
 
 def DescriptorChecksum(desc):
-    INPUT_CHARSET = "0123456789()[],'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#\"\\ ";
-    CHECKSUM_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+    INPUT_CHARSET = "0123456789()[],'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#\"\\ "
+    CHECKSUM_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
 
     c = 1
     cls = 0

--- a/hwilib/descriptor.py
+++ b/hwilib/descriptor.py
@@ -113,7 +113,7 @@ class Descriptor:
             if path_suffix == ")":
                 path_suffix = None
         else:
-            if origin_match == None:
+            if origin_match is None:
                 return None
 
         return cls(origin_fingerprint, origin_path, base_key, path_suffix, testnet, sh_wpkh, wpkh)
@@ -124,9 +124,9 @@ class Descriptor:
         origin = ''
         path_suffix = ''
 
-        if self.wpkh == True:
+        if self.wpkh:
             descriptor_open = 'wpkh('
-        elif self.sh_wpkh == True:
+        elif self.sh_wpkh:
             descriptor_open = 'sh(wpkh('
             descriptor_close = '))'
 

--- a/hwilib/descriptor.py
+++ b/hwilib/descriptor.py
@@ -118,7 +118,6 @@ class Descriptor:
 
         return cls(origin_fingerprint, origin_path, base_key, path_suffix, testnet, sh_wpkh, wpkh)
 
-
     def serialize(self):
         descriptor_open = 'pkh('
         descriptor_close = ')'

--- a/hwilib/descriptor.py
+++ b/hwilib/descriptor.py
@@ -37,7 +37,7 @@ def DescriptorChecksum(desc):
             clscount = 0
     if clscount > 0:
         c = PolyMod(c, cls)
-    for j in range (0, 8):
+    for j in range(0, 8):
         c = PolyMod(c, 0)
     c ^= 1
 
@@ -65,7 +65,7 @@ class Descriptor:
             self.m_path = "m" + origin_path + (path_suffix or "")
 
     @classmethod
-    def parse(cls, desc, testnet = False):
+    def parse(cls, desc, testnet=False):
         sh_wpkh = None
         wpkh = None
         origin_fingerprint = None
@@ -97,7 +97,7 @@ class Descriptor:
         if origin_match:
             origin = origin_match.group(1)
             match = re.search(r"^([0-9a-fA-F]{8})(\/.*)", origin)
-            if  match:
+            if match:
                 origin_fingerprint = match.group(1)
                 origin_path = match.group(2)
                 # Replace h with '

--- a/hwilib/descriptor.py
+++ b/hwilib/descriptor.py
@@ -98,10 +98,10 @@ class Descriptor:
             origin = origin_match.group(1)
             match = re.search(r"^([0-9a-fA-F]{8})(\/.*)", origin)
             if  match:
-              origin_fingerprint = match.group(1)
-              origin_path = match.group(2)
-              # Replace h with '
-              origin_path = origin_path.replace('h', '\'')
+                origin_fingerprint = match.group(1)
+                origin_path = match.group(2)
+                # Replace h with '
+                origin_path = origin_path.replace('h', '\'')
 
             base_key_and_path_match = re.search(r"\[.*\](\w+)([\/\)][\d'\/\*]*)", desc)
         else:

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -96,7 +96,7 @@ class ColdcardClient(HardwareWalletClient):
 
         # start the signing process
         ok = self.device.send_recv(CCProtocolPacker.sign_transaction(sz, expect), timeout=None)
-        assert ok == None
+        assert ok is None
         if self.device.is_simulator:
             self.device.send_recv(CCProtocolPacker.sim_keypress(b'y'))
 
@@ -105,7 +105,7 @@ class ColdcardClient(HardwareWalletClient):
         while 1:
             time.sleep(0.250)
             done = self.device.send_recv(CCProtocolPacker.get_signed_txn(), timeout=None)
-            if done == None:
+            if done is None:
                 continue
             break
 
@@ -126,14 +126,14 @@ class ColdcardClient(HardwareWalletClient):
         keypath = keypath.replace('H', '\'')
 
         ok = self.device.send_recv(CCProtocolPacker.sign_message(message.encode(), keypath, AF_CLASSIC), timeout=None)
-        assert ok == None
+        assert ok is None
         if self.device.is_simulator:
             self.device.send_recv(CCProtocolPacker.sim_keypress(b'y'))
 
         while 1:
             time.sleep(0.250)
             done = self.device.send_recv(CCProtocolPacker.get_signed_msg(), timeout=None)
-            if done == None:
+            if done is None:
                 continue
 
             break
@@ -182,7 +182,7 @@ class ColdcardClient(HardwareWalletClient):
         self.device.check_mitm()
 
         ok = self.device.send_recv(CCProtocolPacker.start_backup())
-        assert ok == None
+        assert ok is None
         if self.device.is_simulator:
             self.device.send_recv(CCProtocolPacker.sim_keypress(b'y'))
 
@@ -192,7 +192,7 @@ class ColdcardClient(HardwareWalletClient):
 
             time.sleep(0.250)
             done = self.device.send_recv(CCProtocolPacker.get_backup_file(), timeout=None)
-            if done == None:
+            if done is None:
                 continue
             break
 

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -80,7 +80,8 @@ class ColdcardClient(HardwareWalletClient):
         chk = sha256()
         for pos in range(0, sz, MAX_BLK_LEN):
             here = fd.read(min(MAX_BLK_LEN, left))
-            if not here: break
+            if not here:
+                break
             left -= len(here)
             result = self.device.send_recv(CCProtocolPacker.upload(pos, sz, here))
             assert result == pos

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -26,7 +26,7 @@ def coldcard_exception(f):
             return f(*args, **kwargs)
         except CCProtoError as e:
             raise BadArgumentError(str(e))
-        except CCUserRefused as e:
+        except CCUserRefused:
             raise ActionCanceledError('{} canceled'.format(f.__name__))
         except CCBusyError as e:
             raise DeviceBusyError(str(e))
@@ -72,7 +72,6 @@ class ColdcardClient(HardwareWalletClient):
         fd = io.BytesIO(base64.b64decode(tx.serialize()))
 
         # learn size (portable way)
-        offset = 0
         sz = fd.seek(0, 2)
         fd.seek(0)
 

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -54,9 +54,9 @@ class ColdcardClient(HardwareWalletClient):
         path = path.replace('H', '\'')
         xpub = self.device.send_recv(CCProtocolPacker.get_xpub(path), timeout=None)
         if self.is_testnet:
-            return {'xpub':xpub_main_2_test(xpub)}
+            return {'xpub': xpub_main_2_test(xpub)}
         else:
-            return {'xpub':xpub}
+            return {'xpub': xpub}
 
     def _get_fingerprint_hex(self):
         # quick method to get fingerprint of wallet
@@ -114,7 +114,7 @@ class ColdcardClient(HardwareWalletClient):
         result_len, result_sha = done
 
         result = self.device.download_file(result_len, result_sha, file_number=1)
-        return {'psbt':base64.b64encode(result).decode()}
+        return {'psbt': base64.b64encode(result).decode()}
 
     # Must return a base64 encoded string with the signed message
     # The message can be any string. keypath is the bip 32 derivation path for the key to sign with

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -1,15 +1,14 @@
 # Coldcard interaction script
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import ActionCanceledError, BadArgumentError, DeviceBusyError, DeviceFailureError, HWWError, UnavailableActionError, UNKNOWN_ERROR, common_err_msgs, handle_errors
+from ..errors import ActionCanceledError, BadArgumentError, DeviceBusyError, DeviceFailureError, UnavailableActionError, common_err_msgs, handle_errors
 from .ckcc.client import ColdcardDevice, COINKITE_VID, CKCC_PID
 from .ckcc.protocol import CCProtocolPacker, CCBusyError, CCProtoError, CCUserRefused
 from .ckcc.constants import MAX_BLK_LEN, AF_P2WPKH, AF_CLASSIC, AF_P2WPKH_P2SH
-from ..base58 import xpub_main_2_test, get_xpub_fingerprint_hex
+from ..base58 import xpub_main_2_test
 from hashlib import sha256
 
 import base64
-import json
 import hid
 import io
 import sys

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -1,5 +1,6 @@
 # Coldcard interaction script
 
+from binascii import b2a_hex
 from ..hwwclient import HardwareWalletClient
 from ..errors import ActionCanceledError, BadArgumentError, DeviceBusyError, DeviceFailureError, UnavailableActionError, common_err_msgs, handle_errors
 from .ckcc.client import ColdcardDevice, COINKITE_VID, CKCC_PID

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -334,7 +334,6 @@ class DigitalbitboxClient(HardwareWalletClient):
         sighash_tuples = []
         for txin, psbt_in, i_num in zip(blank_tx.vin, tx.inputs, range(len(blank_tx.vin))):
             sighash = b""
-            pubkeys = []
             if psbt_in.non_witness_utxo:
                 utxo = psbt_in.non_witness_utxo.vout[txin.prevout.n]
 
@@ -579,7 +578,7 @@ def enumerate(password=''):
     # Try connecting to simulator
     try:
         dev = BitboxSimulator('127.0.0.1', 35345)
-        res = dev.send_recv(b'{"device" : "info"}')
+        dev.send_recv(b'{"device" : "info"}')
         devices.append({'path': b'udp:127.0.0.1:35345', 'interface_number': 0})
         dev.close()
     except:

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -146,7 +146,8 @@ def sha512(x):
     return hashlib.sha512(x).digest()
 
 def double_hash(x):
-    if type(x) is not bytearray: x = x.encode('utf-8')
+    if type(x) is not bytearray:
+        x = x.encode('utf-8')
     return sha256(sha256(x))
 
 def derive_keys(x):
@@ -184,8 +185,8 @@ class BitboxSimulator():
 def send_frame(data, device):
     data = bytearray(data)
     data_len = len(data)
-    seq = 0;
-    idx = 0;
+    seq = 0
+    idx = 0
     write = []
     while idx < data_len:
         if idx == 0:
@@ -207,7 +208,7 @@ def read_frame(device):
     cmd = read[4]
     data_len = read[5] * 256 + read[6]
     data = read[7:]
-    idx = len(read) - 7;
+    idx = len(read) - 7
     while idx < data_len:
         # CONT response
         read = bytearray(device.read(usb_report_size))

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -20,7 +20,7 @@ from ..serializations import CTransaction, PSBT, hash256, hash160, ser_sig_der, 
 from ..base58 import get_xpub_fingerprint, decode, to_address, xpub_main_2_test, get_xpub_fingerprint_hex
 
 applen = 225280 # flash size minus bootloader length
-chunksize = 8*512
+chunksize = 8 * 512
 usb_report_size = 64 # firmware > v2.0
 report_buf_size = 4096 # firmware v2.0.0
 boot_buf_size_send = 4098
@@ -146,13 +146,13 @@ def sha512(x):
     return hashlib.sha512(x).digest()
 
 def double_hash(x):
-    if type(x) is not bytearray: x=x.encode('utf-8')
+    if type(x) is not bytearray: x = x.encode('utf-8')
     return sha256(sha256(x))
 
 def derive_keys(x):
     h = double_hash(x)
     h = sha512(h)
-    return (h[:len(h)//2], h[len(h)//2:])
+    return (h[:len(h) // 2], h[len(h) // 2:])
 
 def to_string(x, enc):
     if isinstance(x, (bytes, bytearray)):
@@ -190,11 +190,11 @@ def send_frame(data, device):
     while idx < data_len:
         if idx == 0:
             # INIT frame
-            write = data[idx : idx + min(data_len, usb_report_size - 7)]
-            device.write(b'\0' + struct.pack(">IBH",HWW_CID, HWW_CMD, data_len & 0xFFFF) + write + b'\xEE' * (usb_report_size - 7 - len(write)))
+            write = data[idx: idx + min(data_len, usb_report_size - 7)]
+            device.write(b'\0' + struct.pack(">IBH", HWW_CID, HWW_CMD, data_len & 0xFFFF) + write + b'\xEE' * (usb_report_size - 7 - len(write)))
         else:
             # CONT frame
-            write = data[idx : idx + min(data_len, usb_report_size - 5)]
+            write = data[idx: idx + min(data_len, usb_report_size - 5)]
             device.write(b'\0' + struct.pack(">IB", HWW_CID, seq) + write + b'\xEE' * (usb_report_size - 5 - len(write)))
             seq += 1
         idx += len(write)
@@ -276,7 +276,7 @@ def send_encrypt(msg, password, device):
         if 'error' in reply:
             password = None
     except Exception as e:
-        reply = {'error':'Exception caught while sending encrypted message to DigitalBitbox ' + str(e)}
+        reply = {'error': 'Exception caught while sending encrypted message to DigitalBitbox ' + str(e)}
     return reply
 
 def stretch_backup_key(password):
@@ -314,9 +314,9 @@ class DigitalbitboxClient(HardwareWalletClient):
             raise DBBError(reply)
 
         if self.is_testnet:
-            return {'xpub':xpub_main_2_test(reply['xpub'])}
+            return {'xpub': xpub_main_2_test(reply['xpub'])}
         else:
-            return {'xpub':reply['xpub']}
+            return {'xpub': reply['xpub']}
 
     # Must return a hex string with the signed transaction
     # The tx must be in the PSBT format
@@ -427,7 +427,7 @@ class DigitalbitboxClient(HardwareWalletClient):
 
         # Return early if nothing to do
         if len(sighash_tuples) == 0:
-            return {'psbt':tx.serialize()}
+            return {'psbt': tx.serialize()}
 
         # Sign the sighashes
         to_send = '{"sign":{"data":['
@@ -466,7 +466,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         for tup, sig in zip(sighash_tuples, der_sigs):
             tx.inputs[tup[2]].partial_sigs[tup[3]] = sig
 
-        return {'psbt':tx.serialize()}
+        return {'psbt': tx.serialize()}
 
     # Must return a base64 encoded string with the signed message
     # The message can be any string
@@ -502,7 +502,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         compact_sig = ser_sig_compact(r, s, recid)
         logging.debug(binascii.hexlify(compact_sig))
 
-        return {"signature":base64.b64encode(compact_sig).decode('utf-8')}
+        return {"signature": base64.b64encode(compact_sig).decode('utf-8')}
 
     # Display address of specified type on the device. Only supports single-key based addresses.
     def display_address(self, keypath, p2sh_p2wpkh, bech32):
@@ -584,7 +584,7 @@ def enumerate(password=''):
     except:
         pass
     for d in devices:
-        if ('interface_number' in d and  d['interface_number'] == 0 \
+        if ('interface_number' in d and d['interface_number'] == 0 \
                 or ('usage_page' in d and d['usage_page'] == 0xffff)):
             d_data = {}
 

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -237,7 +237,7 @@ def send_plain(msg, device):
                 device.write('\0' + msg + '\0' * (hidBufSize - len(msg)))
                 r = bytearray()
                 while len(r) < hidBufSize:
-                    r += bytearray(self.dbb_hid.read(hidBufSize))
+                    r += bytearray(device.read(hidBufSize))
             else:
                 send_frame(msg, device)
                 r = read_frame(device)

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -15,9 +15,9 @@ import sys
 import time
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import ActionCanceledError, BadArgumentError, DeviceFailureError, DeviceAlreadyInitError, DEVICE_NOT_INITIALIZED, DeviceNotReadyError, HWWError, NoPasswordError, UnavailableActionError, UNKNOWN_ERROR, common_err_msgs, handle_errors
-from ..serializations import CTransaction, PSBT, hash256, hash160, ser_sig_der, ser_sig_compact, ser_compact_size
-from ..base58 import get_xpub_fingerprint, decode, to_address, xpub_main_2_test, get_xpub_fingerprint_hex
+from ..errors import ActionCanceledError, BadArgumentError, DeviceFailureError, DeviceAlreadyInitError, DEVICE_NOT_INITIALIZED, DeviceNotReadyError, NoPasswordError, UnavailableActionError, common_err_msgs, handle_errors
+from ..serializations import CTransaction, hash256, ser_sig_der, ser_sig_compact, ser_compact_size
+from ..base58 import get_xpub_fingerprint, xpub_main_2_test, get_xpub_fingerprint_hex
 
 applen = 225280 # flash size minus bootloader length
 chunksize = 8 * 512

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -584,7 +584,7 @@ def enumerate(password=''):
     except:
         pass
     for d in devices:
-        if ('interface_number' in d and d['interface_number'] == 0 \
+        if ('interface_number' in d and d['interface_number'] == 0
                 or ('usage_page' in d and d['usage_page'] == 0xffff)):
             d_data = {}
 

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -585,7 +585,7 @@ def enumerate(password=''):
         pass
     for d in devices:
         if ('interface_number' in d and  d['interface_number'] == 0 \
-        or ('usage_page' in d and d['usage_page'] == 0xffff)):
+                or ('usage_page' in d and d['usage_page'] == 0xffff)):
             d_data = {}
 
             path = d['path'].decode()

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -26,7 +26,7 @@ def enumerate(password=''):
         with handle_errors(common_err_msgs["enumerate"], d_data):
             client = KeepkeyClient(d_data['path'], password)
             client.client.init_device()
-            if not 'keepkey' in client.client.features.vendor:
+            if 'keepkey' not in client.client.features.vendor:
                 continue
 
             if d_data['path'] == 'udp:127.0.0.1:21324':

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -250,7 +250,7 @@ class LedgerClient(HardwareWalletClient):
                 self.app.startUntrustedTransaction(i == 0, i, segwit_inputs, blank_script_code, c_tx.nVersion)
 
             # Number of unused fields for Nano S, only changepath and transaction in bytes req
-            outputData = self.app.finalizeInput(b"DUMMY", -1, -1, change_path, tx_bytes)
+            self.app.finalizeInput(b"DUMMY", -1, -1, change_path, tx_bytes)
 
             # For each input we control do segwit signature
             for i in range(len(segwit_inputs)):
@@ -267,7 +267,7 @@ class LedgerClient(HardwareWalletClient):
                 for signature_attempt in all_signature_attempts[i]:
                     assert(tx.inputs[i].non_witness_utxo is not None)
                     self.app.startUntrustedTransaction(first_input, i, legacy_inputs, script_codes[i], c_tx.nVersion)
-                    outputData = self.app.finalizeInput(b"DUMMY", -1, -1, change_path, tx_bytes)
+                    self.app.finalizeInput(b"DUMMY", -1, -1, change_path, tx_bytes)
                     tx.inputs[i].partial_sigs[signature_attempt[1]] = self.app.untrustedHashSign(signature_attempt[0], "", c_tx.nLockTime, 0x01)
                     first_input = False
 

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -166,7 +166,6 @@ class LedgerClient(HardwareWalletClient):
                             change_path += str(index) + "/"
                         change_path = change_path[:-1]
 
-
         for txin, psbt_in, i_num in zip(c_tx.vin, tx.inputs, range(len(c_tx.vin))):
 
             seq = format(txin.nSequence, 'x')

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -340,7 +340,7 @@ def enumerate(password=''):
     results = []
     for device_id in LEDGER_DEVICE_IDS:
         for d in hid.enumerate(LEDGER_VENDOR_ID, device_id):
-            if ('interface_number' in d and d['interface_number'] == 0 \
+            if ('interface_number' in d and d['interface_number'] == 0
                     or ('usage_page' in d and d['usage_page'] == 0xffa0)):
                 d_data = {}
 

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -342,7 +342,7 @@ def enumerate(password=''):
     for device_id in LEDGER_DEVICE_IDS:
         for d in hid.enumerate(LEDGER_VENDOR_ID, device_id):
             if ('interface_number' in d and  d['interface_number'] == 0 \
-            or ('usage_page' in d and d['usage_page'] == 0xffa0)):
+                    or ('usage_page' in d and d['usage_page'] == 0xffa0)):
                 d_data = {}
 
                 path = d['path'].decode()

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -1,17 +1,15 @@
 # Ledger interaction script
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import ActionCanceledError, BadArgumentError, DeviceConnectionError, DeviceFailureError, HWWError, UnavailableActionError, UNKNOWN_ERROR, common_err_msgs, handle_errors
+from ..errors import ActionCanceledError, BadArgumentError, DeviceConnectionError, DeviceFailureError, UnavailableActionError, common_err_msgs, handle_errors
 from .btchip.btchip import *
 from .btchip.btchipUtils import *
 import base64
 import hid
-import json
 import struct
 from .. import base58
 from ..base58 import get_xpub_fingerprint_hex
-from ..serializations import hash256, hash160, ser_uint256, PSBT, CTransaction, HexToBase64
-import binascii
+from ..serializations import hash256, hash160, CTransaction
 import logging
 import re
 

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -28,7 +28,7 @@ def check_keypath(key_path):
         return False
     # strip hardening chars
     for index in parts[1:]:
-        index_int =  re.sub('[hH\']', '', index)
+        index_int = re.sub('[hH\']', '', index)
         if not index_int.isdigit():
             return False
         if int(index_int) > 0x80000000:
@@ -92,7 +92,7 @@ class LedgerClient(HardwareWalletClient):
         if path != "":
             parent_path = ""
             for ind in path.split("/")[:-1]:
-                parent_path += ind+"/"
+                parent_path += ind + "/"
             parent_path = parent_path[:-1]
 
             # Get parent key fingerprint
@@ -105,7 +105,7 @@ class LedgerClient(HardwareWalletClient):
             if childstr[-1] == "'" or childstr[-1] == "h" or childstr[-1] == "H":
                 childstr = childstr[:-1]
                 hard = 0x80000000
-            child = struct.pack(">I", int(childstr)+hard)
+            child = struct.pack(">I", int(childstr) + hard)
         # Special case for m
         else:
             child = bytearray.fromhex("00000000")
@@ -121,10 +121,10 @@ class LedgerClient(HardwareWalletClient):
             version = bytearray.fromhex("043587CF")
         else:
             version = bytearray.fromhex("0488B21E")
-        extkey = version+depth+fpr+child+chainCode+publicKey
+        extkey = version + depth + fpr + child + chainCode + publicKey
         checksum = hash256(extkey)[:4]
 
-        return {"xpub":base58.encode(extkey+checksum)}
+        return {"xpub": base58.encode(extkey + checksum)}
 
     # Must return a hex string with the signed transaction
     # The tx must be in the combined unsigned transaction format
@@ -137,7 +137,7 @@ class LedgerClient(HardwareWalletClient):
         # Master key fingerprint
         master_fpr = hash160(compress_public_key(self.app.getWalletPublicKey('')["publicKey"]))[:4]
         # An entry per input, each with 0 to many keys to sign with
-        all_signature_attempts = [[]]*len(c_tx.vin)
+        all_signature_attempts = [[]] * len(c_tx.vin)
 
         # NOTE: We only support signing Segwit inputs, where we can skip over non-segwit
         # inputs, or non-segwit inputs, where *all* inputs are non-segwit. This is due
@@ -149,7 +149,7 @@ class LedgerClient(HardwareWalletClient):
         has_segwit = False
         has_legacy = False
 
-        script_codes = [[]]*len(c_tx.vin)
+        script_codes = [[]] * len(c_tx.vin)
 
         # Detect changepath, (p2sh-)p2(w)pkh only
         change_path = ''
@@ -160,10 +160,10 @@ class LedgerClient(HardwareWalletClient):
             for pubkey, path in tx.outputs[i_num].hd_keypaths.items():
                 if struct.pack("<I", path[0]) == master_fpr and len(path) > 2 and path[-2] == 1:
                     # For possible matches, check if pubkey matches possible template
-                    if hash160(pubkey) in txout.scriptPubKey or hash160(bytearray.fromhex("0014")+hash160(pubkey)) in txout.scriptPubKey:
+                    if hash160(pubkey) in txout.scriptPubKey or hash160(bytearray.fromhex("0014") + hash160(pubkey)) in txout.scriptPubKey:
                         change_path = ''
                         for index in path[1:]:
-                            change_path += str(index)+"/"
+                            change_path += str(index) + "/"
                         change_path = change_path[:-1]
 
 
@@ -176,7 +176,7 @@ class LedgerClient(HardwareWalletClient):
             seq_hex = ''.join('{:02x}'.format(x) for x in seq)
 
             if psbt_in.non_witness_utxo:
-                segwit_inputs.append({"value":txin.prevout.serialize()+struct.pack("<Q", psbt_in.non_witness_utxo.vout[txin.prevout.n].nValue), "witness":True, "sequence":seq_hex})
+                segwit_inputs.append({"value": txin.prevout.serialize() + struct.pack("<Q", psbt_in.non_witness_utxo.vout[txin.prevout.n].nValue), "witness": True, "sequence": seq_hex})
                 # We only need legacy inputs in the case where all inputs are legacy, we check
                 # later
                 ledger_prevtx = bitcoinTransaction(psbt_in.non_witness_utxo.serialize())
@@ -184,7 +184,7 @@ class LedgerClient(HardwareWalletClient):
                 legacy_inputs[-1]["sequence"] = seq_hex
                 has_legacy = True
             else:
-                segwit_inputs.append({"value":txin.prevout.serialize()+struct.pack("<Q", psbt_in.witness_utxo.nValue), "witness":True, "sequence":seq_hex})
+                segwit_inputs.append({"value": txin.prevout.serialize() + struct.pack("<Q", psbt_in.witness_utxo.nValue), "witness": True, "sequence": seq_hex})
                 has_segwit = True
 
             pubkeys = []
@@ -248,7 +248,7 @@ class LedgerClient(HardwareWalletClient):
             # Process them up front with all scriptcodes blank
             blank_script_code = bytearray()
             for i in range(len(segwit_inputs)):
-                self.app.startUntrustedTransaction(i==0, i, segwit_inputs, blank_script_code, c_tx.nVersion)
+                self.app.startUntrustedTransaction(i == 0, i, segwit_inputs, blank_script_code, c_tx.nVersion)
 
             # Number of unused fields for Nano S, only changepath and transaction in bytes req
             outputData = self.app.finalizeInput(b"DUMMY", -1, -1, change_path, tx_bytes)
@@ -273,7 +273,7 @@ class LedgerClient(HardwareWalletClient):
                     first_input = False
 
         # Send PSBT back
-        return {'psbt':tx.serialize()}
+        return {'psbt': tx.serialize()}
 
     # Must return a base64 encoded string with the signed message
     # The message can be any string
@@ -290,7 +290,7 @@ class LedgerClient(HardwareWalletClient):
 
         # Make signature into standard bitcoin format
         rLength = signature[3]
-        r = signature[4 : 4 + rLength]
+        r = signature[4: 4 + rLength]
         sLength = signature[4 + rLength + 1]
         s = signature[4 + rLength + 2:]
         if rLength == 33:
@@ -300,7 +300,7 @@ class LedgerClient(HardwareWalletClient):
 
         sig = bytearray(chr(27 + 4 + (signature[0] & 0x01)), 'utf8') + r + s
 
-        return {"signature":base64.b64encode(sig).decode('utf-8')}
+        return {"signature": base64.b64encode(sig).decode('utf-8')}
 
     @ledger_exception
     def display_address(self, keypath, p2sh_p2wpkh, bech32):
@@ -341,7 +341,7 @@ def enumerate(password=''):
     results = []
     for device_id in LEDGER_DEVICE_IDS:
         for d in hid.enumerate(LEDGER_VENDOR_ID, device_id):
-            if ('interface_number' in d and  d['interface_number'] == 0 \
+            if ('interface_number' in d and d['interface_number'] == 0 \
                     or ('usage_page' in d and d['usage_page'] == 0xffa0)):
                 d_data = {}
 

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -2,8 +2,11 @@
 
 from ..hwwclient import HardwareWalletClient
 from ..errors import ActionCanceledError, BadArgumentError, DeviceConnectionError, DeviceFailureError, UnavailableActionError, common_err_msgs, handle_errors
-from .btchip.btchip import *
-from .btchip.btchipUtils import *
+from .btchip.bitcoinTransaction import bitcoinTransaction
+from .btchip.btchip import btchip
+from .btchip.btchipComm import HIDDongleHIDAPI
+from .btchip.BTChipException import BTChipException
+from .btchip.btchipUtils import compress_public_key
 import base64
 import hid
 import struct

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -436,7 +436,7 @@ def enumerate(password=''):
         with handle_errors(common_err_msgs["enumerate"], d_data):
             client = TrezorClient(d_data['path'], password)
             client.client.init_device()
-            if not 'trezor' in client.client.features.vendor:
+            if 'trezor' not in client.client.features.vendor:
                 continue
 
             d_data['model'] = 'trezor_' + client.client.features.model.lower()

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -127,9 +127,9 @@ class TrezorClient(HardwareWalletClient):
             raise BadArgumentError(str(e))
         output = btc.get_public_node(self.client, expanded_path)
         if self.is_testnet:
-            return {'xpub':xpub_main_2_test(output.xpub)}
+            return {'xpub': xpub_main_2_test(output.xpub)}
         else:
-            return {'xpub':output.xpub}
+            return {'xpub': output.xpub}
 
     # Must return a hex string with the signed transaction
     # The tx must be in the psbt format
@@ -328,7 +328,7 @@ class TrezorClient(HardwareWalletClient):
 
             p += 1
 
-        return {'psbt':tx.serialize()}
+        return {'psbt': tx.serialize()}
 
     # Must return a base64 encoded string with the signed message
     # The message can be any string

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -1,26 +1,23 @@
 # Trezor interaction script
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import ActionCanceledError, BadArgumentError, DeviceAlreadyInitError, DeviceAlreadyUnlockedError, DeviceConnectionError, DEVICE_NOT_INITIALIZED, DeviceNotReadyError, HWWError, UnavailableActionError, UNKNOWN_ERROR, common_err_msgs, handle_errors
+from ..errors import ActionCanceledError, BadArgumentError, DeviceAlreadyInitError, DeviceAlreadyUnlockedError, DeviceConnectionError, DEVICE_NOT_INITIALIZED, DeviceNotReadyError, UnavailableActionError, common_err_msgs, handle_errors
 from .trezorlib.client import TrezorClient as Trezor
-from .trezorlib.debuglink import TrezorClientDebugLink, DebugUI
+from .trezorlib.debuglink import TrezorClientDebugLink
 from .trezorlib.exceptions import Cancelled
 from .trezorlib.transport import enumerate_devices, get_transport
 from .trezorlib.ui import echo, PassphraseUI, mnemonic_words, PIN_CURRENT, PIN_NEW, PIN_CONFIRM, PIN_MATRIX_DESCRIPTION, prompt
-from .trezorlib import protobuf, tools, btc, device
+from .trezorlib import tools, btc, device
 from .trezorlib import messages as proto
-from ..base58 import get_xpub_fingerprint, decode, to_address, xpub_main_2_test, get_xpub_fingerprint_hex
-from ..serializations import CTxOut, ser_uint256, uint256_from_str
+from ..base58 import get_xpub_fingerprint, to_address, xpub_main_2_test, get_xpub_fingerprint_hex
+from ..serializations import CTxOut, ser_uint256
 from .. import bech32
 from usb1 import USBErrorNoDevice
 from types import MethodType
 
 import base64
-import binascii
-import json
 import logging
 import sys
-import os
 
 py_enumerate = enumerate # Need to use the enumerate built-in but there's another function already named that
 

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -19,29 +19,29 @@ class HardwareWalletClient(object):
     # Retrieves the public key at the specified BIP 32 derivation path
     def get_pubkey_at_path(self, path):
         raise NotImplementedError('The HardwareWalletClient base class does not '
-            'implement this method')
+                                  'implement this method')
 
     # Must return a hex string with the signed transaction
     # The tx must be in the combined unsigned transaction format
     def sign_tx(self, tx):
         raise NotImplementedError('The HardwareWalletClient base class does not '
-            'implement this method')
+                                  'implement this method')
 
     # Must return a base64 encoded string with the signed message
     # The message can be any string. keypath is the bip 32 derivation path for the key to sign with
     def sign_message(self, message, keypath):
         raise NotImplementedError('The HardwareWalletClient base class does not '
-            'implement this method')
+                                  'implement this method')
 
     # Setup a new device
     def setup_device(self, label='', passphrase=''):
         raise NotImplementedError('The HardwareWalletClient base class does not '
-            'implement this method')
+                                  'implement this method')
 
     # Wipe this device
     def wipe_device(self):
         raise NotImplementedError('The HardwareWalletClient base class does not '
-            'implement this method')
+                                  'implement this method')
 
     # Restore device from mnemonic or xprv
     def restore_device(self, label=''):
@@ -54,7 +54,7 @@ class HardwareWalletClient(object):
     # Close the device
     def close(self):
         raise NotImplementedError('The HardwareWalletClient base class does not '
-            'implement this method')
+                                  'implement this method')
 
     # Prompt pin
     def prompt_pin(self):

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -726,9 +726,6 @@ class PSBT(object):
             raise PSBTSerializationError("invalid magic")
 
         # Read loop
-        separators = 0
-        psbt_input = PartiallySignedInput()
-        in_globals = True
         while True:
             # read the key
             try:

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -151,7 +151,7 @@ def ser_sig_der(r, s):
         if b == 0:
             si += 1
         else:
-            break;
+            break
     s = s[si:]
 
     # Make positive of neg
@@ -524,7 +524,7 @@ class PartiallySignedInput:
                     raise PSBTSerializationError("Duplicate key, input partial signature for pubkey already provided")
 
                 sig = deser_string(f)
-                self.partial_sigs[pubkey] = sig;
+                self.partial_sigs[pubkey] = sig
 
             elif key_type == 3:
                 if self.sighash > 0:
@@ -622,11 +622,14 @@ class PartiallySignedInput:
 
     def is_sane(self):
         # Cannot have both witness and non-witness utxos
-        if self.witness_utxo and self.non_witness_utxo: return False
+        if self.witness_utxo and self.non_witness_utxo:
+            return False
 
         # if we have witness script or scriptwitness, must have witness utxo
-        if len(self.witness_script) != 0 and not self.witness_utxo: return False
-        if not self.final_script_witness.is_null() and not self.witness_utxo: return False
+        if len(self.witness_script) != 0 and not self.witness_utxo:
+            return False
+        if not self.final_script_witness.is_null() and not self.witness_utxo:
+            return False
 
         return True
 
@@ -830,5 +833,6 @@ class PSBT(object):
 
     def is_sane(self):
         for input in self.inputs:
-            if not input.is_sane(): return False
+            if not input.is_sane():
+                return False
         return True

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -260,6 +260,7 @@ class CTxOut(object):
 
     def is_p2pkh(self):
         return len(self.scriptPubKey) == 25 and self.scriptPubKey[0] == 0x76 and self.scriptPubKey[1] == 0xa9 and self.scriptPubKey[2] == 0x14 and self.scriptPubKey[23] == 0x88 and self.scriptPubKey[24] == 0xac
+
     def is_p2pk(self):
         return (len(self.scriptPubKey) == 35 or len(self.scriptPubKey) == 67) and (self.scriptPubKey[0] == 0x21 or self.scriptPubKey[0] == 0x41) and self.scriptPubKey[-1] == 0xac
 

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -787,7 +787,7 @@ class PSBT(object):
             output = PartiallySignedOutput()
             output.deserialize(f)
             self.outputs.append(output)
-        
+
         if len(self.outputs) != len(self.tx.vout):
             raise PSBTSerializationError("Outputs provided does not match the number of outputs in transaction")
 

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -181,7 +181,7 @@ def ser_sig_der(r, s):
 
 def ser_sig_compact(r, s, recid):
     rec = struct.unpack("B", recid)[0]
-    prefix = struct.pack("B", 27 + 4 +rec)
+    prefix = struct.pack("B", 27 + 4 + rec)
 
     sig = b""
     sig += prefix
@@ -191,7 +191,7 @@ def ser_sig_compact(r, s, recid):
 
 # Objects that map to bitcoind objects, which can be serialized/deserialized
 
-MSG_WITNESS_FLAG = 1<<30
+MSG_WITNESS_FLAG = 1 << 30
 
 class COutPoint(object):
     def __init__(self, hash=0, n=0xffffffff):
@@ -702,7 +702,7 @@ class PartiallySignedOutput:
 
 class PSBT(object):
 
-    def __init__(self, tx = None):
+    def __init__(self, tx=None):
         if tx:
             self.tx = tx
         else:

--- a/hwilib/udevinstaller.py
+++ b/hwilib/udevinstaller.py
@@ -15,7 +15,7 @@ class UDevInstaller(object):
             udev_installer.add_user_plugdev_group()
         except CalledProcessError as e:
             if geteuid() != 0:
-                return {'error':'Need to be root.','code':NEED_TO_BE_ROOT}
+                return {'error': 'Need to be root.', 'code': NEED_TO_BE_ROOT}
             raise
         return {"success": True}
 

--- a/hwilib/udevinstaller.py
+++ b/hwilib/udevinstaller.py
@@ -13,7 +13,7 @@ class UDevInstaller(object):
             udev_installer.trigger()
             udev_installer.reload_rules()
             udev_installer.add_user_plugdev_group()
-        except CalledProcessError as e:
+        except CalledProcessError:
             if geteuid() != 0:
                 return {'error': 'Need to be root.', 'code': NEED_TO_BE_ROOT}
             raise

--- a/hwilib/udevinstaller.py
+++ b/hwilib/udevinstaller.py
@@ -1,8 +1,7 @@
-import sys
 from subprocess import check_call, CalledProcessError, DEVNULL
 from .errors import NEED_TO_BE_ROOT
 from shutil import copy
-from os import path, environ, listdir, getlogin, geteuid
+from os import path, listdir, getlogin, geteuid
 
 class UDevInstaller(object):
     @staticmethod

--- a/hwilib/udevinstaller.py
+++ b/hwilib/udevinstaller.py
@@ -33,7 +33,7 @@ class UDevInstaller(object):
 
     def reload_rules(self):
         self._execute(self._udevadm, 'control', '--reload-rules')
-    
+
     def add_user_plugdev_group(self):
         self._create_group('plugdev')
         self._add_user_to_group(getlogin(), 'plugdev')
@@ -54,6 +54,6 @@ class UDevInstaller(object):
             if '.rules' in rules_file_name:
                 rules_file_path = _resource_path(path.join(src_dir_path, rules_file_name))
                 copy(rules_file_path, location)
-    
+
 def _resource_path(relative_path):
     return path.join(path.dirname(__file__), relative_path)

--- a/poetry.lock
+++ b/poetry.lock
@@ -27,6 +27,28 @@ version = "0.13.2"
 
 [[package]]
 category = "dev"
+description = "Discover and load entry points from installed packages."
+name = "entrypoints"
+optional = false
+python-versions = ">=2.7"
+version = "0.3"
+
+[[package]]
+category = "dev"
+description = "the modular source code checker: pep8, pyflakes and co"
+name = "flake8"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "3.7.8"
+
+[package.dependencies]
+entrypoints = ">=0.3.0,<0.4.0"
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.5.0,<2.6.0"
+pyflakes = ">=2.1.0,<2.2.0"
+
+[[package]]
+category = "dev"
 description = "Clean single-source support for Python 3 and 2"
 marker = "sys_platform == \"win32\""
 name = "future"
@@ -64,6 +86,14 @@ version = "1.11"
 
 [package.dependencies]
 altgraph = ">=0.15"
+
+[[package]]
+category = "dev"
+description = "McCabe checker, plugin for flake8"
+name = "mccabe"
+optional = false
+python-versions = "*"
+version = "0.6.1"
 
 [[package]]
 category = "main"
@@ -114,6 +144,14 @@ version = "2.5.0"
 
 [[package]]
 category = "dev"
+description = "passive checker of Python programs"
+name = "pyflakes"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.1.1"
+
+[[package]]
+category = "dev"
 description = "PyInstaller bundles a Python application and all its dependencies into a single package."
 name = "pyinstaller"
 optional = false
@@ -153,22 +191,26 @@ version = "3.7.4"
 typing = ">=3.7.4"
 
 [metadata]
-content-hash = "f26f6b3c5084a3c24872b4cb91d0974a07360b5d2bb7223decb93045183aafc8"
+content-hash = "3998e63fd8e073e6a02c873da2f78130ae57935af702be30b2d1a8efd20475f9"
 python-versions = ">=3.5.6"
 
 [metadata.hashes]
 altgraph = ["d6814989f242b2b43025cba7161fc1b8fb487a62cd49c49245d6fd01c18ac997", "ddf5320017147ba7b810198e0b6619bd7b5563aa034da388cea8546b877f9b0c"]
 autopep8 = ["4d8eec30cc81bc5617dbf1218201d770dc35629363547f17577c61683ccfb3ee"]
 ecdsa = ["20c17e527e75acad8f402290e158a6ac178b91b881f941fc6ea305bfdfb9657c", "5c034ffa23413ac923541ceb3ac14ec15a0d2530690413bff58c12b80e56d884"]
+entrypoints = ["589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19", "c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"]
+flake8 = ["19241c1cbc971b9962473e4438a2ca19749a7dd002dd1a946eaba171b4114548", "8e9dfa3cecb2400b3738a42c54c3043e821682b9c840b0448c0503f781130696"]
 future = ["67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"]
 hidapi = ["1ac170f4d601c340f2cd52fd06e85c5e77bad7ceac811a7bb54b529f7dc28c24", "6424ad75da0021ce8c1bcd78056a04adada303eff3c561f8d132b85d0a914cb3", "8d3be666f464347022e2b47caf9132287885d9eacc7895314fc8fefcb4e42946", "92878bad7324dee619b7832fbfc60b5360d378aa7c5addbfef0a410d8fd342c7", "b4b1f6aff0192e9be153fe07c1b7576cb7a1ff52e78e3f76d867be95301a8e87", "bf03f06f586ce7d8aeb697a94b7dba12dc9271aae92d7a8d4486360ff711a660", "c76de162937326fcd57aa399f94939ce726242323e65c15c67e183da1f6c26f7", "d4ad1e46aef98783a9e6274d523b8b1e766acfc3d72828cd44a337564d984cfa", "d4b5787a04613503357606bb10e59c3e2c1114fa00ee328b838dd257f41cbd7b", "e0be1aa6566979266a8fc845ab0e18613f4918cf2c977fe67050f5dc7e2a9a97", "edfb16b16a298717cf05b8c8a9ad1828b6ff3de5e93048ceccd74e6ae4ff0922"]
 libusb1 = ["adf64a4f3f5c94643a1286f8153bcf4bc787c348b38934aacd7fe17fbeebc571"]
 macholib = ["ac02d29898cf66f27510d8f39e9112ae00590adb4a48ec57b25028d6962b1ae1", "c4180ffc6f909bf8db6cd81cff4b6f601d575568f4d5dee148c830e9851eb9db"]
+mccabe = ["ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42", "dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"]
 mnemonic = ["02a7306a792370f4a0c106c2cf1ce5a0c84b9dbd7e71c6792fdb9ad88a727f1d"]
 pbkdf2 = ["ac6397369f128212c43064a2b4878038dab78dab41875364554aaf2a684e6979"]
 pefile = ["a5d6e8305c6b210849b47a6174ddf9c452b2888340b8177874b862ba6c207645"]
 pyaes = ["02c1b1405c38d3c370b085fb952dd8bea3fadcee6411ad99f312cc129c536d8f"]
 pycodestyle = ["95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56", "e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"]
+pyflakes = ["17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0", "d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"]
 pyinstaller = ["ee7504022d1332a3324250faf2135ea56ac71fdb6309cff8cd235de26b1d0a96"]
 pywin32-ctypes = ["24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942", "9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"]
 typing = ["91dfe6f3f706ee8cc32d38edbbf304e9b7583fb37108fef38229617f8b3eba23", "c8cabb5ab8945cd2f54917be357d134db9cc1eb039e59d1606dc1e60cb1d9d36", "f38d83c5a7a7086543a0f649564d661859c5146a85775ab90c0d2f93ffaa9714"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,17 @@ python-versions = "*"
 version = "0.16.1"
 
 [[package]]
+category = "dev"
+description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
+name = "autopep8"
+optional = false
+python-versions = "*"
+version = "1.4.4"
+
+[package.dependencies]
+pycodestyle = ">=2.4.0"
+
+[[package]]
 category = "main"
 description = "ECDSA cryptographic signature library (pure python)"
 name = "ecdsa"
@@ -95,6 +106,14 @@ version = "1.6.1"
 
 [[package]]
 category = "dev"
+description = "Python style guide checker"
+name = "pycodestyle"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.5.0"
+
+[[package]]
+category = "dev"
 description = "PyInstaller bundles a Python application and all its dependencies into a single package."
 name = "pyinstaller"
 optional = false
@@ -134,11 +153,12 @@ version = "3.7.4"
 typing = ">=3.7.4"
 
 [metadata]
-content-hash = "01d47703b3c72339de7a3ea7e0bb684111dd852e722da2cd09f7e41625f34d20"
+content-hash = "f26f6b3c5084a3c24872b4cb91d0974a07360b5d2bb7223decb93045183aafc8"
 python-versions = ">=3.5.6"
 
 [metadata.hashes]
 altgraph = ["d6814989f242b2b43025cba7161fc1b8fb487a62cd49c49245d6fd01c18ac997", "ddf5320017147ba7b810198e0b6619bd7b5563aa034da388cea8546b877f9b0c"]
+autopep8 = ["4d8eec30cc81bc5617dbf1218201d770dc35629363547f17577c61683ccfb3ee"]
 ecdsa = ["20c17e527e75acad8f402290e158a6ac178b91b881f941fc6ea305bfdfb9657c", "5c034ffa23413ac923541ceb3ac14ec15a0d2530690413bff58c12b80e56d884"]
 future = ["67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"]
 hidapi = ["1ac170f4d601c340f2cd52fd06e85c5e77bad7ceac811a7bb54b529f7dc28c24", "6424ad75da0021ce8c1bcd78056a04adada303eff3c561f8d132b85d0a914cb3", "8d3be666f464347022e2b47caf9132287885d9eacc7895314fc8fefcb4e42946", "92878bad7324dee619b7832fbfc60b5360d378aa7c5addbfef0a410d8fd342c7", "b4b1f6aff0192e9be153fe07c1b7576cb7a1ff52e78e3f76d867be95301a8e87", "bf03f06f586ce7d8aeb697a94b7dba12dc9271aae92d7a8d4486360ff711a660", "c76de162937326fcd57aa399f94939ce726242323e65c15c67e183da1f6c26f7", "d4ad1e46aef98783a9e6274d523b8b1e766acfc3d72828cd44a337564d984cfa", "d4b5787a04613503357606bb10e59c3e2c1114fa00ee328b838dd257f41cbd7b", "e0be1aa6566979266a8fc845ab0e18613f4918cf2c977fe67050f5dc7e2a9a97", "edfb16b16a298717cf05b8c8a9ad1828b6ff3de5e93048ceccd74e6ae4ff0922"]
@@ -148,6 +168,7 @@ mnemonic = ["02a7306a792370f4a0c106c2cf1ce5a0c84b9dbd7e71c6792fdb9ad88a727f1d"]
 pbkdf2 = ["ac6397369f128212c43064a2b4878038dab78dab41875364554aaf2a684e6979"]
 pefile = ["a5d6e8305c6b210849b47a6174ddf9c452b2888340b8177874b862ba6c207645"]
 pyaes = ["02c1b1405c38d3c370b085fb952dd8bea3fadcee6411ad99f312cc129c536d8f"]
+pycodestyle = ["95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56", "e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"]
 pyinstaller = ["ee7504022d1332a3324250faf2135ea56ac71fdb6309cff8cd235de26b1d0a96"]
 pywin32-ctypes = ["24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942", "9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"]
 typing = ["91dfe6f3f706ee8cc32d38edbbf304e9b7583fb37108fef38229617f8b3eba23", "c8cabb5ab8945cd2f54917be357d134db9cc1eb039e59d1606dc1e60cb1d9d36", "f38d83c5a7a7086543a0f649564d661859c5146a85775ab90c0d2f93ffaa9714"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ pywin32-ctypes = {version = "^0.2.0",platform = "win32"}
 pefile = {version = "^2019.4",platform = "win32"}
 macholib = {version = "^1.11",platform = "darwin"}
 autopep8 = "^1.4"
+flake8 = "^3.7"
 
 [tool.poetry.scripts]
 hwi = 'hwilib.cli:main'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ pyinstaller = "^3.4"
 pywin32-ctypes = {version = "^0.2.0",platform = "win32"}
 pefile = {version = "^2019.4",platform = "win32"}
 macholib = {version = "^1.11",platform = "darwin"}
+autopep8 = "^1.4"
 
 [tool.poetry.scripts]
 hwi = 'hwilib.cli:main'

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python3
 
 import argparse
-import subprocess
 import sys
 import unittest
 

--- a/test/test_bech32.py
+++ b/test/test_bech32.py
@@ -93,7 +93,7 @@ class TestSegwitAddress(unittest.TestCase):
             hrp, _ = segwit_addr.bech32_decode(test)
             self.assertIsNotNone(hrp)
             pos = test.rfind('1')
-            test = test[:pos+1] + chr(ord(test[pos + 1]) ^ 1) + test[pos+2:]
+            test = test[:pos + 1] + chr(ord(test[pos + 1]) ^ 1) + test[pos + 2:]
             hrp, _ = segwit_addr.bech32_decode(test)
             self.assertIsNone(hrp)
 

--- a/test/test_coldcard.py
+++ b/test/test_coldcard.py
@@ -27,6 +27,7 @@ def coldcard_test_suite(simulator, rpc, userpass, interface):
             break
         time.sleep(0.5)
     # Cleanup
+
     def cleanup_simulator():
         dev = ColdcardDevice(sn='/tmp/ckcc-simulator.sock')
         resp = dev.send_recv(CCProtocolPacker.logout())

--- a/test/test_coldcard.py
+++ b/test/test_coldcard.py
@@ -14,7 +14,7 @@ from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestD
 
 def coldcard_test_suite(simulator, rpc, userpass, interface):
     # Start the Coldcard simulator
-    simulator_proc = subprocess.Popen(['python3', os.path.basename(simulator)], cwd=os.path.dirname(simulator), stdout=subprocess.DEVNULL)
+    subprocess.Popen(['python3', os.path.basename(simulator)], cwd=os.path.dirname(simulator), stdout=subprocess.DEVNULL)
     # Wait for simulator to be up
     while True:
         enum_res = process_commands(['enumerate'])
@@ -30,7 +30,7 @@ def coldcard_test_suite(simulator, rpc, userpass, interface):
 
     def cleanup_simulator():
         dev = ColdcardDevice(sn='/tmp/ckcc-simulator.sock')
-        resp = dev.send_recv(CCProtocolPacker.logout())
+        dev.send_recv(CCProtocolPacker.logout())
     atexit.register(cleanup_simulator)
 
     # Coldcard specific management command tests

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -52,7 +52,7 @@ def start_bitcoind(bitcoind_path):
     return (rpc, userpass)
 
 class DeviceTestCase(unittest.TestCase):
-    def __init__(self, rpc, rpc_userpass, type, full_type, path, fingerprint, master_xpub, password = '', emulator=None, interface='library', methodName='runTest'):
+    def __init__(self, rpc, rpc_userpass, type, full_type, path, fingerprint, master_xpub, password='', emulator=None, interface='library', methodName='runTest'):
         super(DeviceTestCase, self).__init__(methodName)
         self.rpc = rpc
         self.rpc_userpass = rpc_userpass
@@ -72,7 +72,7 @@ class DeviceTestCase(unittest.TestCase):
         self.interface = interface
 
     @staticmethod
-    def parameterize(testclass, rpc, rpc_userpass, type, full_type, path, fingerprint, master_xpub, password = '', interface='library', emulator=None):
+    def parameterize(testclass, rpc, rpc_userpass, type, full_type, path, fingerprint, master_xpub, password='', interface='library', emulator=None):
         testloader = unittest.TestLoader()
         testnames = testloader.getTestCaseNames(testclass)
         suite = unittest.TestSuite()
@@ -305,9 +305,9 @@ class TestSignTx(DeviceTestCase):
             # Single input PSBTs will be fully signed by first signer
             for psbt_input in first_psbt.inputs[1:]:
                 for pubkey, path in psbt_input.hd_keypaths.items():
-                    psbt_input.hd_keypaths[pubkey] = (0,)+path[1:]
+                    psbt_input.hd_keypaths[pubkey] = (0,) + path[1:]
             for pubkey, path in second_psbt.inputs[0].hd_keypaths.items():
-                second_psbt.inputs[0].hd_keypaths[pubkey] = (0,)+path[1:]
+                second_psbt.inputs[0].hd_keypaths[pubkey] = (0,) + path[1:]
 
             single_input = len(first_psbt.inputs) == 1
 
@@ -360,14 +360,14 @@ class TestSignTx(DeviceTestCase):
                    pkh_info['desc'][4:-10]]
 
         # Get the descriptors with their checksums
-        sh_multi_desc = self.wrpc.getdescriptorinfo('sh(multi(2,'+pubkeys[0]+','+pubkeys[1]+','+pubkeys[2]+'))')['descriptor']
-        sh_wsh_multi_desc = self.wrpc.getdescriptorinfo('sh(wsh(multi(2,'+pubkeys[0]+','+pubkeys[1]+','+pubkeys[2]+')))')['descriptor']
-        wsh_multi_desc = self.wrpc.getdescriptorinfo('wsh(multi(2,'+pubkeys[2]+','+pubkeys[1]+','+pubkeys[0]+'))')['descriptor']
+        sh_multi_desc = self.wrpc.getdescriptorinfo('sh(multi(2,' + pubkeys[0] + ',' + pubkeys[1] + ',' + pubkeys[2] + '))')['descriptor']
+        sh_wsh_multi_desc = self.wrpc.getdescriptorinfo('sh(wsh(multi(2,' + pubkeys[0] + ',' + pubkeys[1] + ',' + pubkeys[2] + ')))')['descriptor']
+        wsh_multi_desc = self.wrpc.getdescriptorinfo('wsh(multi(2,' + pubkeys[2] + ',' + pubkeys[1] + ',' + pubkeys[0] + '))')['descriptor']
 
-        sh_multi_import = {'desc': sh_multi_desc, "timestamp":"now", "label":"shmulti"}
-        sh_wsh_multi_import = {'desc': sh_wsh_multi_desc, "timestamp":"now", "label":"shwshmulti"}
+        sh_multi_import = {'desc': sh_multi_desc, "timestamp": "now", "label": "shmulti"}
+        sh_wsh_multi_import = {'desc': sh_wsh_multi_desc, "timestamp": "now", "label": "shwshmulti"}
         # re-order pubkeys to allow import without "already have private keys" error
-        wsh_multi_import = {'desc': wsh_multi_desc, "timestamp":"now", "label":"wshmulti"}
+        wsh_multi_import = {'desc': wsh_multi_desc, "timestamp": "now", "label": "wshmulti"}
         multi_result = self.wrpc.importmulti([sh_multi_import, sh_wsh_multi_import, wsh_multi_import])
         self.assertTrue(multi_result[0]['success'])
         self.assertTrue(multi_result[1]['success'])
@@ -403,9 +403,9 @@ class TestSignTx(DeviceTestCase):
         # Spend different amounts, requiring 1 to 3 inputs
         for i in range(number_inputs):
             # Create a psbt spending the above
-            if i == number_inputs-1:
-                self.assertTrue((i+1)*in_amt == self.wrpc.getbalance("*", 0, True))
-            psbt = self.wrpc.walletcreatefundedpsbt([], [{self.wpk_rpc.getnewaddress('', 'legacy'):(i+1)*out_amt}, {self.wpk_rpc.getnewaddress('', 'p2sh-segwit'):(i+1)*out_amt}, {self.wpk_rpc.getnewaddress('', 'bech32'):(i+1)*out_amt}], 0, {'includeWatching': True, 'subtractFeeFromOutputs': [0, 1, 2]}, True)
+            if i == number_inputs - 1:
+                self.assertTrue((i + 1) * in_amt == self.wrpc.getbalance("*", 0, True))
+            psbt = self.wrpc.walletcreatefundedpsbt([], [{self.wpk_rpc.getnewaddress('', 'legacy'): (i + 1) * out_amt}, {self.wpk_rpc.getnewaddress('', 'p2sh-segwit'): (i + 1) * out_amt}, {self.wpk_rpc.getnewaddress('', 'bech32'): (i + 1) * out_amt}], 0, {'includeWatching': True, 'subtractFeeFromOutputs': [0, 1, 2]}, True)
 
             # Sign with unknown inputs in two steps
             self._generate_and_finalize(True, psbt)

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -19,12 +19,14 @@ from hwilib.serializations import PSBT
 class DeviceEmulator():
     def start(self):
         pass
+
     def stop(self):
         pass
 
 def start_bitcoind(bitcoind_path):
     datadir = tempfile.mkdtemp()
     bitcoind_proc = subprocess.Popen([bitcoind_path, '-regtest', '-datadir=' + datadir, '-noprinttoconsole'])
+
     def cleanup_bitcoind():
         bitcoind_proc.kill()
         shutil.rmtree(datadir)
@@ -299,7 +301,6 @@ class TestSignTx(DeviceTestCase):
             first_psbt.deserialize(psbt['psbt'])
             second_psbt = PSBT()
             second_psbt.deserialize(psbt['psbt'])
-
 
             # Blank master fingerprint to make hww fail to sign
             # Single input PSBTs will be fully signed by first signer

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -307,7 +307,7 @@ class TestSignTx(DeviceTestCase):
                 for pubkey, path in psbt_input.hd_keypaths.items():
                     psbt_input.hd_keypaths[pubkey] = (0,)+path[1:]
             for pubkey, path in second_psbt.inputs[0].hd_keypaths.items():
-                    second_psbt.inputs[0].hd_keypaths[pubkey] = (0,)+path[1:]
+                second_psbt.inputs[0].hd_keypaths[pubkey] = (0,)+path[1:]
 
             single_input = len(first_psbt.inputs) == 1
 
@@ -356,8 +356,8 @@ class TestSignTx(DeviceTestCase):
         # Get origin info/key pair so wallet doesn't forget how to
         # sign with keys post-import
         pubkeys = [sh_wpkh_info['desc'][8:-11],\
-                wpkh_info['desc'][5:-10],\
-                pkh_info['desc'][4:-10]]
+                   wpkh_info['desc'][5:-10],\
+                   pkh_info['desc'][4:-10]]
 
         # Get the descriptors with their checksums
         sh_multi_desc = self.wrpc.getdescriptorinfo('sh(multi(2,'+pubkeys[0]+','+pubkeys[1]+','+pubkeys[2]+'))')['descriptor']

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -356,8 +356,8 @@ class TestSignTx(DeviceTestCase):
 
         # Get origin info/key pair so wallet doesn't forget how to
         # sign with keys post-import
-        pubkeys = [sh_wpkh_info['desc'][8:-11],\
-                   wpkh_info['desc'][5:-10],\
+        pubkeys = [sh_wpkh_info['desc'][8:-11],
+                   wpkh_info['desc'][5:-10],
                    pkh_info['desc'][4:-10]]
 
         # Get the descriptors with their checksums

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -45,7 +45,7 @@ def start_bitcoind(bitcoind_path):
         try:
             rpc.getblockchaininfo()
             ready = True
-        except JSONRPCException as e:
+        except JSONRPCException:
             time.sleep(0.5)
             pass
 
@@ -451,7 +451,7 @@ class TestSignTx(DeviceTestCase):
             else:
                 self.assertNotIn('code', result)
                 self.assertNotIn('error', result)
-        except OSError as e:
+        except OSError:
             if self.interface == 'cli':
                 pass
 

--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -33,7 +33,7 @@ def digitalbitbox_test_suite(simulator, rpc, userpass, interface):
     atexit.register(cleanup_simulator)
 
     # Set password and load from backup
-    send_encrypt(json.dumps({"seed":{"source":"backup","filename":"test_backup.pdf","key":"key"}}), '0000', dev)
+    send_encrypt(json.dumps({"seed": {"source": "backup", "filename": "test_backup.pdf", "key": "key"}}), '0000', dev)
 
     # params
     type = 'digitalbitbox'
@@ -97,7 +97,7 @@ def digitalbitbox_test_suite(simulator, rpc, userpass, interface):
             result = self.do_command(self.dev_args + ['wipe'])
             self.assertTrue(result['success'])
             send_plain(b'{"password":"0000"}', dev)
-            send_encrypt(json.dumps({"seed":{"source":"backup","filename":"test_backup.pdf","key":"key"}}), '0000', dev)
+            send_encrypt(json.dumps({"seed": {"source": "backup", "filename": "test_backup.pdf", "key": "key"}}), '0000', dev)
 
             # Make sure device is init, setup should fail
             result = self.do_command(self.dev_args + ['-i', 'setup', '--label', 'setup_test', '--backup_passphrase', 'testpass'])

--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -27,6 +27,7 @@ def digitalbitbox_test_suite(simulator, rpc, userpass, interface):
             pass
         time.sleep(0.5)
     # Cleanup
+
     def cleanup_simulator():
         simulator_proc.kill()
         simulator_proc.wait()

--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -10,7 +10,6 @@ import unittest
 
 from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestGetKeypool, TestGetDescriptors, TestSignTx, TestSignMessage
 
-from hwilib.cli import process_commands
 from hwilib.devices.digitalbitbox import BitboxSimulator, send_plain, send_encrypt
 
 def digitalbitbox_test_suite(simulator, rpc, userpass, interface):

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python3
 
 import argparse
-import atexit
 import json
 import os
 import shlex
@@ -11,7 +10,6 @@ import sys
 import time
 import unittest
 
-from authproxy import AuthServiceProxy, JSONRPCException
 from hwilib.devices.trezorlib.transport import enumerate_devices
 from hwilib.devices.trezorlib.transport.udp import UdpTransport
 from hwilib.devices.trezorlib.debuglink import TrezorClientDebugLink, load_device_by_mnemonic, load_device_by_xprv

--- a/test/test_ledger.py
+++ b/test/test_ledger.py
@@ -1,15 +1,8 @@
 #! /usr/bin/env python3
 
 import argparse
-import atexit
-import json
-import os
-import socket
-import subprocess
-import time
 import unittest
 
-from authproxy import AuthServiceProxy, JSONRPCException
 from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestDisplayAddress, TestGetKeypool, TestGetDescriptors, TestSignMessage, TestSignTx
 
 from hwilib.cli import process_commands

--- a/test/test_psbt.py
+++ b/test/test_psbt.py
@@ -16,7 +16,7 @@ class TestPSBT(unittest.TestCase):
     def test_invalid_psbt(self):
         for invalid in self.data['invalid']:
             with self.subTest(invalid=invalid):
-                with self.assertRaises(PSBTSerializationError) as cm:
+                with self.assertRaises(PSBTSerializationError):
                     psbt = PSBT()
                     psbt.deserialize(invalid)
 

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python3
 
 import argparse
-import atexit
 import json
 import os
 import shlex
@@ -12,7 +11,6 @@ import sys
 import time
 import unittest
 
-from authproxy import AuthServiceProxy, JSONRPCException
 from hwilib.devices.trezorlib.transport import enumerate_devices
 from hwilib.devices.trezorlib.transport.udp import UdpTransport
 from hwilib.devices.trezorlib.debuglink import TrezorClientDebugLink, load_device_by_mnemonic, load_device_by_xprv

--- a/test/test_udevrules.py
+++ b/test/test_udevrules.py
@@ -23,7 +23,7 @@ class TestUdevRulesInstaller(unittest.TestCase):
         removedirs(self.INSTALLATION_FOLDER)
 
     def test_rules_file_are_copied(self):
-        result = process_commands( ['installudevrules', '--location', self.INSTALLATION_FOLDER])
+        result = process_commands(['installudevrules', '--location', self.INSTALLATION_FOLDER])
         self.assertIn('error', result)
         self.assertIn('code', result)
         self.assertEqual(result['error'], 'Need to be root.')

--- a/test/test_udevrules.py
+++ b/test/test_udevrules.py
@@ -3,7 +3,7 @@
 import unittest
 import json
 import filecmp
-from os import makedirs, remove, removedirs, walk, path 
+from os import makedirs, remove, removedirs, walk, path
 from hwilib.cli import process_commands
 
 class TestUdevRulesInstaller(unittest.TestCase):

--- a/test/test_udevrules.py
+++ b/test/test_udevrules.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python3
 
 import unittest
-import json
 import filecmp
 from os import makedirs, remove, removedirs, walk, path
 from hwilib.cli import process_commands


### PR DESCRIPTION
Adds support for using the flake8 linter and a travis job that runs it to check for code style and other errors. Also adds a script for using the autopep8 formatter and applies the suggested changes. Both autopep8 and flake8 are added as developer dependencies in pyproject.toml.

Most of the fixes can be done by running an autopep8 command and are indicated as such in the commit message using the scripted-diff format even though scripted diffs aren't actually being checked by travis.

Closes #221
Closes #192 