### PR TITLE
Complete multisig support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Please also see [docs](docs/) for additional information about each device.
 | P2SH-P2WPKH Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | P2WPKH Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | P2SH Multisig Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| P2SH-P2WSH Multisig Inputs | Yes | Yes | Yes | Yes | Yes | No | Yes |
+| P2SH-P2WSH Multisig Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | P2WSH Multisig Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | Bare Multisig Inputs | Yes | Yes | N/A | N/A | Yes | N/A | N/A |
 | Arbitrary scriptPubKey Inputs | Yes | Yes | N/A | N/A | Yes | N/A | N/A |

--- a/docs/coldcard.md
+++ b/docs/coldcard.md
@@ -24,4 +24,6 @@ The `backup` command will create a backup file in the current working directory.
 
 ## Caveat for `signtx`
 
-The Coldcard firmware only supports signing single key transactions. It cannot sign multisig or arbitrary scripts yet.
+- The Coldcard firmware only supports signing single key and multisig transactions. It cannot sign arbitrary scripts.
+- Multsigs need to be registered on the device before a transaction spending that multisig will be signed by the device.
+- Multisigs must use BIP 67. This can be accomplished in Bitcoin Core using the `sortedmulti()` descriptor, available in Bitcoin Core 0.20.

--- a/docs/trezor.md
+++ b/docs/trezor.md
@@ -20,6 +20,7 @@ Due to the limitations of the Trezor, some transactions cannot be signed by a Tr
 - Multisig inputs are limited to at most n-of-15 multisigs. This is a firmware limitation.
 * Transactions with arbitrary input scripts (scriptPubKey, redeemScript, or witnessScript) and arbitrary output scripts cannot be signed. This is a firmware limitation.
 * Send-to-self transactions will result in no prompt for outputs as all outputs will be detected as change.
+- For **Trezor T**, a transaction cannot contain both segwit and non-segwit inputs
 
 ## Note on `backup`
 

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -6,7 +6,8 @@ from ..errors import ActionCanceledError, BadArgumentError, DeviceBusyError, Dev
 from .ckcc.client import ColdcardDevice, COINKITE_VID, CKCC_PID
 from .ckcc.protocol import CCProtocolPacker, CCBusyError, CCProtoError, CCUserRefused
 from .ckcc.constants import MAX_BLK_LEN, AF_P2WPKH, AF_CLASSIC, AF_P2WPKH_P2SH
-from ..base58 import xpub_main_2_test
+from ..base58 import get_xpub_fingerprint, xpub_main_2_test
+from ..serializations import PSBT
 from hashlib import sha256
 
 import base64
@@ -68,53 +69,72 @@ class ColdcardClient(HardwareWalletClient):
     def sign_tx(self, tx):
         self.device.check_mitm()
 
-        # Get psbt in hex and then make binary
-        fd = io.BytesIO(base64.b64decode(tx.serialize()))
+        # Get this devices master key fingerprint
+        xpub = self.device.send_recv(CCProtocolPacker.get_xpub('m/0\''), timeout=None)
+        master_fp = get_xpub_fingerprint(xpub)
 
-        # learn size (portable way)
-        sz = fd.seek(0, 2)
-        fd.seek(0)
+        # For multisigs, we may need to do multiple passes if we appear in an input multiple times
+        passes = 1
+        for psbt_in in tx.inputs:
+            our_keys = 0
+            for key in psbt_in.hd_keypaths.keys():
+                keypath = psbt_in.hd_keypaths[key]
+                if keypath[0] == master_fp and key not in psbt_in.partial_sigs:
+                    our_keys += 1
+            if our_keys > passes:
+                passes = our_keys
 
-        left = sz
-        chk = sha256()
-        for pos in range(0, sz, MAX_BLK_LEN):
-            here = fd.read(min(MAX_BLK_LEN, left))
-            if not here:
+        for i in range(0, passes):
+            # Get psbt in hex and then make binary
+            fd = io.BytesIO(base64.b64decode(tx.serialize()))
+
+            # learn size (portable way)
+            sz = fd.seek(0, 2)
+            fd.seek(0)
+
+            left = sz
+            chk = sha256()
+            for pos in range(0, sz, MAX_BLK_LEN):
+                here = fd.read(min(MAX_BLK_LEN, left))
+                if not here:
+                    break
+                left -= len(here)
+                result = self.device.send_recv(CCProtocolPacker.upload(pos, sz, here))
+                assert result == pos
+                chk.update(here)
+
+            # do a verify
+            expect = chk.digest()
+            result = self.device.send_recv(CCProtocolPacker.sha256())
+            assert len(result) == 32
+            if result != expect:
+                raise DeviceFailureError("Wrong checksum:\nexpect: %s\n   got: %s" % (b2a_hex(expect).decode('ascii'), b2a_hex(result).decode('ascii')))
+
+            # start the signing process
+            ok = self.device.send_recv(CCProtocolPacker.sign_transaction(sz, expect), timeout=None)
+            assert ok is None
+            if self.device.is_simulator:
+                self.device.send_recv(CCProtocolPacker.sim_keypress(b'y'))
+
+            print("Waiting for OK on the Coldcard...", file=sys.stderr)
+
+            while 1:
+                time.sleep(0.250)
+                done = self.device.send_recv(CCProtocolPacker.get_signed_txn(), timeout=None)
+                if done is None:
+                    continue
                 break
