### PR TITLE
trezor tests: use a different invalid pin

### DIFF
--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -210,7 +210,7 @@ class TestTrezorManCommands(TrezorTestCase):
         self.assertEqual(result['error'], 'Non-numeric PIN provided')
         self.assertEqual(result['code'], -7)
 
-        result = self.do_command(self.dev_args + ['sendpin', '00000'])
+        result = self.do_command(self.dev_args + ['sendpin', '1111'])
         self.assertFalse(result['success'])
 
         # Make sure we get a needs pin message


### PR DESCRIPTION
For some reason the pin of 00000 is causing travis to hang due to some recent trezor firmware change. But changing it to 1111 doesn't. So for now, just use 1111 in the test.