### PR TITLE
Minimal install phase for linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ jobs:
     include:
         -   name: lint
             stage: lint
+            install:
+                - pip install flake8
             script: flake8
         -   name: Run non-device tests only
             stage: test


### PR DESCRIPTION
The install phase installs a bunch of stuff and builds simulators, emulators, and bitcoind, all of which we don't need for the linter. Instead, just have a minimal install phase of installing flake8.