### PR TITLE
Add an expert mode and display decoded xpub information

### DIFF
--- a/hwilib/base58.py
+++ b/hwilib/base58.py
@@ -8,11 +8,17 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
 
-from .serializations import hash256
+import hashlib
 import struct
 from binascii import hexlify, unhexlify
 from typing import List
 b58_digits: str = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+def sha256(s):
+    return hashlib.new('sha256', s).digest()
+
+def hash256(s):
+    return sha256(sha256(s))
 
 def encode(b: bytes) -> str:
     """Encode bytes to a base58-encoded string"""

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -107,6 +107,7 @@ def process_commands(cli_args):
     parser.add_argument('--version', action='version', version='%(prog)s {}'.format(__version__))
     parser.add_argument('--stdin', help='Enter commands and arguments via stdin', action='store_true')
     parser.add_argument('--interactive', '-i', help='Use some commands interactively. Currently required for all device configuration commands', action='store_true')
+    parser.add_argument('--expert', help='Do advanced things and get more detailed information returned from some commands. Use at your own risk.', action='store_true')
 
     subparsers = parser.add_subparsers(description='Commands', dest='command')
     # work-around to make subparser required
@@ -228,12 +229,12 @@ def process_commands(cli_args):
 
     # Auto detect if we are using fingerprint or type to identify device
     if args.fingerprint or (args.device_type and not args.device_path):
-        client = find_device(args.password, args.device_type, args.fingerprint)
+        client = find_device(args.password, args.device_type, args.fingerprint, args.expert)
         if not client:
             return {'error': 'Could not find device with specified fingerprint', 'code': DEVICE_CONN_ERROR}
     elif args.device_type and args.device_path:
         with handle_errors(result=result, code=DEVICE_CONN_ERROR):
-            client = get_client(device_type, device_path, password)
+            client = get_client(device_type, device_path, password, args.expert)
         if 'error' in result:
             return result
     else:

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -12,7 +12,7 @@ from .descriptor import Descriptor
 from .devices import __all__ as all_devs
 
 # Get the client for the device
-def get_client(device_type, device_path, password=''):
+def get_client(device_type, device_path, password='', expert=False):
     device_type = device_type.split('_')[0]
     class_name = device_type.capitalize()
     module = device_type.lower()
@@ -21,7 +21,7 @@ def get_client(device_type, device_path, password=''):
     try:
         imported_dev = importlib.import_module('.devices.' + module, __package__)
         client_constructor = getattr(imported_dev, class_name + 'Client')
-        client = client_constructor(device_path, password)
+        client = client_constructor(device_path, password, expert)
     except ImportError:
         if client:
             client.close()
@@ -42,14 +42,14 @@ def enumerate(password=''):
     return result
 
 # Fingerprint or device type required
-def find_device(password='', device_type=None, fingerprint=None):
+def find_device(password='', device_type=None, fingerprint=None, expert=False):
     devices = enumerate(password)
     for d in devices:
         if device_type is not None and d['type'] != device_type and d['model'] != device_type:
             continue
         client = None
         try:
-            client = get_client(d['type'], d['path'], password)
+            client = get_client(d['type'], d['path'], password, expert)
 
             master_fpr = d.get('fingerprint', None)
             if master_fpr is None:

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -36,8 +36,8 @@ def coldcard_exception(f):
 # This class extends the HardwareWalletClient for ColdCard specific things
 class ColdcardClient(HardwareWalletClient):
 
-    def __init__(self, path, password=''):
-        super(ColdcardClient, self).__init__(path, password)
+    def __init__(self, path, password='', expert=False):
+        super(ColdcardClient, self).__init__(path, password, expert)
         # Simulator hard coded pipe socket
         if path == CC_SIMULATOR_SOCK:
             self.device = ColdcardDevice(sn=path)

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -7,7 +7,7 @@ from .ckcc.client import ColdcardDevice, COINKITE_VID, CKCC_PID
 from .ckcc.protocol import CCProtocolPacker, CCBusyError, CCProtoError, CCUserRefused
 from .ckcc.constants import MAX_BLK_LEN, AF_P2WPKH, AF_CLASSIC, AF_P2WPKH_P2SH
 from ..base58 import get_xpub_fingerprint, xpub_main_2_test
-from ..serializations import PSBT
+from ..serializations import ExtendedKey, PSBT
 from hashlib import sha256
 
 import base64
