### PR TITLE
Better cleanup of emulators after tests complete

### DIFF
--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -28,7 +28,7 @@ def digitalbitbox_test_suite(simulator, rpc, userpass, interface):
     # Cleanup
 
     def cleanup_simulator():
-        simulator_proc.kill()
+        simulator_proc.terminate()
         simulator_proc.wait()
     atexit.register(cleanup_simulator)
 

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -62,7 +62,7 @@ class KeepkeyEmulator(DeviceEmulator):
         return client
 
     def stop(self):
-        self.emulator_proc.kill()
+        self.emulator_proc.terminate()
         self.emulator_proc.wait()
 
         # Clean up emulator image

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -64,7 +64,7 @@ class TrezorEmulator(DeviceEmulator):
         return client
 
     def stop(self):
-        os.killpg(os.getpgid(self.emulator_proc.pid), signal.SIGINT)
+        os.killpg(os.getpgid(self.emulator_proc.pid), signal.SIGTERM)
         os.waitpid(self.emulator_proc.pid, 0)
 
         # Clean up emulator image


### PR DESCRIPTION
Use SIGTERM to stop emulators/simulators in tests instead of relying on them to shut themselves down via normal means. This is safe since they're data is ephemeral anyways.

This should fix the travis timeouts as it was waiting for emulators to shut down. By using SIGTERM, they should all terminate.