-            left -= len(here)
-            result = self.device.send_recv(CCProtocolPacker.upload(pos, sz, here))
-            assert result == pos
-            chk.update(here)
 
-        # do a verify
-        expect = chk.digest()
-        result = self.device.send_recv(CCProtocolPacker.sha256())
-        assert len(result) == 32
-        if result != expect:
-            raise DeviceFailureError("Wrong checksum:\nexpect: %s\n   got: %s" % (b2a_hex(expect).decode('ascii'), b2a_hex(result).decode('ascii')))
+            if len(done) != 2:
+                raise DeviceFailureError('Failed: %r' % done)
 
-        # start the signing process
-        ok = self.device.send_recv(CCProtocolPacker.sign_transaction(sz, expect), timeout=None)
-        assert ok is None
-        if self.device.is_simulator:
-            self.device.send_recv(CCProtocolPacker.sim_keypress(b'y'))
+            result_len, result_sha = done
 
-        print("Waiting for OK on the Coldcard...", file=sys.stderr)
+            result = self.device.download_file(result_len, result_sha, file_number=1)
 
-        while 1:
-            time.sleep(0.250)
-            done = self.device.send_recv(CCProtocolPacker.get_signed_txn(), timeout=None)
-            if done is None:
-                continue
-            break
-
-        if len(done) != 2:
-            raise DeviceFailureError('Failed: %r' % done)
-
-        result_len, result_sha = done
-
-        result = self.device.download_file(result_len, result_sha, file_number=1)
-        return {'psbt': base64.b64encode(result).decode()}
+            tx = PSBT()
+            tx.deserialize(base64.b64encode(result).decode())
+        return {'psbt': tx.serialize()}
 
     # Must return a base64 encoded string with the signed message
     # The message can be any string. keypath is the bip 32 derivation path for the key to sign with