@@ -55,9 +55,14 @@ class ColdcardClient(HardwareWalletClient):
         path = path.replace('H', '\'')
         xpub = self.device.send_recv(CCProtocolPacker.get_xpub(path), timeout=None)
         if self.is_testnet:
-            return {'xpub': xpub_main_2_test(xpub)}
+            result = {'xpub': xpub_main_2_test(xpub)}
         else:
-            return {'xpub': xpub}
+            result = {'xpub': xpub}
+        if self.expert:
+            xpub_obj = ExtendedKey()
+            xpub_obj.deserialize(xpub)
+            result.update(xpub_obj.get_printable_dict())
+        return result
 
     def _get_fingerprint_hex(self):
         # quick method to get fingerprint of wallet

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -296,8 +296,8 @@ def format_backup_filename(name):
 # This class extends the HardwareWalletClient for Digital Bitbox specific things
 class DigitalbitboxClient(HardwareWalletClient):
 
-    def __init__(self, path, password):
-        super(DigitalbitboxClient, self).__init__(path, password)
+    def __init__(self, path, password, expert=False):
+        super(DigitalbitboxClient, self).__init__(path, password, expert)
         if not password:
             raise NoPasswordError('Password must be supplied for digital BitBox')
         if path.startswith('udp:'):

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -8,8 +8,8 @@ from ..base58 import get_xpub_fingerprint_hex
 py_enumerate = enumerate # Need to use the enumerate built-in but there's another function already named that
 
 class KeepkeyClient(TrezorClient):
-    def __init__(self, path, password=''):
-        super(KeepkeyClient, self).__init__(path, password)
+    def __init__(self, path, password='', expert=False):
+        super(KeepkeyClient, self).__init__(path, password, expert)
         self.type = 'Keepkey'
 
 def enumerate(password=''):

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -12,7 +12,7 @@ import hid
 import struct
 from .. import base58
 from ..base58 import get_xpub_fingerprint_hex
-from ..serializations import hash256, hash160, CTransaction
+from ..serializations import ExtendedKey, hash256, hash160, CTransaction
 import logging
 import re
 
@@ -135,7 +135,14 @@ class LedgerClient(HardwareWalletClient):
         extkey = version + depth + fpr + child + chainCode + publicKey
         checksum = hash256(extkey)[:4]
 
-        return {"xpub": base58.encode(extkey + checksum)}
+        xpub = base58.encode(extkey + checksum)
+        result = {"xpub": xpub}
+
+        if self.expert:
+            xpub_obj = ExtendedKey()
+            xpub_obj.deserialize(xpub)
+            result.update(xpub_obj.get_printable_dict())
+        return result
 
     # Must return a hex string with the signed transaction
     # The tx must be in the combined unsigned transaction format

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -72,8 +72,8 @@ def ledger_exception(f):
 # This class extends the HardwareWalletClient for Ledger Nano S and Nano X specific things
 class LedgerClient(HardwareWalletClient):
 
-    def __init__(self, path, password=''):
-        super(LedgerClient, self).__init__(path, password)
+    def __init__(self, path, password='', expert=False):
+        super(LedgerClient, self).__init__(path, password, expert)
 
         if path.startswith('tcp'):
             split_path = path.split(':')

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -10,7 +10,7 @@ from .trezorlib.ui import echo, PassphraseUI, mnemonic_words, PIN_CURRENT, PIN_N
 from .trezorlib import tools, btc, device
 from .trezorlib import messages as proto
 from ..base58 import get_xpub_fingerprint, to_address, xpub_main_2_test, get_xpub_fingerprint_hex
-from ..serializations import CTxOut, ser_uint256
+from ..serializations import CTxOut, ExtendedKey, ser_uint256
 from .. import bech32
 from usb1 import USBErrorNoDevice
 from types import MethodType
@@ -126,9 +126,14 @@ class TrezorClient(HardwareWalletClient):
             raise BadArgumentError(str(e))
         output = btc.get_public_node(self.client, expanded_path)
         if self.is_testnet:
-            return {'xpub': xpub_main_2_test(output.xpub)}
+            result = {'xpub': xpub_main_2_test(output.xpub)}
         else:
-            return {'xpub': output.xpub}
+            result = {'xpub': output.xpub}
+        if self.expert:
+            xpub_obj = ExtendedKey()
+            xpub_obj.deserialize(output.xpub)
+            result.update(xpub_obj.get_printable_dict())
+        return result
 
     # Must return a hex string with the signed transaction
     # The tx must be in the psbt format

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -89,8 +89,8 @@ def interactive_get_pin(self, code=None):
 # This class extends the HardwareWalletClient for Trezor specific things
 class TrezorClient(HardwareWalletClient):
 
