### PR TITLE
Replace Ledger tests with automated tests and run them on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 os: linux
-dist: xenial
+dist: bionic
 python:
     - '3.6.8'
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,11 @@ addons:
             - protobuf-compiler
             - cython3
             - ccache
+            - qemu-user-static
+            - gcc-arm-linux-gnueabihf
+            - libc6-dev-armhf-cross
 install:
-    - pip install pipenv pysdl2 protobuf poetry
+    - pip install pipenv pysdl2 protobuf poetry pyqt5 construct mnemonic pyelftools
     # From trezor-mcu to get the correct protobuf version
     - curl -LO "https://github.com/google/protobuf/releases/download/v3.4.0/protoc-3.4.0-linux-x86_64.zip"
     - unzip "protoc-3.4.0-linux-x86_64.zip" -d protoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,11 @@ addons:
             - qemu-user-static
             - gcc-arm-linux-gnueabihf
             - libc6-dev-armhf-cross
+before_install:
+  - |
+    wget -qO- "https://github.com/crazy-max/travis-wait-enhanced/releases/download/v1.0.0/travis-wait-enhanced_1.0.0_linux_x86_64.tar.gz" | tar -zxvf - travis-wait-enhanced
+    mv travis-wait-enhanced /home/travis/bin/
+    travis-wait-enhanced --version
 install:
     - pip install pipenv pysdl2 protobuf poetry pyqt5 construct mnemonic pyelftools
     # From trezor-mcu to get the correct protobuf version
@@ -67,13 +72,13 @@ jobs:
             script: cd test; poetry run ./run_tests.py
         -   name: With process_commands interface
             stage: test
-            script: cd test; poetry run ./run_tests.py --all --interface=library
+            script: cd test; travis-wait-enhanced --timeout=40m -- poetry run ./run_tests.py --all --interface=library
         -   name: With command line interface
             stage: test
-            script: cd test; poetry run ./run_tests.py --all --interface=cli
+            script: cd test; travis-wait-enhanced --timeout=40m -- poetry run ./run_tests.py --all --interface=cli
         -   name: With stdin interface
             stage: test
-            script: cd test; poetry run ./run_tests.py --all --interface=stdin
+            script: cd test; travis-wait-enhanced --timeout=40m -- poetry run ./run_tests.py --all --interface=stdin
         -   name: With wheel command line interface
             stage: test
             services: docker
