### PR TITLE
Set the fallbackfee in bitcoind params

### DIFF
--- a/test/test_device.py
+++ b/test/test_device.py
@@ -25,7 +25,7 @@ class DeviceEmulator():
 
 def start_bitcoind(bitcoind_path):
     datadir = tempfile.mkdtemp()
-    bitcoind_proc = subprocess.Popen([bitcoind_path, '-regtest', '-datadir=' + datadir, '-noprinttoconsole'])
+    bitcoind_proc = subprocess.Popen([bitcoind_path, '-regtest', '-datadir=' + datadir, '-noprinttoconsole', '-fallbackfee=0.0002'])
 
     def cleanup_bitcoind():
         bitcoind_proc.kill()


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/pull/16524 Broke our tests by disabling `-fallbackfee`. This PR sets `-fallbackfee=20000` in our test bitcoind startup args.