-    def __init__(self, path, password=''):
-        super(TrezorClient, self).__init__(path, password)
+    def __init__(self, path, password='', expert=False):
+        super(TrezorClient, self).__init__(path, password, expert)
         self.simulator = False
         if path.startswith('udp'):
             logging.debug('Simulator found, using DebugLink')

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -3,13 +3,14 @@
 class HardwareWalletClient(object):
 
     # device is an HID device that has already been opened.
-    def __init__(self, path, password):
+    def __init__(self, path, password, expert):
         self.path = path
         self.password = password
         self.message_magic = b"\x18Bitcoin Signed Message:\n"
         self.is_testnet = False
         self.fingerprint = None
         self.xpub_cache = {}
+        self.expert = expert
 
     # Get the master BIP 44 pubkey
     def get_master_xpub(self):

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -18,6 +18,8 @@ ser_*, deser_*: functions that handle serialization/deserialization
 from io import BytesIO, BufferedReader
 from codecs import encode
 from .errors import PSBTSerializationError
+from . import base58
+
 import struct
 import binascii
 import hashlib
@@ -833,3 +835,55 @@ class PSBT(object):
             if not input.is_sane():
                 return False
         return True
+
+# An extended public key (xpub) or private key (xprv). Just a data container for now.
+# Only handles deserialization of extended keys into component data to be handled by something else
+class ExtendedKey(object):
+
+    MAINNET_PUBLIC = b'\x04\x88\xB2\x1E'
+    MAINNET_PRIVATE = b'\x04\x88\xAD\xE4'
+    TESTNET_PUBLIC = b'\x04\x35\x87\xCF'
+    TESTNET_PRIVATE = b'\x04\x35\x83\x94'
+
+    def __init__(self):
+        self.is_testnet = False
+        self.is_private = False
+        self.depth = 0
+        self.parent_fingerprint = b''
+        self.child_num = 0
+        self.chaincode = b''
+        self.pubkey = b''
+        self.privkey = b''
+
+    def deserialize(self, xpub: str):
+        data = base58.decode(xpub)[:-4] # Decoded xpub without checksum
+
+        version = data[0:4]
+        if version == ExtendedKey.TESTNET_PUBLIC or version == ExtendedKey.TESTNET_PRIVATE:
+            self.is_testnet = True
+        if version == ExtendedKey.MAINNET_PRIVATE or version == ExtendedKey.TESTNET_PRIVATE:
+            self.is_private = True
+
+        self.depth = data[4]
+        self.parent_fingerprint = data[5:9]
+        self.child_num = struct.unpack('>I', data[9:13])[0]
+        self.chaincode = data[13:45]
+
+        if self.is_private:
+            self.privkey = data[46:]
+        else:
+            self.pubkey = data[45:78]
+
+    def get_printable_dict(self):
+        d = {}
+        d['testnet'] = self.is_testnet
+        d['private'] = self.is_private
+        d['depth'] = self.depth
+        d['parent_fingerprint'] = binascii.hexlify(self.parent_fingerprint).decode()
+        d['child_num'] = self.child_num
+        d['chaincode'] = binascii.hexlify(self.chaincode).decode()
+        if self.is_private:
+            d['privkey'] = binascii.hexlify(self.privkey).decode()
+        else:
+            d['pubkey'] = binascii.hexlify(self.pubkey).decode()
+        return d

--- a/test/test_coldcard.py
+++ b/test/test_coldcard.py
@@ -78,9 +78,22 @@ def coldcard_test_suite(simulator, rpc, userpass, interface):
             self.assertEqual(result['error'], 'The Coldcard does not need a PIN sent from the host')
             self.assertEqual(result['code'], -9)
 
