### PR TITLE
Implement a simple Qt GUI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-exclude = *.pyc,__pycache__,hwilib/devices/btchip/,hwilib/devices/ckcc/,hwilib/devices/trezorlib/,test/work/
+exclude = *.pyc,__pycache__,hwilib/devices/btchip/,hwilib/devices/ckcc/,hwilib/devices/trezorlib/,test/work/,hwilib/ui
 ignore = E261,E302,E305,E501,E722,W5
 per-file-ignores = setup.py:E122

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ test/emulator.img
 test/work
 pip-wheel-metadata
 .mypy_cache/
+
+# Qt stuff
+hwiqt.pyproject.user
+hwilib/ui/ui_*.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,6 @@ jobs:
         -   name: macOS binary distribution (no tests)
             stage: test
             os: osx
-            osx_image: xcode7.3
             language: generic
             addons:
                 artifacts:

--- a/contrib/build_bin.sh
+++ b/contrib/build_bin.sh
@@ -11,9 +11,9 @@ poetry install
 
 # We now need to remove debugging symbols and build id from the hidapi SO file
 so_dir=`dirname $(dirname $(poetry run which python))`/lib/python3.6/site-packages
-find ${so_dir} -name '*.so' -type f -execdir strip '{}' \;
+strip ${so_dir}/hid*.so
 if [[ $OSTYPE != *"darwin"* ]]; then
-    find ${so_dir} -name '*.so' -type f -execdir strip -R .note.gnu.build-id '{}' \;
+    strip -R .note.gnu.build-id ${so_dir}/hid*.so
 fi
 
 # We also need to change the timestamps of all of the base library files
@@ -23,6 +23,8 @@ TZ=UTC find ${lib_dir} -name '*.py' -type f -execdir touch -t "201901010000.00" 
 # Make the standalone binary
 export PYTHONHASHSEED=42
 poetry run pyinstaller hwi.spec
+poetry run contrib/generate-ui.sh
+poetry run pyinstaller hwi-qt.spec
 unset PYTHONHASHSEED
 
 # Make the final compressed package
@@ -32,5 +34,5 @@ OS=`uname | tr '[:upper:]' '[:lower:]'`
 if [[ $OS == "darwin" ]]; then
     OS="mac"
 fi
-tar -czf "hwi-${VERSION}-${OS}-amd64.tar.gz" hwi
+tar -czf "hwi-${VERSION}-${OS}-amd64.tar.gz" hwi hwi-qt
 popd

--- a/contrib/build_wine.sh
+++ b/contrib/build_wine.sh
@@ -69,13 +69,24 @@ POETRY="wine $PYHOME/Scripts/poetry.exe"
 sleep 5 # For some reason, pausing for a few seconds makes the next step work
 $POETRY install
 
+# make the ui files
+pushd hwilib/ui
+for file in *.ui
+do
+    gen_file=ui_`echo $file| cut -d. -f1`.py
+    $POETRY run pyside2-uic $file -o $gen_file
+    sed -i 's/raise()/raise_()/g' $gen_file
+done
+popd
+
 # Do the build
 export PYTHONHASHSEED=42
 $POETRY run pyinstaller hwi.spec
+$POETRY run pyinstaller hwi-qt.spec
 unset PYTHONHASHSEED
 
 # Make the final compressed package
 pushd dist
 VERSION=`$POETRY run hwi --version | cut -d " " -f 2 | dos2unix`
-zip "hwi-${VERSION}-windows-amd64.zip" hwi.exe
+zip "hwi-${VERSION}-windows-amd64.zip" hwi.exe hwi-qt.exe
 popd

--- a/contrib/generate-ui.sh
+++ b/contrib/generate-ui.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+pushd hwilib/ui
+for file in *.ui
+do
+    gen_file=ui_`echo $file| cut -d. -f1`.py
+    pyside2-uic $file -o $gen_file
+    sed -i 's/raise()/raise_()/g' $gen_file
+done
+popd

--- a/hwi-qt.py
+++ b/hwi-qt.py
@@ -1,0 +1,7 @@
+#! /usr/bin/env python3
+
+if __name__ == '__main__':
+    from hwilib.gui import main
+    main()
+else:
+    raise ImportError('hwi-qt is not importable. Import hwilib instead')

--- a/hwi-qt.spec
+++ b/hwi-qt.spec
@@ -1,0 +1,43 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+import platform
+
+block_cipher = None
+
+binaries = []
+if platform.system() == 'Windows':
+    binaries = [("c:/python3/libusb-1.0.dll", ".")]
+elif platform.system() == 'Linux':
+    binaries = [("/lib/x86_64-linux-gnu/libusb-1.0.so.0", ".")]
+elif platform.system() == 'Darwin':
+    find_brew_libusb_proc = subprocess.Popen(['brew', '--prefix', 'libusb'], stdout=subprocess.PIPE)
+    libusb_path = find_brew_libusb_proc.communicate()[0]
+    binaries = [(libusb_path.rstrip().decode() + "/lib/libusb-1.0.dylib", ".")]
+
+a = Analysis(['hwi-qt.py'],
+             binaries=binaries,
+             datas=[],
+             hiddenimports=[],
+             hookspath=['contrib/pyinstaller-hooks/'],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='hwi-qt',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          upx_exclude=[],
+          runtime_tmpdir=None,
+          console=False )

--- a/hwilib/gui.py
+++ b/hwilib/gui.py
@@ -9,6 +9,7 @@ try:
     from .ui.ui_mainwindow import Ui_MainWindow
     from .ui.ui_sendpindialog import Ui_SendPinDialog
     from .ui.ui_setpassphrasedialog import Ui_SetPassphraseDialog
+    from .ui.ui_signmessagedialog import Ui_SignMessageDialog
     from .ui.ui_signpsbtdialog import Ui_SignPSBTDialog
 except ImportError:
     print('Could not import UI files, did you run contrib/generate-ui.sh')
@@ -109,6 +110,27 @@ class SignPSBTDialog(QDialog):
         res = commands.signtx(self.client, psbt_str)
         self.ui.psbt_out_textedit.setPlainText(res['psbt'])
 
+class SignMessageDialog(QDialog):
+    def __init__(self, client):
+        super(SignMessageDialog, self).__init__()
+        self.ui = Ui_SignMessageDialog()
+        self.ui.setupUi(self)
+        self.setWindowTitle('Sign Message')
+        self.client = client
+
+        self.ui.path_lineedit.setValidator(QRegExpValidator(QRegExp("m(/[0-9]+['Hh]?)+"), None))
+        self.ui.msg_textedit.setFocus()
+
+        self.ui.signmsg_button.clicked.connect(self.signmsg_button_clicked)
+        self.ui.buttonBox.clicked.connect(self.accept)
+
+    @Slot()
+    def signmsg_button_clicked(self):
+        msg_str = self.ui.msg_textedit.toPlainText()
+        path = self.ui.path_lineedit.text()
+        res = commands.signmessage(self.client, msg_str, path)
+        self.ui.sig_textedit.setPlainText(res['signature'])
+
 class HWIQt(QMainWindow):
     def __init__(self):
         super(HWIQt, self).__init__()
