### PR TITLE
Bump minimum python version to 3.6

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -191,8 +191,8 @@ version = "3.7.4"
 typing = ">=3.7.4"
 
 [metadata]
-content-hash = "3998e63fd8e073e6a02c873da2f78130ae57935af702be30b2d1a8efd20475f9"
-python-versions = ">=3.5.6"
+content-hash = "efb94ab72596b3a8e2c057d24c9ff91efcbe40bfed6b7ca1ed3de909745a72c6"
+python-versions = "^3.6"
 
 [metadata.hashes]
 altgraph = ["d6814989f242b2b43025cba7161fc1b8fb487a62cd49c49245d6fd01c18ac997", "ddf5320017147ba7b810198e0b6619bd7b5563aa034da388cea8546b877f9b0c"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.5.6"
+python = "^3.6"
 hidapi = "^0.7.99"
 ecdsa = "^0.13.0"
 pyaes = "^1.6"

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup_kwargs = {
     'py_modules': modules,
     'install_requires': install_requires,
     'entry_points': entry_points,
-    'python_requires': '>=3.5.6',
+    'python_requires': '>=3.6,<4.0',
 }
 
 


### PR DESCRIPTION
Needed for #203

This is not expected to impact existing projects using HWI. AFAIK there are only two projects that use HWI, [Wasabi Wallet](https://github.com/zkSNACKs/WalletWasabi) and [Junction](https://github.com/justinmoon/junction). Wasabi use the binary distribution so it is not effected. Junction also requires 3.6+.