+    class TestColdcardGetXpub(DeviceTestCase):
+        def test_getxpub(self):
+            result = self.do_command(self.dev_args + ['--expert', 'getxpub', 'm/44h/0h/0h/3'])
+            self.assertEqual(result['xpub'], 'tpubDFHiBJDeNvqPWNJbzzxqDVXmJZoNn2GEtoVcFhMjXipQiorGUmps3e5ieDGbRrBPTFTh9TXEKJCwbAGW9uZnfrVPbMxxbFohuFzfT6VThty')
+            self.assertTrue(result['testnet'])
+            self.assertFalse(result['private'])
+            self.assertEqual(result['depth'], 4)
+            self.assertEqual(result['parent_fingerprint'], 'bc123c3e')
+            self.assertEqual(result['child_num'], 3)
+            self.assertEqual(result['chaincode'], '806b26507824f73bc331494afe122f428ef30dde80b2c1ce025d2d03aff411e7')
+            self.assertEqual(result['pubkey'], '0368000bdff5e0b71421c37b8514de8acd4d98ba9908d183d9da56d02ca4fcfd08')
+
     # Generic device tests
     suite = unittest.TestSuite()
     suite.addTest(DeviceTestCase.parameterize(TestColdcardManCommands, rpc, userpass, 'coldcard', 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', '', interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestColdcardGetXpub, rpc, userpass, 'coldcard', 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd', interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'coldcard', 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd', interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'coldcard_simulator', 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd', interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestGetDescriptors, rpc, userpass, 'coldcard', 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd', interface=interface))

--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -125,9 +125,22 @@ def digitalbitbox_test_suite(simulator, rpc, userpass, interface):
             result = self.do_command(self.dev_args + ['backup', '--label', 'backup_test_backup', '--backup_passphrase', 'testpass'])
             self.assertTrue(result['success'])
 
+    class TestBitboxGetXpub(DeviceTestCase):
+        def test_getxpub(self):
+            result = self.do_command(self.dev_args + ['--expert', 'getxpub', 'm/44h/0h/0h/3'])
+            self.assertEqual(result['xpub'], 'xpub6Du9e5Cz1NZWz3dvsvM21tsj4xEdbAb7AcbysFL42Y3yr8PLMnsaxhetHxurTpX5Rp5RbnFFwP1wct8K3gErCUSwcxFhxThsMBSxdmkhTNf')
+            self.assertFalse(result['testnet'])
+            self.assertFalse(result['private'])
+            self.assertEqual(result['depth'], 4)
+            self.assertEqual(result['parent_fingerprint'], '31d5e5ea')
+            self.assertEqual(result['child_num'], 3)
+            self.assertEqual(result['chaincode'], '7062818c752f878bf96ca668f77630452c3fa033b7415eed3ff568e04ada8104')
+            self.assertEqual(result['pubkey'], '029078c9ad8421afd958d7bc054a0952874923e2586fc9375604f0479a354ea193')
+
     # Generic Device tests
     suite = unittest.TestSuite()
     suite.addTest(DeviceTestCase.parameterize(TestDBBManCommands, rpc, userpass, type, full_type, path, fingerprint, master_xpub, '0000', interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestBitboxGetXpub, rpc, userpass, type, full_type, path, fingerprint, master_xpub, '0000', interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, type, full_type, path, fingerprint, master_xpub, '0000', interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'digitalbitbox_01_simulator', full_type, path, fingerprint, master_xpub, '0000', interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestGetDescriptors, rpc, userpass, type, full_type, path, fingerprint, master_xpub, '0000', interface=interface))

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -137,6 +137,17 @@ class TestKeepkeyGetxpub(KeepkeyTestCase):
                     gxp_res = self.do_command(['-t', 'keepkey', '-d', 'udp:127.0.0.1:21324', 'getxpub', path_vec['path']])
                     self.assertEqual(gxp_res['xpub'], path_vec['xpub'])
 
+    def test_expert_getxpub(self):
+        result = self.do_command(['-t', 'keepkey', '-d', 'udp:127.0.0.1:21324', '--expert', 'getxpub', 'm/44h/0h/0h/3'])
+        self.assertEqual(result['xpub'], 'xpub6FMafWAi3n3ET2rU5yQr16UhRD1Zx4dELmcEw3NaYeBaNnipcr2zjzYp1sNdwR3aTN37hxAqRWQ13AWUZr6L9jc617mU6EvgYXyBjXrEhgr')
+        self.assertFalse(result['testnet'])
+        self.assertFalse(result['private'])
+        self.assertEqual(result['depth'], 4)
+        self.assertEqual(result['parent_fingerprint'], 'f7e318db')
+        self.assertEqual(result['child_num'], 3)
+        self.assertEqual(result['chaincode'], '95a7fb33c4f0896f66045cd7f45ed49a9e72372d2aed204ad0149c39b7b17905')
+        self.assertEqual(result['pubkey'], '022e6d9c18e5a837e802fb09abe00f787c8ccb0fc489c6ec5dc2613d930efd7eae')
+
 # Keepkey specific management (setup, wipe, restore, backup, promptpin, sendpin) command tests
 class TestKeepkeyManCommands(KeepkeyTestCase):
     def setUp(self):

--- a/test/test_ledger.py
+++ b/test/test_ledger.py
@@ -186,6 +186,24 @@ def ledger_test_suite(emulator, rpc, userpass, interface, signtx=False):
             self.assertEqual(result['error'], 'The Ledger Nano S and X do not support creating a backup via software')
             self.assertEqual(result['code'], -9)
 
+    class TestLedgerGetXpub(DeviceTestCase):
+        def setUp(self):
+            self.emulator.start()
+
+        def tearDown(self):
+            self.emulator.stop()
+
+        def test_getxpub(self):
+            result = self.do_command(self.dev_args + ['--expert', 'getxpub', 'm/44h/0h/0h/3'])
+            self.assertEqual(result['xpub'], 'xpub6DqTtMuqBiBsSPb5UxB1qgJ3ViXuhoyZYhw3zTK4MywLB6psioW4PN1SAbhxVVirKQojnTBsjG5gXiiueRBgWmUuN43dpbMSgMCQHVqx2bR')
+            self.assertFalse(result['testnet'])
+            self.assertFalse(result['private'])
+            self.assertEqual(result['depth'], 4)
+            self.assertEqual(result['parent_fingerprint'], '2930ce56')
+            self.assertEqual(result['child_num'], 3)
+            self.assertEqual(result['chaincode'], 'a3cd503ab3ffd3c31610a84307f141528c7e9b8416e10980ced60d1868b463e2')
+            self.assertEqual(result['pubkey'], '03d5edb7c091b5577e1e2e6493b34e602b02547518222e26472cfab1745bb5977d')
+
     device_model = 'ledger_nano_s_simulator'
     path = 'tcp:127.0.0.1:9999'
     master_xpub = 'xpub6Cak8u8nU1evR4eMoz5UX12bU9Ws5RjEgq2Kq1RKZrsEQF6Cvecoyr19ZYRikWoJo16SXeft5fhkzbXcmuPfCzQKKB9RDPWT8XnUM62ieB9'
@@ -195,6 +213,7 @@ def ledger_test_suite(emulator, rpc, userpass, interface, signtx=False):
     # Generic Device tests
     suite = unittest.TestSuite()
     suite.addTest(DeviceTestCase.parameterize(TestLedgerDisabledCommands, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestLedgerGetXpub, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestGetDescriptors, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -143,6 +143,17 @@ class TestTrezorGetxpub(TrezorTestCase):
                     gxp_res = self.do_command(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', 'getxpub', path_vec['path']])
                     self.assertEqual(gxp_res['xpub'], path_vec['xpub'])
 
+    def test_expert_getxpub(self):
+        result = self.do_command(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', '--expert', 'getxpub', 'm/44h/0h/0h/3'])
+        self.assertEqual(result['xpub'], 'xpub6FMafWAi3n3ET2rU5yQr16UhRD1Zx4dELmcEw3NaYeBaNnipcr2zjzYp1sNdwR3aTN37hxAqRWQ13AWUZr6L9jc617mU6EvgYXyBjXrEhgr')
+        self.assertFalse(result['testnet'])
+        self.assertFalse(result['private'])
+        self.assertEqual(result['depth'], 4)
+        self.assertEqual(result['parent_fingerprint'], 'f7e318db')
+        self.assertEqual(result['child_num'], 3)
+        self.assertEqual(result['chaincode'], '95a7fb33c4f0896f66045cd7f45ed49a9e72372d2aed204ad0149c39b7b17905')
+        self.assertEqual(result['pubkey'], '022e6d9c18e5a837e802fb09abe00f787c8ccb0fc489c6ec5dc2613d930efd7eae')
+
 # Trezor specific management (setup, wipe, restore, backup, promptpin, sendpin) command tests
 class TestTrezorManCommands(TrezorTestCase):
     def setUp(self):


### PR DESCRIPTION
Adds an `--expert` switch to enable an expert mode. This mode can be used to hide potentially dangerous or otherwise expertise needed behavior. It can also hide output that isn't useful to most users, but may be useful to an expert.

For now, the only thing hidden behind this expert mode switch is newly added decoded xpub information. In `getxpub` and `getmasterxpub`, when `--expert` is used, the xpub will be decoded and that decoded information added to the returned dict. This includes which network the xpub is for, its depth, parent fingerprint, child number, chaincode, and the pubkey itself. This is being hidden behind `--expert` because it isn't generally useful to users, but maybe useful to experts who may need xpubs decoded, e.g. to get just the pubkey.