@@ -127,6 +149,7 @@ class HWIQt(QMainWindow):
         self.ui.sendpin_button.clicked.connect(self.show_sendpindialog)
         self.ui.getxpub_button.clicked.connect(self.show_getxpubdialog)
         self.ui.signtx_button.clicked.connect(self.show_signpsbtdialog)
+        self.ui.signmsg_button.clicked.connect(self.show_signmessagedialog)
 
         self.ui.enumerate_combobox.currentIndexChanged.connect(self.get_client_and_device_info)
 
@@ -207,6 +230,11 @@ class HWIQt(QMainWindow):
     @Slot()
     def show_signpsbtdialog(self):
         self.current_dialog = SignPSBTDialog(self.client)
+        self.current_dialog.exec_()
+
+    @Slot()
+    def show_signmessagedialog(self):
+        self.current_dialog = SignMessageDialog(self.client)
         self.current_dialog.exec_()
 
 def main():

--- a/hwilib/gui.py
+++ b/hwilib/gui.py
@@ -227,6 +227,15 @@ class HWIQt(QMainWindow):
 
         self.ui.enumerate_combobox.currentIndexChanged.connect(self.get_client_and_device_info)
 
+    def clear_info(self):
+        self.ui.getxpub_button.setEnabled(False)
+        self.ui.signtx_button.setEnabled(False)
+        self.ui.signmsg_button.setEnabled(False)
+        self.ui.display_addr_button.setEnabled(False)
+        self.ui.getkeypool_opts_button.setEnabled(False)
+        self.ui.keypool_textedit.clear()
+        self.ui.desc_textedit.clear()
+
     @Slot()
     def refresh_clicked(self):
         if self.client:
@@ -244,6 +253,7 @@ class HWIQt(QMainWindow):
             dev_str = '{} fingerprint:{} path:{}'.format(dev['model'], fingerprint, dev['path'])
             self.ui.enumerate_combobox.addItem(dev_str)
         self.ui.enumerate_combobox.currentIndexChanged.connect(self.get_client_and_device_info)
+        self.clear_info()
 
     @Slot()
     def show_setpassphrasedialog(self):
@@ -260,7 +270,14 @@ class HWIQt(QMainWindow):
     def get_client_and_device_info(self, index):
         self.ui.sendpin_button.setEnabled(False)
         if index == 0:
+            self.clear_info()
             return
+
+        self.ui.getxpub_button.setEnabled(True)
+        self.ui.signtx_button.setEnabled(True)
+        self.ui.signmsg_button.setEnabled(True)
+        self.ui.display_addr_button.setEnabled(True)
+        self.ui.getkeypool_opts_button.setEnabled(True)
 
         # Get the client
         self.device_info = self.devices[index - 1]
@@ -271,6 +288,7 @@ class HWIQt(QMainWindow):
         # Enable the sendpin button if it's a trezor and it needs it
         if self.device_info['needs_pin_sent']:
             self.ui.sendpin_button.setEnabled(True)
+            self.clear_info()
             return
         else:
             self.ui.sendpin_button.setEnabled(False)

--- a/hwilib/gui.py
+++ b/hwilib/gui.py
@@ -4,12 +4,22 @@ from . import commands
 
 try:
     from .ui.ui_mainwindow import Ui_MainWindow
+    from .ui.ui_setpassphrasedialog import Ui_SetPassphraseDialog
 except ImportError:
     print('Could not import UI files, did you run contrib/generate-ui.sh')
     exit(-1)
 
-from PySide2.QtWidgets import QApplication, QMainWindow
+from PySide2.QtWidgets import QApplication, QDialog, QMainWindow
 from PySide2.QtCore import Slot
+
+class SetPassphraseDialog(QDialog):
+    def __init__(self):
+        super(SetPassphraseDialog, self).__init__()
+        self.ui = Ui_SetPassphraseDialog()
+        self.ui.setupUi(self)
+        self.setWindowTitle('Set Passphrase')
+
+        self.ui.passphrase_lineedit.setFocus()
 
 class HWIQt(QMainWindow):
     def __init__(self):
@@ -19,19 +29,35 @@ class HWIQt(QMainWindow):
         self.setWindowTitle('HWI Qt')
 
         self.devices = []
+        self.client = None
+        self.passphrase = ''
+        self.current_dialog = None
 
         self.ui.enumerate_refresh_button.clicked.connect(self.refresh_clicked)
+        self.ui.setpass_button.clicked.connect(self.show_setpassphrasedialog)
 
     @Slot()
     def refresh_clicked(self):
-        self.devices = commands.enumerate()
+        self.devices = commands.enumerate(self.passphrase)
         self.ui.enumerate_combobox.clear()
+        self.ui.enumerate_combobox.addItem('')
         for dev in self.devices:
             fingerprint = 'none'
             if 'fingerprint' in dev:
                 fingerprint = dev['fingerprint']
             dev_str = '{} fingerprint:{} path:{}'.format(dev['model'], fingerprint, dev['path'])
             self.ui.enumerate_combobox.addItem(dev_str)
+
+    @Slot()
+    def show_setpassphrasedialog(self):
+        self.current_dialog = SetPassphraseDialog()
+        self.current_dialog.accepted.connect(self.setpassphrasedialog_accepted)
+        self.current_dialog.exec_()
+
+    @Slot()
+    def setpassphrasedialog_accepted(self):
+        self.passphrase = self.current_dialog.ui.passphrase_lineedit.text()
+        self.current_dialog = None
 
 def main():
     app = QApplication()

--- a/hwilib/gui.py
+++ b/hwilib/gui.py
@@ -9,6 +9,7 @@ except ImportError:
     exit(-1)
 
 from PySide2.QtWidgets import QApplication, QMainWindow
+from PySide2.QtCore import Slot
 
 class HWIQt(QMainWindow):
     def __init__(self):
@@ -17,13 +18,27 @@ class HWIQt(QMainWindow):
         self.ui.setupUi(self)
         self.setWindowTitle('HWI Qt')
 
-def main():
-    devices = commands.enumerate()
-    print(devices)
+        self.devices = []
 
+        self.ui.enumerate_refresh_button.clicked.connect(self.refresh_clicked)
+
+    @Slot()
+    def refresh_clicked(self):
+        self.devices = commands.enumerate()
+        self.ui.enumerate_combobox.clear()
+        for dev in self.devices:
+            fingerprint = 'none'
+            if 'fingerprint' in dev:
+                fingerprint = dev['fingerprint']
+            dev_str = '{} fingerprint:{} path:{}'.format(dev['model'], fingerprint, dev['path'])
+            self.ui.enumerate_combobox.addItem(dev_str)
+
+def main():
     app = QApplication()
 
     window = HWIQt()
-    window.show()
 
+    window.refresh_clicked()
+
+    window.show()
     app.exec_()

--- a/hwilib/gui.py
+++ b/hwilib/gui.py
@@ -9,6 +9,7 @@ try:
     from .ui.ui_mainwindow import Ui_MainWindow
     from .ui.ui_sendpindialog import Ui_SendPinDialog
     from .ui.ui_setpassphrasedialog import Ui_SetPassphraseDialog
