### PR TITLE
Print out hash of message being signed for verification

### DIFF
--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -12,7 +12,7 @@ import hid
 import struct
 from .. import base58
 from ..base58 import get_xpub_fingerprint_hex
-from ..serializations import hash256, hash160, CTransaction
+from ..serializations import hash256, hash160, CTransaction, sha256
 import logging
 import re
 
@@ -283,6 +283,7 @@ class LedgerClient(HardwareWalletClient):
             raise BadArgumentError("Invalid keypath")
         message = bytearray(message, 'utf-8')
         keypath = keypath[2:]
+        print("Message hash displayed on screen: "+sha256(message).hex())
         # First display on screen what address you're signing for
         self.app.getWalletPublicKey(keypath, True)
         self.app.signMessagePrepare(keypath, message)


### PR DESCRIPTION
Really this is only useful for documenting exactly how the sighash is computed(for verification of what you're signing on a known good host?). I'm actually leaning concept NACK on this, but wanted to open this up to see if I'm alone on this.