### PR TITLE
[WIP] Multisig address display

### DIFF
--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -23,7 +23,7 @@ def backup_device_handler(args, client):
     return backup_device(client, label=args.label, backup_passphrase=args.backup_passphrase)
 
 def displayaddress_handler(args, client):
-    return displayaddress(client, desc=args.desc, path=args.path, sh_wpkh=args.sh_wpkh, wpkh=args.wpkh)
+    return displayaddress(client, desc=args.desc, path=args.path, sh_wpkh=args.sh_wpkh, wpkh=args.wpkh, redeem_script=args.redeem_script)
 
 def enumerate_handler(args):
     return enumerate(password=args.password)
@@ -154,6 +154,7 @@ def process_commands(cli_args):
     group.add_argument('--path', help='The BIP 32 derivation path of the key embedded in the address, default follows BIP43 convention, e.g. m/84h/0h/0h/1/*')
     displayaddr_parser.add_argument('--sh_wpkh', action='store_true', help='Display the p2sh-nested segwit address associated with this key path')
     displayaddr_parser.add_argument('--wpkh', action='store_true', help='Display the bech32 version of the address associated with this key path')
+    displayaddr_parser.add_argument('--redeem_script', help='P2SH redeem script')
     displayaddr_parser.set_defaults(func=displayaddress_handler)
 
     setupdev_parser = subparsers.add_parser('setup', help='Setup a device. Passphrase protection uses the password given by -p. Requires interactive mode')

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -197,11 +197,11 @@ def getdescriptors(client, account=0):
 
     return result
 
-def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False):
+def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False, redeem_script=None):
     if path is not None:
         if sh_wpkh and wpkh:
             return {'error': 'Both `--wpkh` and `--sh_wpkh` can not be selected at the same time.', 'code': BAD_ARGUMENT}
-        return client.display_address(path, sh_wpkh, wpkh)
+        return client.display_address(path, sh_wpkh, wpkh, redeem_script=redeem_script)
     elif desc is not None:
         if client.fingerprint is None:
             master_xpub = client.get_pubkey_at_path('m/0h')['xpub']

--- a/hwilib/devices/ckcc/protocol.py
+++ b/hwilib/devices/ckcc/protocol.py
@@ -110,6 +110,28 @@ class CCProtocolPacker:
         return pack('<4sI', b'show', addr_fmt) + subpath.encode('ascii')
 
     @staticmethod
+    def show_p2sh_address(M, xfp_paths, witdeem_script, addr_fmt=AF_P2SH):
+        # For multisig (aka) P2SH cases, you will need all the info required to build
+        # the redeem script, and the Coldcard must already have been enrolled
+        # into the wallet.
+        # - redeem script must be provided
+        # - full subkey paths for each involved key is required in a list of lists of ints, where
+        #   is a XFP and derivation path, like in BIP174
+        # - the order of xfp_paths must match the order of pubkeys in
+        #   redeem script (after BIP67 sort). This allows for dup xfp values.
+        assert addr_fmt & AFC_SCRIPT
+        assert 30 <= len(witdeem_script) <= 520
+
+        rv = pack('<4sIBBH', b'p2sh', addr_fmt, M, len(xfp_paths), len(witdeem_script))
+        rv += witdeem_script
+
+        for xfp_path in xfp_paths:
+            ln = len(xfp_path)
+            rv += pack('<B%dI' % ln, ln, *xfp_path)
+
+        return rv
+
+    @staticmethod
     def sim_keypress(key):
         # Simulator ONLY: pretend a key is pressed
         return b'XKEY' + key

--- a/hwilib/devices/ckcc/utils.py
+++ b/hwilib/devices/ckcc/utils.py
@@ -85,4 +85,24 @@ def get_pubkey_string(b):
         y = p - y
     return x.to_bytes(32, byteorder="big") + y.to_bytes(32, byteorder="big")
 
+def str_to_int_path(xfp, path):
+    # convert text  m/34'/33/44 into BIP174 binary compat format
+    # - include hex for fingerprint (m) as first arg
+
+    rv = [struct.unpack('<I', binascii.a2b_hex(xfp))[0]]
+    for i in path.split('/'):
+        if i == 'm': continue
+        if not i: continue      # trailing or duplicated slashes
+
+        if i[-1] in "'phHP":
+            assert len(i) >= 2, i
+            here = int(i[:-1]) | 0x80000000
+        else:
+            here = int(i)
+            assert 0 <= here < 0x80000000, here
+
+        rv.append(here)
+
+    return rv
+
 # EOF

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -33,6 +33,11 @@ class HardwareWalletClient(object):
         raise NotImplementedError('The HardwareWalletClient base class does not '
                                   'implement this method')
 
+    # Display address on device display
+    def display_address(self, keypath, p2sh_p2wpkh, bech32):
+        raise NotImplementedError('The HardwareWalletClient base class does not '
+                                  'implement this method')
+
     # Setup a new device
     def setup_device(self, label='', passphrase=''):
         raise NotImplementedError('The HardwareWalletClient base class does not '

--- a/test/test_coldcard.py
+++ b/test/test_coldcard.py
@@ -13,7 +13,7 @@ from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestD
 
 def coldcard_test_suite(simulator, rpc, userpass, interface):
     # Start the Coldcard simulator
-    coldcard_proc = subprocess.Popen(['python3', os.path.basename(simulator)], cwd=os.path.dirname(simulator), stdout=subprocess.DEVNULL, preexec_fn=os.setsid)
+    coldcard_proc = subprocess.Popen(['python3', os.path.basename(simulator), '-m'], cwd=os.path.dirname(simulator), stdout=subprocess.DEVNULL, preexec_fn=os.setsid)
     # Wait for simulator to be up
     while True:
         try:


### PR DESCRIPTION
This PR modifies the existing `displayaddress` command to also display multisig addresses for the 2 devices that I know support it -- Trezor and ColdCard. I don't own a KeepKey so haven't tried that, yet. To my knolwledge, Ledger and BitBox firmwares don't support this feature.

Looking for feedback on the API:
- The ColdCard demands a list of derivation paths for every signer in a redeem script. To support this, I allow `path` to be a comma-separated list of paths -- existing behavior is preserved and only in the ColdCard multisig case is it treated as a comma-separated list. But this might confuse people ...
- I left the `--sh_wpkh` and `--wpkh` flags, which would clearly need to be renamed if they can also represent P2WSH.
-  Added a `redeem_script` parameter to `displayaddress` command and to the `display_address` methods of `TrezorClient` and `ColdcardClient`. I use the presence of this variable to indicate whether we're dealing with a multisig address or not.
- I did not attempt to modify the `desc` parameter to support multisig since it feels a little odd for HWI to be generating redeem scripts (what the HWW libraries need to display a multisig address). Should I add this?

Test coverage is decent:
- 2/2 Native segwit, wrapped segwit, and legacy addresses are checked for Trezor
- 2/4 legacy address checked for ColdCard. As described in [this document](https://github.com/Coldcard/firmware/blob/061c3e5f79cc83f1a1e5af5ca1315d7814bff5f8/unix/README.md#other-startup-flags), the ColdCard simulator has `-m`,  `--wrap` or `--p2wsh` flags to add legacy, wrapped, or native segwit multisig wallets on the ColdCard. The problem, however, is that each wallet shares the same set of bip32 fingerprints -- so you can only have one of these wallets active at a time (cc @peter-conalgo is this accurate?). This is why I'm only testing legacy addresses and not wrapped / native segwit. Perhaps my unittest could restart the simulator once for each flag? Another option would be for HWI unittests to generate and upload our own multisig wallets to the simulator.