+    from .ui.ui_signpsbtdialog import Ui_SignPSBTDialog
 except ImportError:
     print('Could not import UI files, did you run contrib/generate-ui.sh')
     exit(-1)
@@ -89,6 +90,25 @@ class GetXpubDialog(QDialog):
         res = commands.getxpub(self.client, path)
         self.ui.xpub_lineedit.setText(res['xpub'])
 
+class SignPSBTDialog(QDialog):
+    def __init__(self, client):
+        super(SignPSBTDialog, self).__init__()
+        self.ui = Ui_SignPSBTDialog()
+        self.ui.setupUi(self)
+        self.setWindowTitle('Sign PSBT')
+        self.client = client
+
+        self.ui.psbt_in_textedit.setFocus()
+
+        self.ui.sign_psbt_button.clicked.connect(self.sign_psbt_button_clicked)
+        self.ui.buttonBox.clicked.connect(self.accept)
+
+    @Slot()
+    def sign_psbt_button_clicked(self):
+        psbt_str = self.ui.psbt_in_textedit.toPlainText()
+        res = commands.signtx(self.client, psbt_str)
+        self.ui.psbt_out_textedit.setPlainText(res['psbt'])
+
 class HWIQt(QMainWindow):
     def __init__(self):
         super(HWIQt, self).__init__()
@@ -106,6 +126,7 @@ class HWIQt(QMainWindow):
         self.ui.setpass_button.clicked.connect(self.show_setpassphrasedialog)
         self.ui.sendpin_button.clicked.connect(self.show_sendpindialog)
         self.ui.getxpub_button.clicked.connect(self.show_getxpubdialog)
+        self.ui.signtx_button.clicked.connect(self.show_signpsbtdialog)
 
         self.ui.enumerate_combobox.currentIndexChanged.connect(self.get_client_and_device_info)
 
@@ -181,6 +202,11 @@ class HWIQt(QMainWindow):
     @Slot()
     def show_getxpubdialog(self):
         self.current_dialog = GetXpubDialog(self.client)
+        self.current_dialog.exec_()
+
+    @Slot()
+    def show_signpsbtdialog(self):
+        self.current_dialog = SignPSBTDialog(self.client)
         self.current_dialog.exec_()
 
 def main():

--- a/hwilib/gui.py
+++ b/hwilib/gui.py
@@ -67,11 +67,20 @@ class HWIQt(QMainWindow):
 
     @Slot()
     def get_device_info(self, index):
+        self.ui.sendpin_button.setEnabled(False)
         if index == 0:
             return
+
         # Get the client
         dev = self.devices[index - 1]
         self.client = commands.get_client(dev['model'], dev['path'], self.passphrase)
+
+        # Enable the sendpin button if it's a trezor and it needs it
+        if dev['needs_pin_sent']:
+            self.ui.sendpin_button.setEnabled(True)
+            return
+        else:
+            self.ui.sendpin_button.setEnabled(False)
 
         # do getkeypool and getdescriptors
         keypool = commands.getkeypool(self.client, 'm/49h/0h/0h/*', 0, 1000, False, True, 0, False, True)

--- a/hwilib/gui.py
+++ b/hwilib/gui.py
@@ -1,0 +1,29 @@
+#! /usr/bin/env python3
+
+from . import commands
+
+try:
+    from .ui.ui_mainwindow import Ui_MainWindow
+except ImportError:
+    print('Could not import UI files, did you run contrib/generate-ui.sh')
+    exit(-1)
+
+from PySide2.QtWidgets import QApplication, QMainWindow
+
+class HWIQt(QMainWindow):
+    def __init__(self):
+        super(HWIQt, self).__init__()
+        self.ui = Ui_MainWindow()
+        self.ui.setupUi(self)
+        self.setWindowTitle('HWI Qt')
+
+def main():
+    devices = commands.enumerate()
+    print(devices)
+
+    app = QApplication()
+
+    window = HWIQt()
+    window.show()
+
+    app.exec_()

--- a/hwilib/gui.py
+++ b/hwilib/gui.py
@@ -285,7 +285,7 @@ class HWIQt(QMainWindow):
                                       self.getkeypool_opts['account'],
                                       self.getkeypool_opts['sh_wpkh'],
                                       self.getkeypool_opts['wpkh'])
-        descriptors = commands.getdescriptors(self.client, 0)
+        descriptors = commands.getdescriptors(self.client, self.getkeypool_opts['account'])
 
         self.ui.keypool_textedit.setPlainText(json.dumps(keypool, indent=2))
         self.ui.desc_textedit.setPlainText(json.dumps(descriptors, indent=2))

--- a/hwilib/gui.py
+++ b/hwilib/gui.py
@@ -207,7 +207,7 @@ class GetKeypoolOptionsDialog(QDialog):
             self.ui.account_spinbox.setEnabled(False)
 
 class HWIQt(QMainWindow):
-    def __init__(self):
+    def __init__(self, passphrase='', testnet=False):
         super(HWIQt, self).__init__()
         self.ui = Ui_MainWindow()
         self.ui.setupUi(self)
@@ -216,7 +216,8 @@ class HWIQt(QMainWindow):
         self.devices = []
         self.client = None
         self.device_info = {}
