### PR TITLE
Disable sending the passphrase on Trezor T

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -110,6 +110,8 @@ class TrezorClient(HardwareWalletClient):
 
     def _check_unlocked(self):
         self.client.init_device()
+        if self.client.features.model == 'T':
+            self.client.ui.disallow_passphrase()
         if self.client.features.pin_protection and not self.client.features.pin_cached:
             raise DeviceNotReadyError('{} is locked. Unlock by using \'promptpin\' and then \'sendpin\'.'.format(self.type))
 

--- a/hwilib/devices/trezorlib/client.py
+++ b/hwilib/devices/trezorlib/client.py
@@ -135,7 +135,7 @@ class TrezorClient:
         else:
             try:
                 passphrase = self.ui.get_passphrase()
-            except exceptions.Cancelled:
+            except:
                 self.call_raw(messages.Cancel())
                 raise
 

--- a/hwilib/devices/trezorlib/debuglink.py
+++ b/hwilib/devices/trezorlib/debuglink.py
@@ -159,6 +159,7 @@ class DebugUI:
         self.pin = None
         self.passphrase = "sphinx of black quartz, judge my wov"
         self.input_flow = None
+        self.return_passphrase = True
 
     def button_request(self, code):
         if self.input_flow is None:
@@ -177,8 +178,13 @@ class DebugUI:
         else:
             return self.debuglink.read_pin_encoded()
 
+    def disallow_passphrase(self):
+        self.return_passphrase = False
+
     def get_passphrase(self):
-        return self.passphrase
+        if self.return_passphrase:
+            return self.passphrase
+        raise ValueError('Passphrase from Host is not allowed for Trezor T')
 
 
 class TrezorClientDebugLink(TrezorClient):

--- a/hwilib/devices/trezorlib/ui.py
+++ b/hwilib/devices/trezorlib/ui.py
@@ -63,6 +63,7 @@ class PassphraseUI:
         self.pinmatrix_shown = False
         self.prompt_shown = False
         self.always_prompt = False
+        self.return_passphrase = True
 
     def button_request(self, code):
         if not self.prompt_shown:
@@ -73,8 +74,13 @@ class PassphraseUI:
     def get_pin(self, code=None):
         raise NotImplementedError('get_pin is not needed')
 
+    def disallow_passphrase(self):
+        self.return_passphrase = False
+
     def get_passphrase(self):
-        return self.passphrase
+        if self.return_passphrase:
+            return self.passphrase
+        raise ValueError('Passphrase from Host is not allowed for Trezor T')
 
 def mnemonic_words(expand=False, language="english"):
     if expand:


### PR DESCRIPTION
The Trezor T allows users to enter passphrases on the host in the same manner that passphrases are entered for the Trezor One. We shouldn't allow this. So, when the passphrase callback happens, if it's a Trezor T, we raise an exception.

Fixes #286