### PR TITLE
Remove Bitcoin ppa and just use incompatible BDB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,9 @@ cache:
         - test/work
 addons:
     apt:
-        sources:
-            - sourceline: 'ppa:bitcoin/bitcoin'
         packages:
-            - libdb4.8-dev
-            - libdb4.8++-dev
+            - libdb-dev
+            - libdb++-dev
             - build-essential
             - curl
             - git


### PR DESCRIPTION
We are already configuring bitcoind with --with-incompatible-bdb so there's no need to need the bitcoin ppa.