-        self.passphrase = ''
+        self.passphrase = passphrase
+        self.testnet = testnet
         self.current_dialog = None
         self.getkeypool_opts = {
             'start': 0,
@@ -296,6 +297,7 @@ class HWIQt(QMainWindow):
         # Get the client
         self.device_info = self.devices[index - 1]
         self.client = commands.get_client(self.device_info['model'], self.device_info['path'], self.passphrase)
+        self.client.is_testnet = self.testnet
         self.get_device_info()
 
     def get_device_info(self):
@@ -403,7 +405,7 @@ def process_gui_commands(cli_args):
     # Qt setup
     app = QApplication()
 
-    window = HWIQt()
+    window = HWIQt(args.password, args.testnet)
 
     window.refresh_clicked()
 

--- a/hwilib/gui.py
+++ b/hwilib/gui.py
@@ -5,6 +5,7 @@ import json
 from . import commands
 
 try:
+    from .ui.ui_displayaddressdialog import Ui_DisplayAddressDialog
     from .ui.ui_getxpubdialog import Ui_GetXpubDialog
     from .ui.ui_mainwindow import Ui_MainWindow
     from .ui.ui_sendpindialog import Ui_SendPinDialog
@@ -131,6 +132,26 @@ class SignMessageDialog(QDialog):
         res = commands.signmessage(self.client, msg_str, path)
         self.ui.sig_textedit.setPlainText(res['signature'])
 
+class DisplayAddressDialog(QDialog):
+    def __init__(self, client):
+        super(DisplayAddressDialog, self).__init__()
+        self.ui = Ui_DisplayAddressDialog()
+        self.ui.setupUi(self)
+        self.setWindowTitle('Display Address')
+        self.client = client
+
+        self.ui.path_lineedit.setValidator(QRegExpValidator(QRegExp("m(/[0-9]+['Hh]?)+"), None))
+        self.ui.path_lineedit.setFocus()
+
+        self.ui.go_button.clicked.connect(self.go_button_clicked)
+        self.ui.buttonBox.clicked.connect(self.accept)
+
+    @Slot()
+    def go_button_clicked(self):
+        path = self.ui.path_lineedit.text()
+        res = commands.displayaddress(self.client, path, sh_wpkh=self.ui.sh_wpkh_radio.isChecked(), wpkh=self.ui.wpkh_radio.isChecked())
+        self.ui.address_lineedit.setText(res['address'])
+
 class HWIQt(QMainWindow):
     def __init__(self):
         super(HWIQt, self).__init__()
@@ -150,6 +171,7 @@ class HWIQt(QMainWindow):
         self.ui.getxpub_button.clicked.connect(self.show_getxpubdialog)
         self.ui.signtx_button.clicked.connect(self.show_signpsbtdialog)
         self.ui.signmsg_button.clicked.connect(self.show_signmessagedialog)
+        self.ui.display_addr_button.clicked.connect(self.show_displayaddressdialog)
 
         self.ui.enumerate_combobox.currentIndexChanged.connect(self.get_client_and_device_info)
 
@@ -235,6 +257,11 @@ class HWIQt(QMainWindow):
     @Slot()
     def show_signmessagedialog(self):
         self.current_dialog = SignMessageDialog(self.client)
+        self.current_dialog.exec_()
+
+    @Slot()
+    def show_displayaddressdialog(self):
+        self.current_dialog = DisplayAddressDialog(self.client)
         self.current_dialog.exec_()
 
 def main():

--- a/hwilib/gui.py
+++ b/hwilib/gui.py
@@ -3,7 +3,7 @@
 import json
 
 from . import commands
-from .errors import handle_errors
+from .errors import handle_errors, DEVICE_NOT_INITIALIZED
 
 try:
     from .ui.ui_displayaddressdialog import Ui_DisplayAddressDialog
@@ -303,6 +303,12 @@ class HWIQt(QMainWindow):
             return
         else:
             self.ui.sendpin_button.setEnabled(False)
+
+        # If it isn't initialized, show an error but don't do anything
+        if 'code' in self.device_info and self.device_info['code'] == DEVICE_NOT_INITIALIZED:
+            self.clear_info()
+            QMessageBox.information(None, "Not initialized yet", 'Device is not initalized yet')
+            return
 
         # do getkeypool and getdescriptors
         keypool = do_command(commands.getkeypool, self.client,

--- a/hwilib/gui.py
+++ b/hwilib/gui.py
@@ -6,13 +6,15 @@ from . import commands
 
 try:
     from .ui.ui_mainwindow import Ui_MainWindow
+    from .ui.ui_sendpindialog import Ui_SendPinDialog
     from .ui.ui_setpassphrasedialog import Ui_SetPassphraseDialog
 except ImportError:
     print('Could not import UI files, did you run contrib/generate-ui.sh')
     exit(-1)
 
-from PySide2.QtWidgets import QApplication, QDialog, QMainWindow
-from PySide2.QtCore import Slot
+from PySide2.QtGui import QRegExpValidator
+from PySide2.QtWidgets import QApplication, QDialog, QLineEdit, QMainWindow
+from PySide2.QtCore import QRegExp, Signal, Slot
 
 class SetPassphraseDialog(QDialog):
     def __init__(self):
@@ -23,6 +25,48 @@ class SetPassphraseDialog(QDialog):
 
         self.ui.passphrase_lineedit.setFocus()
 
+class SendPinDialog(QDialog):
+    pin_sent_success = Signal()
+
+    def __init__(self, client):
+        super(SendPinDialog, self).__init__()
+        self.ui = Ui_SendPinDialog()
+        self.ui.setupUi(self)
+        self.setWindowTitle('Send Pin')
+        self.client = client
+        self.ui.pin_lineedit.setFocus()
+        self.ui.pin_lineedit.setValidator(QRegExpValidator(QRegExp("[1-9]+"), None))
+        self.ui.pin_lineedit.setEchoMode(QLineEdit.Password)
+
+        self.ui.p1_button.clicked.connect(self.button_clicked(1))
+        self.ui.p2_button.clicked.connect(self.button_clicked(2))
+        self.ui.p3_button.clicked.connect(self.button_clicked(3))
+        self.ui.p4_button.clicked.connect(self.button_clicked(4))
+        self.ui.p5_button.clicked.connect(self.button_clicked(5))
+        self.ui.p6_button.clicked.connect(self.button_clicked(6))
+        self.ui.p7_button.clicked.connect(self.button_clicked(7))
+        self.ui.p8_button.clicked.connect(self.button_clicked(8))
+        self.ui.p9_button.clicked.connect(self.button_clicked(9))
+
+        self.accepted.connect(self.sendpindialog_accepted)
+        commands.prompt_pin(self.client)
+
+    def button_clicked(self, number):
+        @Slot()
+        def button_clicked_num():
+            self.ui.pin_lineedit.setText(self.ui.pin_lineedit.text() + str(number))
+        return button_clicked_num
+
+    @Slot()
+    def sendpindialog_accepted(self):
+        pin = self.ui.pin_lineedit.text()
+
+        # Send the pin
+        commands.send_pin(self.client, pin)
+        self.client.close()
+        self.client = None
+        self.pin_sent_success.emit()
+
 class HWIQt(QMainWindow):
     def __init__(self):
         super(HWIQt, self).__init__()
@@ -32,16 +76,22 @@ class HWIQt(QMainWindow):
 
         self.devices = []
         self.client = None
+        self.device_info = {}
         self.passphrase = ''
         self.current_dialog = None
 
         self.ui.enumerate_refresh_button.clicked.connect(self.refresh_clicked)
         self.ui.setpass_button.clicked.connect(self.show_setpassphrasedialog)
+        self.ui.sendpin_button.clicked.connect(self.show_sendpindialog)
 
-        self.ui.enumerate_combobox.currentIndexChanged.connect(self.get_device_info)
+        self.ui.enumerate_combobox.currentIndexChanged.connect(self.get_client_and_device_info)
 
     @Slot()
     def refresh_clicked(self):
+        if self.client:
+            self.client.close()
+            self.client = None
+
         self.devices = commands.enumerate(self.passphrase)
         self.ui.enumerate_combobox.currentIndexChanged.disconnect()
         self.ui.enumerate_combobox.clear()
@@ -52,7 +102,7 @@ class HWIQt(QMainWindow):
                 fingerprint = dev['fingerprint']
             dev_str = '{} fingerprint:{} path:{}'.format(dev['model'], fingerprint, dev['path'])
             self.ui.enumerate_combobox.addItem(dev_str)
-        self.ui.enumerate_combobox.currentIndexChanged.connect(self.get_device_info)
+        self.ui.enumerate_combobox.currentIndexChanged.connect(self.get_client_and_device_info)
 
     @Slot()
     def show_setpassphrasedialog(self):
@@ -66,17 +116,19 @@ class HWIQt(QMainWindow):
         self.current_dialog = None
 
     @Slot()
-    def get_device_info(self, index):
+    def get_client_and_device_info(self, index):
         self.ui.sendpin_button.setEnabled(False)
         if index == 0:
             return
 
         # Get the client
-        dev = self.devices[index - 1]
-        self.client = commands.get_client(dev['model'], dev['path'], self.passphrase)
+        self.device_info = self.devices[index - 1]
+        self.client = commands.get_client(self.device_info['model'], self.device_info['path'], self.passphrase)
+        self.get_device_info()
 
+    def get_device_info(self):
         # Enable the sendpin button if it's a trezor and it needs it
-        if dev['needs_pin_sent']:
+        if self.device_info['needs_pin_sent']:
             self.ui.sendpin_button.setEnabled(True)
             return
         else:
@@ -88,6 +140,20 @@ class HWIQt(QMainWindow):
 
         self.ui.keypool_textedit.setPlainText(json.dumps(keypool, indent=2))
         self.ui.desc_textedit.setPlainText(json.dumps(descriptors, indent=2))
+
+    @Slot()
+    def show_sendpindialog(self):
+        self.current_dialog = SendPinDialog(self.client)
+        self.current_dialog.pin_sent_success.connect(self.sendpindialog_accepted)
+        self.current_dialog.exec_()
+
+    @Slot()
+    def sendpindialog_accepted(self):
+        self.current_dialog = None
+
+        curr_index = self.ui.enumerate_combobox.currentIndex()
+        self.refresh_clicked()
+        self.ui.enumerate_combobox.setCurrentIndex(curr_index)
 
 def main():
     app = QApplication()

--- a/hwilib/ui/displayaddressdialog.ui
+++ b/hwilib/ui/displayaddressdialog.ui
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DisplayAddressDialog</class>
+ <widget class="QDialog" name="DisplayAddressDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>469</width>
+    <height>196</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>350</x>
+     <y>150</y>
+     <width>101</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Close</set>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="path_lineedit">
+   <property name="geometry">
+    <rect>
+     <x>120</x>
+     <y>10</y>
+     <width>331</width>
+     <height>32</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>20</y>
+     <width>111</width>
+     <height>18</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Derivation Path</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="go_button">
+   <property name="geometry">
+    <rect>
+     <x>410</x>
+     <y>50</y>
+     <width>41</width>
+     <height>41</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Go</string>
+   </property>
+   <property name="autoDefault">
+    <bool>false</bool>
+   </property>
+   <property name="default">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_2">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>120</y>
+     <width>58</width>
+     <height>18</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Address</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="address_lineedit">
+   <property name="geometry">
+    <rect>
+     <x>70</x>
+     <y>110</y>
+     <width>381</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="readOnly">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QGroupBox" name="type_groupbox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>50</y>
+     <width>381</width>
+     <height>40</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="minimumSize">
+    <size>
+     <width>0</width>
+     <height>30</height>
+    </size>
+   </property>
+   <property name="title">
+    <string/>
+   </property>
+   <widget class="QRadioButton" name="sh_wpkh_radio">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>10</y>
+      <width>121</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>P2SH-P2WPKH</string>
+    </property>
+    <property name="checked">
+     <bool>true</bool>
+    </property>
+   </widget>
+   <widget class="QRadioButton" name="wpkh_radio">
+    <property name="geometry">
+     <rect>
+      <x>150</x>
+      <y>10</y>
+      <width>91</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>P2WPKH</string>
+    </property>
+   </widget>
+   <widget class="QRadioButton" name="radioButton">
+    <property name="geometry">
+     <rect>
+      <x>260</x>
+      <y>10</y>
+      <width>105</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>P2PKH</string>
+    </property>
+   </widget>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>DisplayAddressDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>DisplayAddressDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hwilib/ui/getkeypooloptionsdialog.ui
+++ b/hwilib/ui/getkeypooloptionsdialog.ui
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GetKeypoolOptionsDialog</class>
+ <widget class="QDialog" name="GetKeypoolOptionsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>440</width>
+    <height>224</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>80</x>
+     <y>180</y>
+     <width>341</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>20</y>
+     <width>41</width>
+     <height>18</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Start</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_2">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>60</y>
+     <width>31</width>
+     <height>18</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>End</string>
+   </property>
+  </widget>
+  <widget class="QSpinBox" name="start_spinbox">
+   <property name="geometry">
+    <rect>
+     <x>80</x>
+     <y>10</y>
+     <width>161</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="maximum">
+    <number>2147483647</number>
+   </property>
+  </widget>
+  <widget class="QSpinBox" name="end_spinbox">
+   <property name="geometry">
+    <rect>
+     <x>80</x>
+     <y>50</y>
+     <width>161</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="maximum">
+    <number>2147483647</number>
+   </property>
+   <property name="value">
+    <number>1000</number>
+   </property>
+  </widget>
+  <widget class="QCheckBox" name="internal_checkbox">
+   <property name="geometry">
+    <rect>
+     <x>280</x>
+     <y>10</y>
+     <width>88</width>
+     <height>22</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Internal</string>
+   </property>
+  </widget>
+  <widget class="QCheckBox" name="keypool_checkbox">
+   <property name="geometry">
+    <rect>
+     <x>280</x>
+     <y>40</y>
+     <width>88</width>
+     <height>22</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>keypool</string>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QGroupBox" name="groupBox">
+   <property name="geometry">
+    <rect>
+     <x>280</x>
+     <y>70</y>
+     <width>141</width>
+     <height>101</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string/>
+   </property>
+   <widget class="QRadioButton" name="sh_wpkh_radio">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>10</y>
+      <width>121</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>P2SH-P2WPKH</string>
+    </property>
+    <property name="checked">
+     <bool>true</bool>
+    </property>
+   </widget>
+   <widget class="QRadioButton" name="wpkh_radio">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>40</y>
+      <width>105</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>P2WPKH</string>
+    </property>
+   </widget>
+   <widget class="QRadioButton" name="pkh_radio">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>70</y>
+      <width>105</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>P2PKH</string>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QGroupBox" name="groupBox_2">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>90</y>
+     <width>231</width>
+     <height>91</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string/>
+   </property>
+   <widget class="QSpinBox" name="account_spinbox">
+    <property name="geometry">
+     <rect>
+      <x>100</x>
+      <y>10</y>
+      <width>111</width>
+      <height>32</height>
+     </rect>
+    </property>
+    <property name="maximum">
+     <number>2147483647</number>
+    </property>
+    <property name="value">
+     <number>0</number>
+    </property>
+   </widget>
+   <widget class="QRadioButton" name="account_radio">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>10</y>
+      <width>81</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Account</string>
+    </property>
+    <property name="checked">
+     <bool>true</bool>
+    </property>
+   </widget>
+   <widget class="QRadioButton" name="path_radio">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>50</y>
+      <width>61</width>
+      <height>22</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Path</string>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="path_lineedit">
+    <property name="enabled">
+     <bool>false</bool>
+    </property>
+    <property name="geometry">
+     <rect>
+      <x>80</x>
+      <y>50</y>
+      <width>141</width>
+      <height>32</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>m/0'/0'/*</string>
+    </property>
+   </widget>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>GetKeypoolOptionsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>GetKeypoolOptionsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hwilib/ui/getxpubdialog.ui
+++ b/hwilib/ui/getxpubdialog.ui
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GetXpubDialog</class>
+ <widget class="QDialog" name="GetXpubDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1205</width>
+    <height>158</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QLabel" name="path_label">
+   <property name="geometry">
+    <rect>
+     <x>320</x>
+     <y>20</y>
+     <width>101</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Derivation Path</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="path_lineedit">
+   <property name="geometry">
+    <rect>
+     <x>430</x>
+     <y>20</y>
+     <width>401</width>
+     <height>32</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>1100</x>
+     <y>110</y>
+     <width>91</width>
+     <height>34</height>
+    </rect>
+   </property>
+   <property name="focusPolicy">
+    <enum>Qt::NoFocus</enum>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Close</set>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="getxpub_button">
+   <property name="geometry">
+    <rect>
+     <x>840</x>
+     <y>20</y>
+     <width>88</width>
+     <height>34</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Get xpub</string>
+   </property>
+   <property name="autoDefault">
+    <bool>false</bool>
+   </property>
+   <property name="default">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QLabel" name="xpub_label">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>70</y>
+     <width>41</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>xpub</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="xpub_lineedit">
+   <property name="geometry">
+    <rect>
+     <x>70</x>
+     <y>70</y>
+     <width>1121</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="focusPolicy">
+    <enum>Qt::NoFocus</enum>
+   </property>
+   <property name="readOnly">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <zorder>buttonBox</zorder>
+  <zorder>path_label</zorder>
+  <zorder>path_lineedit</zorder>
+  <zorder>getxpub_button</zorder>
+  <zorder>xpub_label</zorder>
+  <zorder>xpub_lineedit</zorder>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/hwilib/ui/hwiqt.pyproject
+++ b/hwilib/ui/hwiqt.pyproject
@@ -1,0 +1,3 @@
+{
+    "files": ["mainwindow.ui"]
+}

--- a/hwilib/ui/hwiqt.pyproject
+++ b/hwilib/ui/hwiqt.pyproject
@@ -1,3 +1,3 @@
 {
-    "files": ["mainwindow.ui","setpassphrasedialog.ui","getxpubdialog.ui","signpsbtdialog.ui","sendpindialog.ui","signmessagedialog.ui"]
+    "files": ["signmessagedialog.ui","mainwindow.ui","setpassphrasedialog.ui","getxpubdialog.ui","signpsbtdialog.ui","sendpindialog.ui","displayaddressdialog.ui"]
 }

--- a/hwilib/ui/hwiqt.pyproject
+++ b/hwilib/ui/hwiqt.pyproject
@@ -1,3 +1,3 @@
 {
-    "files": ["mainwindow.ui"]
+    "files": ["mainwindow.ui","setpassphrasedialog.ui"]
 }

--- a/hwilib/ui/hwiqt.pyproject
+++ b/hwilib/ui/hwiqt.pyproject
@@ -1,3 +1,3 @@
 {
-    "files": ["mainwindow.ui","setpassphrasedialog.ui"]
+    "files": ["mainwindow.ui","setpassphrasedialog.ui","sendpindialog.ui"]
 }

--- a/hwilib/ui/hwiqt.pyproject
+++ b/hwilib/ui/hwiqt.pyproject
@@ -1,3 +1,3 @@
 {
-    "files": ["mainwindow.ui","setpassphrasedialog.ui","sendpindialog.ui","getxpubdialog.ui"]
+    "files": ["mainwindow.ui","setpassphrasedialog.ui","getxpubdialog.ui","sendpindialog.ui","signpsbtdialog.ui"]
 }

--- a/hwilib/ui/hwiqt.pyproject
+++ b/hwilib/ui/hwiqt.pyproject
@@ -1,3 +1,3 @@
 {
-    "files": ["mainwindow.ui","setpassphrasedialog.ui","sendpindialog.ui"]
+    "files": ["mainwindow.ui","setpassphrasedialog.ui","sendpindialog.ui","getxpubdialog.ui"]
 }

--- a/hwilib/ui/hwiqt.pyproject
+++ b/hwilib/ui/hwiqt.pyproject
@@ -1,3 +1,3 @@
 {
-    "files": ["signmessagedialog.ui","mainwindow.ui","setpassphrasedialog.ui","getxpubdialog.ui","signpsbtdialog.ui","sendpindialog.ui","displayaddressdialog.ui"]
+    "files": ["signpsbtdialog.ui","mainwindow.ui","sendpindialog.ui","getxpubdialog.ui","signmessagedialog.ui","displayaddressdialog.ui","setpassphrasedialog.ui","getkeypooloptionsdialog.ui"]
 }

--- a/hwilib/ui/hwiqt.pyproject
+++ b/hwilib/ui/hwiqt.pyproject
@@ -1,3 +1,3 @@
 {
-    "files": ["mainwindow.ui","setpassphrasedialog.ui","getxpubdialog.ui","sendpindialog.ui","signpsbtdialog.ui"]
+    "files": ["mainwindow.ui","setpassphrasedialog.ui","getxpubdialog.ui","signpsbtdialog.ui","sendpindialog.ui","signmessagedialog.ui"]
 }

--- a/hwilib/ui/mainwindow.ui
+++ b/hwilib/ui/mainwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>828</width>
-    <height>600</height>
+    <height>430</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,7 @@
       <x>19</x>
       <y>29</y>
       <width>794</width>
-      <height>531</height>
+      <height>375</height>
      </rect>
     </property>
     <layout class="QVBoxLayout" name="verticalLayout">
@@ -74,6 +74,124 @@
          </property>
          <property name="text">
           <string>Refresh</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="1" column="1">
+        <widget class="QPushButton" name="sendpin_button">
+         <property name="text">
+          <string>Send Pin</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QPushButton" name="setpass_button">
+         <property name="text">
+          <string>Set Passphrase</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QPushButton" name="signtx_button">
+         <property name="text">
+          <string>Sign PSBT</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QPushButton" name="getxpub_button">
+         <property name="text">
+          <string>Get an xpub</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QPushButton" name="signmsg_button">
+         <property name="text">
+          <string>Sign Message</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="actions_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>20</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Actions:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QPushButton" name="getkeypool_opts_button">
+         <property name="toolTip">
+          <string>Change the options used for getkeypool</string>
+         </property>
+         <property name="text">
+          <string>Change getkeypool options</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QPushButton" name="display_addr_button">
+         <property name="text">
+          <string>Display Address</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QLabel" name="keypool_label">
+         <property name="text">
+          <string>Keypool:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPlainTextEdit" name="keypool_textedit">
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QLabel" name="desc_label">
+         <property name="text">
+          <string>Descriptors:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPlainTextEdit" name="desc_textedit">
+         <property name="readOnly">
+          <bool>true</bool>
          </property>
         </widget>
        </item>

--- a/hwilib/ui/mainwindow.ui
+++ b/hwilib/ui/mainwindow.ui
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>MainWindow</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <widget class="QWidget" name="verticalLayoutWidget">
+    <property name="geometry">
+     <rect>
+      <x>19</x>
+      <y>29</y>
+      <width>751</width>
+      <height>531</height>
+     </rect>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout"/>
+   </widget>
+  </widget>
+  <widget class="QStatusBar" name="statusbar"/>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/hwilib/ui/mainwindow.ui
+++ b/hwilib/ui/mainwindow.ui
@@ -107,6 +107,9 @@
        </item>
        <item row="2" column="1">
         <widget class="QPushButton" name="signtx_button">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="text">
           <string>Sign PSBT</string>
          </property>
@@ -114,6 +117,9 @@
        </item>
        <item row="2" column="0">
         <widget class="QPushButton" name="getxpub_button">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="text">
           <string>Get an xpub</string>
          </property>
@@ -121,6 +127,9 @@
        </item>
        <item row="2" column="2">
         <widget class="QPushButton" name="signmsg_button">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="text">
           <string>Sign Message</string>
          </property>
@@ -147,6 +156,9 @@
        </item>
        <item row="1" column="2">
         <widget class="QPushButton" name="getkeypool_opts_button">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="toolTip">
           <string>Change the options used for getkeypool</string>
          </property>
@@ -157,6 +169,9 @@
        </item>
        <item row="3" column="0">
         <widget class="QPushButton" name="display_addr_button">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="text">
           <string>Display Address</string>
          </property>

--- a/hwilib/ui/mainwindow.ui
+++ b/hwilib/ui/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
+    <width>828</width>
     <height>600</height>
    </rect>
   </property>
@@ -19,11 +19,67 @@
      <rect>
       <x>19</x>
       <y>29</y>
-      <width>751</width>
+      <width>794</width>
       <height>531</height>
      </rect>
     </property>
-    <layout class="QVBoxLayout" name="verticalLayout"/>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Maximum</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>200</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QComboBox" name="enumerate_combobox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="enumerate_refresh_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>30</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Refresh</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
    </widget>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>

--- a/hwilib/ui/mainwindow.ui
+++ b/hwilib/ui/mainwindow.ui
@@ -90,6 +90,9 @@
       <layout class="QGridLayout" name="gridLayout">
        <item row="1" column="1">
         <widget class="QPushButton" name="sendpin_button">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="text">
           <string>Send Pin</string>
          </property>

--- a/hwilib/ui/sendpindialog.ui
+++ b/hwilib/ui/sendpindialog.ui
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SendPinDialog</class>
+ <widget class="QDialog" name="SendPinDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>257</width>
+    <height>234</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>60</x>
+     <y>190</y>
+     <width>181</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="pin_lineedit">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>231</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="readOnly">
+    <bool>false</bool>
+   </property>
+  </widget>
+  <widget class="QWidget" name="gridLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>50</y>
+     <width>231</width>
+     <height>131</height>
+    </rect>
+   </property>
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="2" column="1">
+     <widget class="QPushButton" name="p2_button">
+      <property name="text">
+       <string>?</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QPushButton" name="p4_button">
+      <property name="text">
+       <string>?</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QPushButton" name="p1_button">
+      <property name="text">
+       <string>?</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QPushButton" name="p8_button">
+      <property name="text">
+       <string>?</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0">
+     <widget class="QPushButton" name="p7_button">
+      <property name="text">
+       <string>?</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="QPushButton" name="p5_button">
+      <property name="text">
+       <string>?</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="2">
+     <widget class="QPushButton" name="p9_button">
+      <property name="text">
+       <string>?</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="2">
+     <widget class="QPushButton" name="p6_button">
+      <property name="text">
+       <string>?</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="2">
+     <widget class="QPushButton" name="p3_button">
+      <property name="text">
+       <string>?</string>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>SendPinDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>SendPinDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hwilib/ui/setpassphrasedialog.ui
+++ b/hwilib/ui/setpassphrasedialog.ui
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SetPassphraseDialog</class>
+ <widget class="QDialog" name="SetPassphraseDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>96</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>40</x>
+     <y>50</y>
+     <width>341</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="passphrase_lineedit">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>10</y>
+     <width>351</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="clearButtonEnabled">
+    <bool>false</bool>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>SetPassphraseDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>SetPassphraseDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hwilib/ui/signmessagedialog.ui
+++ b/hwilib/ui/signmessagedialog.ui
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SignMessageDialog</class>
+ <widget class="QDialog" name="SignMessageDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>957</width>
+    <height>350</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>600</x>
+     <y>300</y>
+     <width>341</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Close</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>70</y>
+     <width>61</width>
+     <height>18</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Message</string>
+   </property>
+  </widget>
+  <widget class="QPlainTextEdit" name="msg_textedit">
+   <property name="geometry">
+    <rect>
+     <x>80</x>
+     <y>20</y>
+     <width>861</width>
+     <height>131</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_2">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>180</y>
+     <width>121</width>
+     <height>18</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Key Derivation Path</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="path_lineedit">
+   <property name="geometry">
+    <rect>
+     <x>150</x>
+     <y>170</y>
+     <width>391</width>
+     <height>32</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="signmsg_button">
+   <property name="geometry">
+    <rect>
+     <x>570</x>
+     <y>170</y>
+     <width>101</width>
+     <height>34</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Sign Message</string>
+   </property>
+   <property name="autoDefault">
+    <bool>false</bool>
+   </property>
+   <property name="default">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_3">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>230</y>
+     <width>71</width>
+     <height>18</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Signature</string>
+   </property>
+  </widget>
+  <widget class="QPlainTextEdit" name="sig_textedit">
+   <property name="geometry">
+    <rect>
+     <x>90</x>
+     <y>220</y>
+     <width>851</width>
+     <height>61</height>
+    </rect>
+   </property>
+   <property name="textInteractionFlags">
+    <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>SignMessageDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>SignMessageDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hwilib/ui/signpsbtdialog.ui
+++ b/hwilib/ui/signpsbtdialog.ui
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SignPSBTDialog</class>
+ <widget class="QDialog" name="SignPSBTDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>987</width>
+    <height>813</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>630</x>
+     <y>760</y>
+     <width>341</width>
+     <height>32</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Close</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>180</y>
+     <width>58</width>
+     <height>61</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>PSBT To Sign</string>
+   </property>
+   <property name="wordWrap">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QPlainTextEdit" name="psbt_in_textedit">
+   <property name="geometry">
+    <rect>
+     <x>90</x>
+     <y>20</y>
+     <width>881</width>
+     <height>321</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QPlainTextEdit" name="psbt_out_textedit">
+   <property name="geometry">
+    <rect>
+     <x>90</x>
+     <y>410</y>
+     <width>881</width>
+     <height>331</height>
+    </rect>
+   </property>
+   <property name="textInteractionFlags">
+    <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_2">
+   <property name="geometry">
+    <rect>
+     <x>30</x>
+     <y>530</y>
+     <width>58</width>
+     <height>61</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>PSBT Result</string>
+   </property>
+   <property name="wordWrap">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="sign_psbt_button">
+   <property name="geometry">
+    <rect>
+     <x>480</x>
+     <y>350</y>
+     <width>88</width>
+     <height>34</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Sign PSBT</string>
+   </property>
+   <property name="autoDefault">
+    <bool>false</bool>
+   </property>
+   <property name="default">
+    <bool>true</bool>
+   </property>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>SignPSBTDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>SignPSBTDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/poetry.lock
+++ b/poetry.lock
@@ -163,6 +163,17 @@ altgraph = "*"
 setuptools = "*"
 
 [[package]]
+category = "main"
+description = "Python bindings for the Qt cross-platform application and UI framework"
+name = "pyside2"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <3.9"
+version = "5.14.0"
+
+[package.dependencies]
+shiboken2 = "5.14.0"
+
+[[package]]
 category = "dev"
 description = ""
 marker = "sys_platform == \"win32\""
@@ -170,6 +181,14 @@ name = "pywin32-ctypes"
 optional = false
 python-versions = "*"
 version = "0.2.0"
+
+[[package]]
+category = "main"
+description = "Python / C++ bindings helper module"
+name = "shiboken2"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <3.9"
+version = "5.14.0"
 
 [[package]]
 category = "main"
@@ -191,8 +210,8 @@ version = "3.7.4"
 typing = ">=3.7.4"
 
 [metadata]
-content-hash = "efb94ab72596b3a8e2c057d24c9ff91efcbe40bfed6b7ca1ed3de909745a72c6"
-python-versions = "^3.6"
+content-hash = "e076be1de3ff88d71f7ed62865dc7f4ecc424ef5d409cc1b7db578021961164a"
+python-versions = "^3.6,<3.9"
 
 [metadata.hashes]
 altgraph = ["d6814989f242b2b43025cba7161fc1b8fb487a62cd49c49245d6fd01c18ac997", "ddf5320017147ba7b810198e0b6619bd7b5563aa034da388cea8546b877f9b0c"]
@@ -212,6 +231,8 @@ pyaes = ["02c1b1405c38d3c370b085fb952dd8bea3fadcee6411ad99f312cc129c536d8f"]
 pycodestyle = ["95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56", "e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"]
 pyflakes = ["17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0", "d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"]
 pyinstaller = ["ee7504022d1332a3324250faf2135ea56ac71fdb6309cff8cd235de26b1d0a96"]
+pyside2 = ["11bba54a62bcd9d7879d3e74cc54c0054c8c6dcdf011ecee9b47c5229cbd7af9", "578b727a5a254cfd509ea2f1fa31779f217a2a1d765c770727662dac950d60eb", "72feeb655958791383085bcb3154f6b3e193c1d66b6aa771c4244a6cafd62b7e", "77474e11c0bb3efa2d7e8506fe0f36049585ba911b8242e070b5f8978e5ba6f7", "c9f59e8c49a9a3b0cca04d8468becd8a562eb9ad0ac1d4d9a8622d2dfa3ce4c9", "ce43f98333443242cd3fe976d72fcb3acf6bb7fa40dd5949e59947a501d5dd72"]
 pywin32-ctypes = ["24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942", "9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"]
+shiboken2 = ["101fc366798f88cbff13586907f3755bebbd9304e66626fb6b0f6b28e0c9a5d2", "47c7c2652f578b37588e8b6daff3a852b3c88ae0f83be13886e4a74859e81763", "4f138656fc755399776062c89492d61f887d4e5fe7c78cded73917e80afcf2f5", "676fef81e4d95b02816fde7359c1f2604efa3edd34b05ab0da42c57c7555f7d7", "a88267c7cc17501effc6b1b36d85e7ab28173af939b975ea42716ed12493b478", "ab3ba84784c9641a11a21a8c64d494fa8b57be25e081e77f76747d543699f03c"]
 typing = ["91dfe6f3f706ee8cc32d38edbbf304e9b7583fb37108fef38229617f8b3eba23", "c8cabb5ab8945cd2f54917be357d134db9cc1eb039e59d1606dc1e60cb1d9d36", "f38d83c5a7a7086543a0f649564d661859c5146a85775ab90c0d2f93ffaa9714"]
 typing-extensions = ["2ed632b30bb54fc3941c382decfd0ee4148f5c591651c9272473fea2c6397d95", "b1edbbf0652660e32ae780ac9433f4231e7339c7f9a8057d0f042fcbcea49b87", "d8179012ec2c620d3791ca6fe2bf7979d979acdbef1fca0bc56b37411db682ed"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,14 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.6,<3.9"
 hidapi = "^0.7.99"
 ecdsa = "^0.13.0"
 pyaes = "^1.6"
 mnemonic = "^0.18.0"
 typing-extensions = "^3.7"
 libusb1 = "^1.7"
+pyside2 = "^5.14.0"
 
 [tool.poetry.dev-dependencies]
 pyinstaller = "^3.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ exclude = ["docs/", "test/"]
 include = ["hwilib/**/*.py", "udev/"]
 packages = [
     { include = "hwi.py" },
+    { include = "hwi-qt.py" },
     { include = "hwilib" },
 ]
 
@@ -34,6 +35,7 @@ flake8 = "^3.7"
 
 [tool.poetry.scripts]
 hwi = 'hwilib.cli:main'
+hwi-qt = 'hwilib.gui:main'
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/setup.py
+++ b/setup.py
@@ -11,20 +11,21 @@ packages = \
  'hwilib.devices.trezorlib.transport']
 
 package_data = \
-{'': ['*'], 'hwilib': ['udev/*']}
+{'': ['*'], 'hwilib': ['udev/*', 'ui/*']}
 
 modules = \
-['hwi']
+['hwi', 'hwi-qt']
 install_requires = \
 ['ecdsa>=0.13.0,<0.14.0',
  'hidapi>=0.7.99,<0.8.0',
  'libusb1>=1.7,<2.0',
  'mnemonic>=0.18.0,<0.19.0',
  'pyaes>=1.6,<2.0',
+ 'pyside2>=5.14.0,<6.0.0',
  'typing-extensions>=3.7,<4.0']
 
 entry_points = \
-{'console_scripts': ['hwi = hwilib.cli:main']}
+{'console_scripts': ['hwi = hwilib.cli:main', 'hwi-qt = hwilib.gui:main']}
 
 setup_kwargs = {
     'name': 'hwi',
@@ -41,7 +42,7 @@ setup_kwargs = {
     'py_modules': modules,
     'install_requires': install_requires,
     'entry_points': entry_points,
-    'python_requires': '>=3.6,<4.0',
+    'python_requires': '>=3.6,<3.9',
 }
 
 


### PR DESCRIPTION
Closes #263

Adds a simple Qt GUI which reflects the CLI. Qt for Python (PySides2) is being used. It has been added as a dependency.

The UI is designed using QtCrerator and makes use of `.ui` files. These `.ui` files need to be converted into importable python modules. This can be done by using the new `contrib/generate-ui.sh` script.

Future work:
* Do Core things automatically
* Allow send pin to be used externally by GUI programs so there is a built in way to to the pin stuff

Screenshots:
![image](https://user-images.githubusercontent.com/3782274/71196145-68932c80-225d-11ea-82c3-523fcc781cc6.png)