@@ -83,7 +88,7 @@ jobs:
                 - docker run -it --name hwi-builder -v $PWD:/opt/hwi --rm  --workdir /opt/hwi hwi-builder /bin/bash -c "contrib/build_dist.sh"
                 - sudo chown -R `whoami`:`whoami` dist/
                 - pip install dist/*.whl
-                - cd test; ./run_tests.py --all --interface=cli
+                - cd test; travis-wait-enhanced --timeout=40m -- poetry run ./run_tests.py --all --interface=cli
         -   name: With sdist command line interface
             stage: test
             services: docker
@@ -93,7 +98,7 @@ jobs:
                 - docker run -it --name hwi-builder -v $PWD:/opt/hwi --rm  --workdir /opt/hwi hwi-builder /bin/bash -c "contrib/build_dist.sh"
                 - sudo chown -R `whoami`:`whoami` dist/
                 - pip install dist/*.tar.gz
-                - cd test; ./run_tests.py --all --interface=cli
+                - cd test; travis-wait-enhanced --timeout=40m -- poetry run ./run_tests.py --all --interface=cli
         -   name: With linux binary distribution command line interface
             stage: test
             services: docker
@@ -102,7 +107,7 @@ jobs:
             script:
                 - docker run -it --name hwi-builder -v $PWD:/opt/hwi --rm  --workdir /opt/hwi hwi-builder /bin/bash -c "contrib/build_bin.sh && contrib/build_wine.sh && contrib/build_dist.sh"
                 - sudo chown -R `whoami`:`whoami` dist/
-                - cd test; poetry run ./run_tests.py --all --interface=bindist
+                - cd test; travis-wait-enhanced --timeout=40m -- poetry run ./run_tests.py --all --interface=bindist
                 - cd ..; sha256sum dist/*
         -   name: macOS binary distribution (no tests)
             stage: test
@@ -112,6 +117,7 @@ jobs:
             addons:
                 artifacts:
                     working_dir: dist
+            before_install:
             install:
                 - brew update && brew upgrade pyenv
                 - brew install libusb

--- a/test/data/speculos-screen-text.patch
+++ b/test/data/speculos-screen-text.patch
@@ -1,0 +1,55 @@
+From 3d4ff5c0f7ffa434f73990f03b21c20153d810da Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Fri, 15 Nov 2019 18:20:25 -0500
+Subject: [PATCH] Send out screen text over unix socket
+
+---
+ mcu/bagl.py | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/mcu/bagl.py b/mcu/bagl.py
+index e68ab9c..8c8b3f7 100644
+--- a/mcu/bagl.py
++++ b/mcu/bagl.py
+@@ -1,4 +1,8 @@
+ import binascii
++import json
++import os
++import socket
++
+ from collections import namedtuple
+ from construct import *
+ 
+@@ -61,6 +65,8 @@ SEPROXYHAL_TAG_SCREEN_DISPLAY_RAW_STATUS_START = 0x00
+ 
+ DrawState = namedtuple('DrawState', 'x y width height colors bpp xx yy')
+ 
++SCREEN_TEXT_SOCKET = '/tmp/ledger-screen.sock'
++
+ class Bagl:
+     def __init__(self, m, width, height):
+         self.m = m
+@@ -69,6 +75,8 @@ class Bagl:
+ 
+         self.draw_state = DrawState(0, 0, 0, 0, [], 0, 0, 0)
+ 
++        self.screen_text_sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
++
+     def refresh(self):
+         self.m.update()
+ 
+@@ -566,6 +574,11 @@ class Bagl:
+         elif type_ == BAGL_LABEL:
+             self._display_bagl_labeline(component, context, halignment, valignment, baseline, char_height, strwidth, type_)
+         elif type_ == BAGL_LABELINE:
++            try:
++                data = {"y": component.y, "text": context.decode()}
++                self.screen_text_sock.sendto(json.dumps(data).encode(), SCREEN_TEXT_SOCKET)
++            except:
++                pass
+             self._display_bagl_labeline(component, context, halignment, valignment, baseline, char_height, strwidth, type_)
+         elif type_ == BAGL_ICON:
+             self._display_bagl_icon(component, context)
+-- 
+2.24.0
+

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -52,7 +52,7 @@ parser.add_argument('--all', help='Run tests on all existing simulators', defaul
 parser.add_argument('--bitcoind', help='Path to bitcoind', default='work/bitcoin/src/bitcoind')
 parser.add_argument('--interface', help='Which interface to send commands over', choices=['library', 'cli', 'bindist', 'stdin'], default='library')
 
-parser.set_defaults(trezor=False, trezor_t=False, coldcard=False, keepkey=False, bitbox=False, ledger=False)
+parser.set_defaults(trezor=None, trezor_t=None, coldcard=None, keepkey=None, bitbox=None, ledger=None)
 args = parser.parse_args()
 
 # Run tests
@@ -65,12 +65,21 @@ if sys.platform.startswith("linux"):
     suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestUdevRulesInstaller))
 
 if args.all:
-    args.trezor = True
-    args.trezor_t = True
-    args.coldcard = True
-    args.keepkey = True
-    args.bitbox = True
-    args.ledger = True
+    # Default all true unless overridden
+    args.trezor = True if args.trezor is None else args.trezor
+    args.trezor_t = True if args.trezor_t is None else args.trezor_t
+    args.coldcard = True if args.coldcard is None else args.coldcard
+    args.keepkey = True if args.keepkey is None else args.keepkey
+    args.bitbox = True if args.bitbox is None else args.bitbox
+    args.ledger = True if args.ledger is None else args.ledger
+else:
+    # Default all false unless overridden
+    args.trezor = False if args.trezor is None else args.trezor
+    args.trezor_t = False if args.trezor_t is None else args.trezor_t
+    args.coldcard = False if args.coldcard is None else args.coldcard
+    args.keepkey = False if args.keepkey is None else args.keepkey
+    args.bitbox = False if args.bitbox is None else args.bitbox
+    args.ledger = False if args.ledger is None else args.ledger
 
 if args.trezor or args.trezor_t or args.coldcard or args.ledger or args.keepkey or args.bitbox:
     # Start bitcoind

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -29,11 +29,9 @@ coldcard_group = parser.add_mutually_exclusive_group()
 coldcard_group.add_argument('--no-coldcard', dest='coldcard', help='Do not run Coldcard test with simulator', action='store_false')
 coldcard_group.add_argument('--coldcard', dest='coldcard', help='Run Coldcard test with simulator', action='store_true')
 
-ledger_s_group = parser.add_mutually_exclusive_group()
-ledger_s_group.add_argument('--ledger-s', help='Run physical Ledger Nano S tests.', action='store_true')
-
-ledger_x_group = parser.add_mutually_exclusive_group()
-ledger_x_group.add_argument('--ledger-x', help='Run physical Ledger Nano X tests.', action='store_true')
+ledger_group = parser.add_mutually_exclusive_group()
+ledger_group.add_argument('--no-ledger', dest='ledger', help='Do not run Ledger test with emulator', action='store_false')
+ledger_group.add_argument('--ledger', dest='ledger', help='Run Ledger test with emulator', action='store_true')
 
 keepkey_group = parser.add_mutually_exclusive_group()
 keepkey_group.add_argument('--no-keepkey', dest='keepkey', help='Do not run Keepkey test with emulator', action='store_false')
@@ -48,12 +46,13 @@ parser.add_argument('--trezor-t-path', dest='trezor_t_path', help='Path to Trezo
 parser.add_argument('--coldcard-path', dest='coldcard_path', help='Path to Coldcar simulator', default='work/firmware/unix/headless.py')
 parser.add_argument('--keepkey-path', dest='keepkey_path', help='Path to Keepkey emulator', default='work/keepkey-firmware/bin/kkemu')
 parser.add_argument('--bitbox-path', dest='bitbox_path', help='Path to Digital Bitbox simulator', default='work/mcu/build/bin/simulator')
+parser.add_argument('--ledger-path', dest='ledger_path', help='Path to Ledger emulator', default='work/speculos/speculos.py')
 
 parser.add_argument('--all', help='Run tests on all existing simulators', default=False, action='store_true')
 parser.add_argument('--bitcoind', help='Path to bitcoind', default='work/bitcoin/src/bitcoind')
 parser.add_argument('--interface', help='Which interface to send commands over', choices=['library', 'cli', 'bindist', 'stdin'], default='library')
 
-parser.set_defaults(trezor=False, trezor_t=False, coldcard=False, keepkey=False, bitbox=False)
+parser.set_defaults(trezor=False, trezor_t=False, coldcard=False, keepkey=False, bitbox=False, ledger=False)
 args = parser.parse_args()
 
 # Run tests
@@ -71,8 +70,9 @@ if args.all:
     args.coldcard = True
     args.keepkey = True
     args.bitbox = True
+    args.ledger = True
 
-if args.trezor or args.trezor_t or args.coldcard or args.ledger_s or args.ledger_x or args.keepkey or args.bitbox:
+if args.trezor or args.trezor_t or args.coldcard or args.ledger or args.keepkey or args.bitbox:
     # Start bitcoind
     rpc, userpass = start_bitcoind(args.bitcoind)
 
@@ -86,10 +86,8 @@ if args.trezor or args.trezor_t or args.coldcard or args.ledger_s or args.ledger
         suite.addTest(trezor_test_suite(args.trezor_t_path, rpc, userpass, args.interface, True))
     if args.keepkey:
         suite.addTest(keepkey_test_suite(args.keepkey_path, rpc, userpass, args.interface))
-    if args.ledger_s:
-        suite.addTest(ledger_test_suite("ledger_nano_s", rpc, userpass, args.interface))
-    if args.ledger_x:
-        suite.addTest(ledger_test_suite("ledger_nano_x", rpc, userpass, args.interface))
+    if args.ledger:
+        suite.addTest(ledger_test_suite(args.ledger_path, rpc, userpass, args.interface))
 
 result = unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)
 sys.exit(not result.wasSuccessful())

--- a/test/test_ledger.py
+++ b/test/test_ledger.py
@@ -135,7 +135,7 @@ class LedgerEmulator(DeviceEmulator):
         os.waitpid(self.emulator_proc.pid, 0)
         self.kp_thread.join()
 
-def ledger_test_suite(emulator, rpc, userpass, interface):
+def ledger_test_suite(emulator, rpc, userpass, interface, signtx=False):
 
     # Ledger specific disabled command tests
     class TestLedgerDisabledCommands(DeviceTestCase):
@@ -198,9 +198,10 @@ def ledger_test_suite(emulator, rpc, userpass, interface):
     suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestGetDescriptors, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestSignMessage, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
+    if signtx:
+        suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     return suite
 
 if __name__ == '__main__':
@@ -208,11 +209,12 @@ if __name__ == '__main__':
     parser.add_argument('emulator', help='Path to the ledger emulator')
     parser.add_argument('bitcoind', help='Path to bitcoind binary')
     parser.add_argument('--interface', help='Which interface to send commands over', choices=['library', 'cli', 'bindist'], default='library')
+    parser.add_argument('--signtx', help='Run the transaction signing tests too', action='store_true')
 
     args = parser.parse_args()
 
     # Start bitcoind
     rpc, userpass = start_bitcoind(args.bitcoind)
 
-    suite = ledger_test_suite(args.emulator, rpc, userpass, args.interface)
+    suite = ledger_test_suite(args.emulator, rpc, userpass, args.interface, args.signtx)
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/test/test_ledger.py
+++ b/test/test_ledger.py
@@ -1,28 +1,150 @@
 #! /usr/bin/env python3
 
 import argparse
+import json
+import os
+import subprocess
+import signal
+import socket
+import time
 import unittest
 
-from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestDisplayAddress, TestGetKeypool, TestGetDescriptors, TestSignMessage, TestSignTx
+from test_device import DeviceEmulator, DeviceTestCase, start_bitcoind, TestDeviceConnect, TestDisplayAddress, TestGetKeypool, TestGetDescriptors, TestSignMessage, TestSignTx
+from threading import Thread
 
 from hwilib.cli import process_commands
 
-def ledger_test_suite(device_model, rpc, userpass, interface):
-    # Look for real ledger using HWI API(self-referential, but no other way)
-    enum_res = process_commands(['enumerate'])
-    path = None
-    master_xpub = None
-    fingerprint = None
-    for device in enum_res:
-        if device['type'] == 'ledger':
-            fingerprint = device['fingerprint']
-            path = device['path']
-            master_xpub = process_commands(['-f', fingerprint, 'getmasterxpub'])['xpub']
-            break
-    assert(path is not None and master_xpub is not None and fingerprint is not None)
+SCREEN_TEXT_SOCKET = '/tmp/ledger-screen.sock'
+KEYBOARD_PORT = 1235
+
+
+class ScreenTextThread(Thread):
+    def get_screen_text(self, use_timeout=False):
+        if use_timeout:
+            self.sock.settimeout(5)
+        else:
+            self.sock.settimeout(None)
+        data_str = self.sock.recv(200)
+        if len(data_str) == 0:
+            return ''
+        data = json.loads(data_str.decode())
+
+        text = ''
+        if data['y'] == 12: # Upper line
+            text = data['text']
+            text += self.get_screen_text() # Get next line
+        elif data['y'] == 26 or data['y'] == 28: # lower line or single line
+            text = data['text']
+        return text
+
+    def run(self):
+        self.running = True
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        while True:
+            try:
+                self.sock.bind(SCREEN_TEXT_SOCKET)
+                break
+            except:
+                os.remove(SCREEN_TEXT_SOCKET)
+
+        self.key_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.key_sock.connect(('127.0.0.1', KEYBOARD_PORT))
+
+        seen_msg_hash = False
+        while True:
+            try:
+                text = self.get_screen_text(False)
+                break
+            except:
+                continue
+        while self.running:
+            just_wait = False
+            if text.startswith('Address') or text.startswith('Message hash') or text.startswith("Reviewoutput") or text.startswith("Amount") or text.startswith("Fees") or text == 'Confirmtransaction':
+                time.sleep(0.05)
+                self.key_sock.send(b'Rr')
+                if text.startswith('Message hash'):
+                    seen_msg_hash = True
+            elif text == 'Approve' or text.startswith('Accept'):
+                time.sleep(0.05)
+                self.key_sock.send(b'LRlr')
+            elif text == 'Signmessage':
+                time.sleep(0.05)
+                if seen_msg_hash:
+                    self.key_sock.send(b'LRlr')
+                    seen_msg_hash = False
+                else:
+                    self.key_sock.send(b'Rr')
+            elif text == 'Cancel' or text == 'Reject':
+                time.sleep(0.05)
+                self.key_sock.send(b'Ll')
+            else:
+                # For everything else, do nothing and wait for next text
+                just_wait = True
+
+            try:
+                if just_wait:
+                    # Main screen, don't do anything
+                    new_text = self.get_screen_text(False)
+                else:
+                    # Try to fetch the next text
+                    # If it times out, maybe our input didn't make it, so try processing text again
+                    new_text = self.get_screen_text(True)
+                text = new_text
+            except:
+                continue
+
+        self.sock.close()
+
+    def stop(self):
+        self.running = False
+        self.sock.shutdown(socket.SHUT_RDWR)
+        self.sock.close()
+        self.key_sock.close()
+        os.remove(SCREEN_TEXT_SOCKET)
+
+class LedgerEmulator(DeviceEmulator):
+    def __init__(self, path):
+        self.emulator_path = path
+        self.emulator_proc = None
+
+    def start(self):
+        # Start the emulator
+        self.emulator_proc = subprocess.Popen(['python3', './' + os.path.basename(self.emulator_path), '-bn', './apps/btc.elf'], cwd=os.path.dirname(self.emulator_path), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, preexec_fn=os.setsid)
+        # Wait for simulator to be up
+        while True:
+            try:
+                enum_res = process_commands(['enumerate'])
+                found = False
+                for dev in enum_res:
+                    if dev['type'] == 'ledger' and 'error' not in dev:
+                        found = True
+                        break
+                if found:
+                    break
+            except Exception as e:
+                print(str(e))
+                pass
+            time.sleep(0.5)
+
+        self.kp_thread = ScreenTextThread()
+        self.kp_thread.start()
+
+    def stop(self):
+        self.kp_thread.stop()
+        os.killpg(os.getpgid(self.emulator_proc.pid), signal.SIGTERM)
+        os.waitpid(self.emulator_proc.pid, 0)
+        self.kp_thread.join()
+
+def ledger_test_suite(emulator, rpc, userpass, interface):
 
     # Ledger specific disabled command tests
     class TestLedgerDisabledCommands(DeviceTestCase):
+        def setUp(self):
+            self.emulator.start()
+
+        def tearDown(self):
+            self.emulator.stop()
+
         def test_pin(self):
             result = self.do_command(self.dev_args + ['promptpin'])
             self.assertIn('error', result)
@@ -64,22 +186,27 @@ def ledger_test_suite(device_model, rpc, userpass, interface):
             self.assertEqual(result['error'], 'The Ledger Nano S and X do not support creating a backup via software')
             self.assertEqual(result['code'], -9)
 
+    device_model = 'ledger_nano_s_simulator'
+    path = 'tcp:127.0.0.1:9999'
+    master_xpub = 'xpub6Cak8u8nU1evR4eMoz5UX12bU9Ws5RjEgq2Kq1RKZrsEQF6Cvecoyr19ZYRikWoJo16SXeft5fhkzbXcmuPfCzQKKB9RDPWT8XnUM62ieB9'
+    fingerprint = 'f5acc2fd'
+    dev_emulator = LedgerEmulator(emulator)
+
     # Generic Device tests
     suite = unittest.TestSuite()
-    suite.addTest(DeviceTestCase.parameterize(TestLedgerDisabledCommands, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestGetDescriptors, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestSignMessage, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestLedgerDisabledCommands, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestGetDescriptors, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestSignMessage, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     return suite
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Test Ledger implementation on physical device')
+    parser = argparse.ArgumentParser(description='Test Ledger implementation')
+    parser.add_argument('emulator', help='Path to the ledger emulator')
     parser.add_argument('bitcoind', help='Path to bitcoind binary')
-    parser.add_argument('device_model', help='Device model', choices=['ledger_nano_s', 'ledger_nano_x'])
     parser.add_argument('--interface', help='Which interface to send commands over', choices=['library', 'cli', 'bindist'], default='library')
 
     args = parser.parse_args()
@@ -87,5 +214,5 @@ if __name__ == '__main__':
     # Start bitcoind
     rpc, userpass = start_bitcoind(args.bitcoind)
 
-    suite = ledger_test_suite(args.device_model, rpc, userpass, args.interface)
+    suite = ledger_test_suite(args.emulator, rpc, userpass, args.interface)
     unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
This PR adds the necessary build and test scripts to make use of Ledger's [Speculos](https://github.com/LedgerHQ/speculos) emulator. Speculos emulates Ledger Nano S's and will allow us to test that the commands we send to Ledger devices work.

Following the same pattern as our other device tests, Speculos will be cloned to `test/work`, built from source, and then run by the `test_ledger.py` script. The functionality to use a physical device in this test has been removed and the command line args to `test_ledger.py` and `run_tests.py` have been updated to reflect this. They follow the same pattern as other device tests.

As the emulator does not automatically accept and click through user interface prompts, we needed some way to do the user interaction. This required two pieces: 1) a way to read the emulated display, and 2) another thread to send input. To get the display output, I've added a patch that will output the text displayed to a unix socket. This way we can read the display and know which keypresses to send. Then, another thread is started which listens on that unix socket and sends the appropriate keypress responses  the the emulator's keypress server. This way we can automatically respond to all the stuff displayed on screen.

The Travis config has also been updated. Ubuntu Bionic was needed for the emulator to run, so Travis has been updated to use Bionic instead of Xenial. All of the necessary dependencies will be installed.

Lastly, `test_big_tx` on the emulator takes ~15 minutes. This is long enough to cause Travis to timeout. To get around this, we will install the [`travis-wait-enhanced`](https://github.com/crazy-max/travis-wait-enhanced) tool. This will print out an information line every minute so that we don't hit the ["No output was received" timeout](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received) but still print the test results as the tests run (Travis's recommended `travis_wait` function unfortunately does not print out the test output until the command finishes, making it really hard to know what is going on). Our Travis runs are starting to take quite a long time now.

Closes #277