--- a/test/data/coldcard-multisig-setup.patch
+++ b/test/data/coldcard-multisig-setup.patch
@@ -1,0 +1,29 @@
+From 86e11ded21ffe839cb907e2096fd7bc832c79ce3 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Tue, 17 Dec 2019 17:56:05 -0500
+Subject: [PATCH] Change default simulator multisig
+
+---
+ unix/frozen-modules/sim_settings.py | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/unix/frozen-modules/sim_settings.py b/unix/frozen-modules/sim_settings.py
+index db78972..9565078 100644
+--- a/unix/frozen-modules/sim_settings.py
++++ b/unix/frozen-modules/sim_settings.py
+@@ -62,7 +62,11 @@ if '-m' in sys.argv:
+         sim_defaults['multisig'] = [["CC-2-of-4", [2, 4], [[1130956047, "tpubDF2rnouQaaYrUEy2JM1YD3RFzew4onawGM4X2Re67gguTf5CbHonBRiFGe3Xjz7DK88dxBFGf2i7K1hef3PM4cFKyUjcbJXddaY9F5tJBoP"], [3503269483, "tpubDFcrvj5n7gyatVbr8dHCUfHT4CGvL8hREBjtxc4ge7HZgqNuPhFimPRtVg6fRRwfXiQthV9EBjNbwbpgV2VoQeL1ZNXoAWXxP2L9vMtRjax"], [2389277556, "tpubDExj5FnaUnPAjjgzELoSiNRkuXJG8Cm1pbdiA4Hc5vkAZHphibeVcUp6mqH5LuNVKbtLVZxVSzyja5X26Cfmx6pzRH6gXBUJAH7MiqwNyuM"], [3190206587, "tpubDFiuHYSJhNbHaGtB5skiuDLg12tRboh2uVZ6KGXxr8WVr28pLcS7F3gv8SsHFa2tm1jtx3VAuw56YfgRkdo6DXyfp51oygTKY3nJFT5jBMt"]], {"pp": "48'/1'/0'/1'", "ch": "XTN", "ft": 26}]]
+     else:
+         # P2SH: 2of4 using BIP39 passwords: "Me", "Myself", "and I", and (empty string) on simulator
+-        sim_defaults['multisig'] = [['MeMyself', [2, 4], [[3503269483, 'tpubD9429UXFGCTKJ9NdiNK4rC5ygqSUkginycYHccqSg5gkmyQ7PZRHNjk99M6a6Y3NY8ctEUUJvCu6iCCui8Ju3xrHRu3Ez1CKB4ZFoRZDdP9'], [2389277556, 'tpubD97nVL37v5tWyMf9ofh5rznwhh1593WMRg6FT4o6MRJkKWANtwAMHYLrcJFsFmPfYbY1TE1LLQ4KBb84LBPt1ubvFwoosvMkcWJtMwvXgSc'], [3190206587, 'tpubD9ArfXowvGHnuECKdGXVKDMfZVGdephVWg8fWGWStH3VKHzT4ph3A4ZcgXWqFu1F5xGTfxncmrnf3sLC86dup2a8Kx7z3xQ3AgeNTQeFxPa'], [1130956047, 'tpubD8NXmKsmWp3a3DXhbihAYbYLGaRNVdTnr6JoSxxfXYQcmwVtW2hv8QoDwng6JtEonmJoL3cNEwfd2cLXMpGezwZ2vL2dQ7259bueNKj9C8n']], {'ch': 'XTN', 'pp': "45'"}]]
++        sim_defaults['multisig'] = [
++            ['mstest', [2, 3], [[1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj'], [1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj'], [1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj']], {'ft': 8, 'ch': 'XTN'}],
++            ['mstest1', [2, 3], [[1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj'], [1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj'], [1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj']], {'ft': 14, 'ch': 'XTN'}],
++            ['mstest2', [2, 3], [[1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj'], [1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj'], [1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj']], {'ft': 26, 'ch': 'XTN'}],
++            ]
+     sim_defaults['fee_limit'] = -1
+ 
+ if '--xfp' in sys.argv:
+-- 
+2.24.1
+

--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -63,7 +63,7 @@ if [ ! -d "firmware" ]; then
     coldcard_setup_needed=true
 else
     cd firmware
-    git reset --hard HEAD^ # Undo git-am for checking and updating
+    git reset --hard HEAD~2 # Undo git-am for checking and updating
     git fetch
 
     # Determine if we need to pull. From https://stackoverflow.com/a/3278427
@@ -81,6 +81,7 @@ else
 fi
 # Apply patch to make simulator work in linux environments
 git am ../../data/coldcard-linux-sock.patch
+git am ../../data/coldcard-multisig-setup.patch
 
 # Build the simulator. This is cached, but it is also fast
 cd unix

--- a/test/test_coldcard.py
+++ b/test/test_coldcard.py
@@ -13,7 +13,7 @@ from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestD
 
 def coldcard_test_suite(simulator, rpc, userpass, interface):
     # Start the Coldcard simulator
-    coldcard_proc = subprocess.Popen(['python3', os.path.basename(simulator)], cwd=os.path.dirname(simulator), stdout=subprocess.DEVNULL, preexec_fn=os.setsid)
+    coldcard_proc = subprocess.Popen(['python3', os.path.basename(simulator), '-m'], cwd=os.path.dirname(simulator), stdout=subprocess.DEVNULL, preexec_fn=os.setsid)
     # Wait for simulator to be up
     while True:
         try:

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -361,9 +361,9 @@ class TestSignTx(DeviceTestCase):
                    pkh_info['desc'][4:-10]]
 
         # Get the descriptors with their checksums
-        sh_multi_desc = self.wrpc.getdescriptorinfo('sh(multi(2,' + pubkeys[0] + ',' + pubkeys[1] + ',' + pubkeys[2] + '))')['descriptor']
-        sh_wsh_multi_desc = self.wrpc.getdescriptorinfo('sh(wsh(multi(2,' + pubkeys[0] + ',' + pubkeys[1] + ',' + pubkeys[2] + ')))')['descriptor']
-        wsh_multi_desc = self.wrpc.getdescriptorinfo('wsh(multi(2,' + pubkeys[2] + ',' + pubkeys[1] + ',' + pubkeys[0] + '))')['descriptor']
+        sh_multi_desc = self.wrpc.getdescriptorinfo('sh(sortedmulti(2,' + pubkeys[0] + ',' + pubkeys[1] + ',' + pubkeys[2] + '))')['descriptor']
+        sh_wsh_multi_desc = self.wrpc.getdescriptorinfo('sh(wsh(sortedmulti(2,' + pubkeys[0] + ',' + pubkeys[1] + ',' + pubkeys[2] + ')))')['descriptor']
+        wsh_multi_desc = self.wrpc.getdescriptorinfo('wsh(sortedmulti(2,' + pubkeys[2] + ',' + pubkeys[1] + ',' + pubkeys[0] + '))')['descriptor']
 
         sh_multi_import = {'desc': sh_multi_desc, "timestamp": "now", "label": "shmulti"}
         sh_wsh_multi_import = {'desc': sh_wsh_multi_desc, "timestamp": "now", "label": "shwshmulti"}

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -335,7 +335,7 @@ class TestSignTx(DeviceTestCase):
             self.assertTrue(self.wrpc.testmempoolaccept([finalize_res['hex']])[0]["allowed"])
         return finalize_res['hex']
 
-    def _test_signtx(self, input_type, multisig):
+    def _test_signtx(self, input_type, multisig, external):
         # Import some keys to the watch only wallet and send coins to them
         keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--sh_wpkh', '30', '40'])
         import_result = self.wrpc.importmulti(keypool_desc)
@@ -408,8 +408,9 @@ class TestSignTx(DeviceTestCase):
                 self.assertTrue((i + 1) * in_amt == self.wrpc.getbalance("*", 0, True))
             psbt = self.wrpc.walletcreatefundedpsbt([], [{self.wpk_rpc.getnewaddress('', 'legacy'): (i + 1) * out_amt}, {self.wpk_rpc.getnewaddress('', 'p2sh-segwit'): (i + 1) * out_amt}, {self.wpk_rpc.getnewaddress('', 'bech32'): (i + 1) * out_amt}], 0, {'includeWatching': True, 'subtractFeeFromOutputs': [0, 1, 2]}, True)
 
-            # Sign with unknown inputs in two steps
-            self._generate_and_finalize(True, psbt)
+            if external:
+                # Sign with unknown inputs in two steps
+                self._generate_and_finalize(True, psbt)
             # Sign all inputs all at once
             final_tx = self._generate_and_finalize(False, psbt)
 
@@ -419,12 +420,13 @@ class TestSignTx(DeviceTestCase):
     # Test wrapper to avoid mixed-inputs signing for Ledger
     def test_signtx(self):
         supports_mixed = {'coldcard', 'trezor_1', 'digitalbitbox', 'keepkey'}
-        supports_multisig = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard'}
+        supports_multisig = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t'}
+        supports_external = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard'}
         if self.full_type not in supports_mixed:
-            self._test_signtx("legacy", self.full_type in supports_multisig)
-            self._test_signtx("segwit", self.full_type in supports_multisig)
+            self._test_signtx("legacy", self.full_type in supports_multisig, self.full_type in supports_external)
+            self._test_signtx("segwit", self.full_type in supports_multisig, self.full_type in supports_external)
         else:
-            self._test_signtx("all", self.full_type in supports_multisig)
+            self._test_signtx("all", self.full_type in supports_multisig, self.full_type in supports_external)
 
     # Make a huge transaction which might cause some problems with different interfaces
     def test_big_tx(self):

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -419,7 +419,7 @@ class TestSignTx(DeviceTestCase):
     # Test wrapper to avoid mixed-inputs signing for Ledger
     def test_signtx(self):
         supports_mixed = {'coldcard', 'trezor_1', 'digitalbitbox', 'keepkey'}
-        supports_multisig = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey'}
+        supports_multisig = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard'}
         if self.full_type not in supports_mixed:
             self._test_signtx("legacy", self.full_type in supports_multisig)
             self._test_signtx("segwit", self.full_type in supports_multisig)


### PR DESCRIPTION
I've tested multisig with all of the devices supported by HWI. This PR fixes the implementations in devices where multisig did not work as well as adds tests for multisig as applicable.

Only two devices had issues with multisig: Trezor T and Coldcard. The Trezor T has some issues because of it's inability to have mixed segwit and non-segwit inputs in a transaction. This poses an issue for us because we skip inputs by declaring the input as being a segwit input and then discarding the signature for it. In this PR, this issue is now documented as a caveat. However this did cause some problems with multisigs since we have to do multiple passes of the transaction, and later rounds would originally mark fully signed inputs as not ours, which, when having legacy multisigs, runs into the mixed segwit issue. This is resolved by not marking those as segwit inputs but still ignoring them.

Additionally, there is now a supports external inputs whitelist in the test to avoid issues with that.

To use multisig with the Coldcard requires enrolling the multisig wallet beforehand. This requirement is now documented. For our tests, we enroll the multisig wallet at startup using the method provided by the simulator's command line arguments. We apply a patch to the simulator to use the multisig wallets that we use in the tests instead of the default provided by the simulator. Additionally, like the Trezor, the Coldcard needs to do multiple passes of signing the transaction if there is a multisig in which the Coldcard is a participant multiple times. So the `sign_tx()` function is updated to handle the multiple passes. Lastly, the Coldcard uses and enforces BIP 67. So we need to use the `sortedmulti` descriptor to handle that.

Both the Coldcard and Trezor T are now enabled for multisig tests.

Closes #248