### PR TITLE
List features

### DIFF
--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -5,6 +5,7 @@ from .commands import (
     displayaddress,
     enumerate,
     find_device,
+    get_client_class,
     get_client,
     getmasterxpub,
     getxpub,
@@ -22,6 +23,7 @@ from .commands import (
 )
 from .errors import (
     handle_errors,
+    BAD_ARGUMENT,
     DEVICE_CONN_ERROR,
     HELP_TEXT,
     MISSING_ARGUMENTS,
@@ -87,6 +89,10 @@ def send_pin_handler(args, client):
 
 def install_udev_rules_handler(args):
     return install_udev_rules('udev', args.location)
+
+def getfeatures_handler(args):
+    client_class = get_client_class(args.device_type)
+    return client_class.get_features()
 
 class HWIHelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):
     pass
@@ -208,6 +214,9 @@ def process_commands(cli_args):
     sendpin_parser.add_argument('pin', help='The numeric positions of the PIN')
     sendpin_parser.set_defaults(func=send_pin_handler)
 
+    getfeatures_parser = subparsers.add_parser('getfeatures', help='Returns the supported features for the given device type')
+    getfeatures_parser.set_defaults(func=getfeatures_handler)
+
     if sys.platform.startswith("linux"):
         udevrules_parser = subparsers.add_parser('installudevrules', help='Install and load the udev rule files for the hardware wallet devices')
         udevrules_parser.add_argument('--location', help='The path where the udev rules files will be copied', default='/etc/udev/rules.d/')
@@ -251,6 +260,14 @@ def process_commands(cli_args):
     # Install the devices udev rules for Linux
     if command == 'installudevrules':
         with handle_errors(msg="installudevrules failed:", result=result):
+            result = args.func(args)
+        return result
+
+    # Do get features
+    if command == 'getfeatures':
+        if not args.device_type:
+            return {'error': 'Device type needs to be specified to get features', 'code': BAD_ARGUMENT}
+        with handle_errors(result=result, debug=args.debug):
             result = args.func(args)
         return result
 

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -44,14 +44,17 @@ class AddressType(Enum):
     SH_WPKH = 3
 
 def get_client_class(device_type):
-    device_type = device_type.split('_')[0]
-    class_name = device_type.capitalize()
-    module = device_type.lower()
+    device_type_split = device_type.split('_')
+    if device_type_split[-1].lower() == 'simulator':
+        del device_type_split[-1]
+    device_type_split = [x.capitalize() for x in device_type_split]
+    device_model = ''.join(device_type_split)
+    module = device_type_split[0].lower()
 
     try:
         imported_dev = importlib.import_module('.devices.' + module, __package__)
-        client_constructor = getattr(imported_dev, class_name + 'Client')
-    except ImportError:
+        client_constructor = getattr(imported_dev, device_model + 'Client')
+    except (ImportError, AttributeError):
         raise UnknownDeviceError('Unknown device type specified')
 
     return client_constructor
@@ -89,7 +92,7 @@ def find_device(password='', device_type=None, fingerprint=None, expert=False):
             continue
         client = None
         try:
-            client = get_client(d['type'], d['path'], password, expert)
+            client = get_client(d['model'], d['path'], password, expert)
 
             if fingerprint:
                 master_fpr = d.get('fingerprint', None)

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -43,21 +43,29 @@ class AddressType(Enum):
     WPKH = 2
     SH_WPKH = 3
 
-# Get the client for the device
-def get_client(device_type, device_path, password='', expert=False):
+def get_client_class(device_type):
     device_type = device_type.split('_')[0]
     class_name = device_type.capitalize()
     module = device_type.lower()
 
-    client = None
     try:
         imported_dev = importlib.import_module('.devices.' + module, __package__)
         client_constructor = getattr(imported_dev, class_name + 'Client')
-        client = client_constructor(device_path, password, expert)
     except ImportError:
+        raise UnknownDeviceError('Unknown device type specified')
+
+    return client_constructor
+
+# Get the client for the device
+def get_client(device_type, device_path, password='', expert=False):
+    client = None
+    try:
+        client_constructor = get_client_class(device_type)
+        client = client_constructor(device_path, password, expert)
+    except:
         if client:
             client.close()
-        raise UnknownDeviceError('Unknown device type specified')
+        raise
 
     return client
 

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -340,6 +340,11 @@ class ColdcardClient(HardwareWalletClient):
     def toggle_passphrase(self):
         raise UnavailableActionError('The Coldcard does not support toggling passphrase from the host')
 
+    # Get HWI features for this device
+    @classmethod
+    def get_features(self):
+        raise NotImplementedError('The Coldcard does not implement this method')
+
 def enumerate(password=''):
     results = []
     devices = hid.enumerate(COINKITE_VID, CKCC_PID)

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -2,7 +2,11 @@
 
 from typing import Dict, Union
 
-from ..hwwclient import HardwareWalletClient
+from ..hwwclient import (
+    DeviceFeature,
+    HardwareWalletClient,
+    SupportedFeatures,
+)
 from ..errors import (
     ActionCanceledError,
     BadArgumentError,
@@ -93,6 +97,29 @@ def coldcard_exception(f):
 
 # This class extends the HardwareWalletClient for ColdCard specific things
 class ColdcardClient(HardwareWalletClient):
+
+    # Setup features
+    features = SupportedFeatures()
+    features.getxpub = DeviceFeature.SUPPORTED
+    features.signmessage = DeviceFeature.SUPPORTED
+    features.setup = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.wipe = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.recover = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.backup = DeviceFeature.SUPPORTED
+    features.sign_p2pkh = DeviceFeature.SUPPORTED
+    features.sign_p2sh_p2wpkh = DeviceFeature.SUPPORTED
+    features.sign_p2wpkh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2sh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2sh_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_multi_bare = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_bare = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_p2sh = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_p2sh_p2wsh = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_p2wsh = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_coinjoin = DeviceFeature.SUPPORTED
+    features.sign_mixed_segwit = DeviceFeature.SUPPORTED
+    features.display_address = DeviceFeature.SUPPORTED
 
     def __init__(self, path, password='', expert=False):
         super(ColdcardClient, self).__init__(path, password, expert)
@@ -343,7 +370,7 @@ class ColdcardClient(HardwareWalletClient):
     # Get HWI features for this device
     @classmethod
     def get_features(self):
-        raise NotImplementedError('The Coldcard does not implement this method')
+        return self.features.get_printable_dict()
 
 def enumerate(password=''):
     results = []

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -15,7 +15,11 @@ import sys
 import time
 from typing import Dict, Union
 
-from ..hwwclient import HardwareWalletClient
+from ..hwwclient import (
+    DeviceFeature,
+    HardwareWalletClient,
+    SupportedFeatures,
+)
 from ..errors import (
     ActionCanceledError,
     BadArgumentError,
@@ -326,6 +330,29 @@ def format_backup_filename(name):
 # This class extends the HardwareWalletClient for Digital Bitbox specific things
 class DigitalbitboxClient(HardwareWalletClient):
 
+    # Setup features
+    features = SupportedFeatures()
+    features.getxpub = DeviceFeature.SUPPORTED
+    features.signmessage = DeviceFeature.SUPPORTED
+    features.setup = DeviceFeature.SUPPORTED
+    features.wipe = DeviceFeature.SUPPORTED
+    features.recover = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.backup = DeviceFeature.SUPPORTED
+    features.sign_p2pkh = DeviceFeature.SUPPORTED
+    features.sign_p2sh_p2wpkh = DeviceFeature.SUPPORTED
+    features.sign_p2wpkh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2sh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2sh_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_multi_bare = DeviceFeature.SUPPORTED
+    features.sign_arbitrary_bare = DeviceFeature.SUPPORTED
+    features.sign_arbitrary_p2sh = DeviceFeature.SUPPORTED
+    features.sign_arbitrary_p2sh_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_arbitrary_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_coinjoin = DeviceFeature.SUPPORTED
+    features.sign_mixed_segwit = DeviceFeature.SUPPORTED
+    features.display_address = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+
     def __init__(self, path, password, expert=False):
         super(DigitalbitboxClient, self).__init__(path, password, expert)
         if not password:
@@ -620,7 +647,7 @@ class DigitalbitboxClient(HardwareWalletClient):
     # Get HWI features for this device
     @classmethod
     def get_features(self):
-        raise NotImplementedError('The Digital Bitbox does not implement this method')
+        return self.features.get_printable_dict()
 
 class Digitalbitbox01Client(DigitalbitboxClient):
     def __init__(self, path, password='', expert=False):

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -617,6 +617,11 @@ class DigitalbitboxClient(HardwareWalletClient):
     def toggle_passphrase(self):
         raise UnavailableActionError('The Digital Bitbox does not support toggling passphrase from the host')
 
+    # Get HWI features for this device
+    @classmethod
+    def get_features(self):
+        raise NotImplementedError('The Digital Bitbox does not implement this method')
+
 class Digitalbitbox01Client(DigitalbitboxClient):
     def __init__(self, path, password='', expert=False):
         super(Digitalbitbox01Client, self).__init__(path, password, expert)

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -617,6 +617,11 @@ class DigitalbitboxClient(HardwareWalletClient):
     def toggle_passphrase(self):
         raise UnavailableActionError('The Digital Bitbox does not support toggling passphrase from the host')
 
+class Digitalbitbox01Client(DigitalbitboxClient):
+    def __init__(self, path, password='', expert=False):
+        super(Digitalbitbox01Client, self).__init__(path, password, expert)
+        self.type = 'Digital BitBox01'
+
 def enumerate(password=''):
     results = []
     devices = hid.enumerate(DBB_VENDOR_ID, DBB_DEVICE_ID)

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -6,6 +6,10 @@ from ..errors import (
     common_err_msgs,
     handle_errors,
 )
+from ..hwwclient import (
+    DeviceFeature,
+    SupportedFeatures,
+)
 from .trezorlib.transport import (
     enumerate_devices,
     KEEPKEY_VENDOR_IDS,
@@ -15,9 +19,37 @@ from .trezor import TrezorClient
 py_enumerate = enumerate # Need to use the enumerate built-in but there's another function already named that
 
 class KeepkeyClient(TrezorClient):
+
+    # Setup features
+    features = SupportedFeatures()
+    features.getxpub = DeviceFeature.SUPPORTED
+    features.signmessage = DeviceFeature.SUPPORTED
+    features.setup = DeviceFeature.SUPPORTED
+    features.wipe = DeviceFeature.SUPPORTED
+    features.recover = DeviceFeature.SUPPORTED
+    features.backup = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_p2pkh = DeviceFeature.SUPPORTED
+    features.sign_p2sh_p2wpkh = DeviceFeature.SUPPORTED
+    features.sign_p2wpkh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2sh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2sh_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_multi_bare = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_bare = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_p2sh = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_p2sh_p2wsh = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_p2wsh = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_coinjoin = DeviceFeature.SUPPORTED
+    features.sign_mixed_segwit = DeviceFeature.SUPPORTED
+    features.display_address = DeviceFeature.SUPPORTED
+
     def __init__(self, path, password='', expert=False):
         super(KeepkeyClient, self).__init__(path, password, expert)
         self.type = 'Keepkey'
+
+    @classmethod
+    def get_features(self):
+        return self.features.get_printable_dict()
 
 def enumerate(password=''):
     results = []

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -387,6 +387,11 @@ class LedgerClient(HardwareWalletClient):
     def toggle_passphrase(self):
         raise UnavailableActionError('The Ledger Nano S and X do not support toggling passphrase from the host')
 
+    # Get HWI features for this device
+    @classmethod
+    def get_features(self):
+        raise NotImplementedError('The Ledger Nano S and X does not implement this method')
+
 class LedgerNanoSClient(LedgerClient):
     def __init__(self, path, password='', expert=False):
         super(LedgerNanoSClient, self).__init__(path, password, expert)

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -102,6 +102,7 @@ class LedgerClient(HardwareWalletClient):
 
     def __init__(self, path, password='', expert=False):
         super(LedgerClient, self).__init__(path, password, expert)
+        self.type = 'Ledger Nano S and X'
 
         if path.startswith('tcp'):
             split_path = path.split(':')
@@ -385,6 +386,16 @@ class LedgerClient(HardwareWalletClient):
     # Toggle passphrase
     def toggle_passphrase(self):
         raise UnavailableActionError('The Ledger Nano S and X do not support toggling passphrase from the host')
+
+class LedgerNanoSClient(LedgerClient):
+    def __init__(self, path, password='', expert=False):
+        super(LedgerNanoSClient, self).__init__(path, password, expert)
+        self.type = 'Ledger Nano S'
+
+class LedgerNanoXClient(LedgerClient):
+    def __init__(self, path, password='', expert=False):
+        super(LedgerNanoXClient, self).__init__(path, password, expert)
+        self.type = 'Ledger Nano X'
 
 def enumerate(password=''):
     results = []

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -2,7 +2,11 @@
 
 from typing import Dict, Union
 
-from ..hwwclient import HardwareWalletClient
+from ..hwwclient import (
+    DeviceFeature,
+    HardwareWalletClient,
+    SupportedFeatures,
+)
 from ..errors import (
     ActionCanceledError,
     BadArgumentError,
@@ -99,6 +103,29 @@ def ledger_exception(f):
 
 # This class extends the HardwareWalletClient for Ledger Nano S and Nano X specific things
 class LedgerClient(HardwareWalletClient):
+
+    # Setup features
+    features = SupportedFeatures()
+    features.getxpub = DeviceFeature.SUPPORTED
+    features.signmessage = DeviceFeature.SUPPORTED
+    features.setup = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.wipe = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.recover = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.backup = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_p2pkh = DeviceFeature.SUPPORTED
+    features.sign_p2sh_p2wpkh = DeviceFeature.SUPPORTED
+    features.sign_p2wpkh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2sh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2sh_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_multi_bare = DeviceFeature.SUPPORTED
+    features.sign_arbitrary_bare = DeviceFeature.SUPPORTED
+    features.sign_arbitrary_p2sh = DeviceFeature.SUPPORTED
+    features.sign_arbitrary_p2sh_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_arbitrary_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_coinjoin = DeviceFeature.SUPPORTED
+    features.sign_mixed_segwit = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.display_address = DeviceFeature.SUPPORTED
 
     def __init__(self, path, password='', expert=False):
         super(LedgerClient, self).__init__(path, password, expert)
@@ -390,7 +417,7 @@ class LedgerClient(HardwareWalletClient):
     # Get HWI features for this device
     @classmethod
     def get_features(self):
-        raise NotImplementedError('The Ledger Nano S and X does not implement this method')
+        return self.features.get_printable_dict()
 
 class LedgerNanoSClient(LedgerClient):
     def __init__(self, path, password='', expert=False):

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -357,19 +357,19 @@ class LedgerClient(HardwareWalletClient):
 
     # Setup a new device
     def setup_device(self, label='', passphrase=''):
-        raise UnavailableActionError('The Ledger Nano S and X do not support software setup')
+        raise UnavailableActionError('The {} does not support software setup'.format(self.type))
 
     # Wipe this device
     def wipe_device(self):
-        raise UnavailableActionError('The Ledger Nano S and X do not support wiping via software')
+        raise UnavailableActionError('The {} does not support wiping via software'.format(self.type))
 
     # Restore device from mnemonic or xprv
     def restore_device(self, label='', word_count=24):
-        raise UnavailableActionError('The Ledger Nano S and X do not support restoring via software')
+        raise UnavailableActionError('The {} does not support restoring via software'.format(self.type))
 
     # Begin backup process
     def backup_device(self, label='', passphrase=''):
-        raise UnavailableActionError('The Ledger Nano S and X do not support creating a backup via software')
+        raise UnavailableActionError('The {} does not support creating a backup via software'.format(self.type))
 
     # Close the device
     def close(self):
@@ -377,11 +377,11 @@ class LedgerClient(HardwareWalletClient):
 
     # Prompt pin
     def prompt_pin(self):
-        raise UnavailableActionError('The Ledger Nano S and X do not need a PIN sent from the host')
+        raise UnavailableActionError('The {} does not need a PIN sent from the host'.format(self.type))
 
     # Send pin
     def send_pin(self, pin):
-        raise UnavailableActionError('The Ledger Nano S and X do not need a PIN sent from the host')
+        raise UnavailableActionError('The {} does not need a PIN sent from the host'.format(self.type))
 
     # Toggle passphrase
     def toggle_passphrase(self):

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -551,6 +551,11 @@ class TrezorClient(HardwareWalletClient):
                 print(PIN_MATRIX_DESCRIPTION, file=sys.stderr)
         return {'success': True}
 
+    # Get HWI features for this device
+    @classmethod
+    def get_features(self):
+        raise NotImplementedError('The {} does not implement this method'.format(self.type))
+
 class Trezor1Client(TrezorClient):
     def __init__(self, path, password='', expert=False):
         super(Trezor1Client, self).__init__(path, password, expert)

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -551,6 +551,16 @@ class TrezorClient(HardwareWalletClient):
                 print(PIN_MATRIX_DESCRIPTION, file=sys.stderr)
         return {'success': True}
 
+class Trezor1Client(TrezorClient):
+    def __init__(self, path, password='', expert=False):
+        super(Trezor1Client, self).__init__(path, password, expert)
+        self.type = 'Trezor 1'
+
+class TrezorTClient(TrezorClient):
+    def __init__(self, path, password='', expert=False):
+        super(TrezorTClient, self).__init__(path, password, expert)
+        self.type = 'Trezor T'
+
 def enumerate(password=''):
     results = []
     for dev in enumerate_devices():

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -2,7 +2,11 @@
 
 from typing import Dict, Union
 
-from ..hwwclient import HardwareWalletClient
+from ..hwwclient import (
+    DeviceFeature,
+    HardwareWalletClient,
+    SupportedFeatures,
+)
 from ..errors import (
     ActionCanceledError,
     BadArgumentError,
@@ -554,17 +558,73 @@ class TrezorClient(HardwareWalletClient):
     # Get HWI features for this device
     @classmethod
     def get_features(self):
-        raise NotImplementedError('The {} does not implement this method'.format(self.type))
+        raise UnavailableActionError('A specific Trezor model must be specified to get the features')
 
 class Trezor1Client(TrezorClient):
+
+    # Setup features
+    features = SupportedFeatures()
+    features.getxpub = DeviceFeature.SUPPORTED
+    features.signmessage = DeviceFeature.SUPPORTED
+    features.setup = DeviceFeature.SUPPORTED
+    features.wipe = DeviceFeature.SUPPORTED
+    features.recover = DeviceFeature.SUPPORTED
+    features.backup = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_p2pkh = DeviceFeature.SUPPORTED
+    features.sign_p2sh_p2wpkh = DeviceFeature.SUPPORTED
+    features.sign_p2wpkh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2sh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2sh_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_multi_bare = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_bare = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_p2sh = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_p2sh_p2wsh = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_p2wsh = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_coinjoin = DeviceFeature.SUPPORTED
+    features.sign_mixed_segwit = DeviceFeature.SUPPORTED
+    features.display_address = DeviceFeature.SUPPORTED
+
     def __init__(self, path, password='', expert=False):
         super(Trezor1Client, self).__init__(path, password, expert)
         self.type = 'Trezor 1'
 
+    @classmethod
+    def get_features(self):
+        return self.features.get_printable_dict()
+
 class TrezorTClient(TrezorClient):
+
+    # Setup features
+    features = SupportedFeatures()
+    features.getxpub = DeviceFeature.SUPPORTED
+    features.signmessage = DeviceFeature.SUPPORTED
+    features.setup = DeviceFeature.SUPPORTED
+    features.wipe = DeviceFeature.SUPPORTED
+    features.recover = DeviceFeature.SUPPORTED
+    features.backup = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_p2pkh = DeviceFeature.SUPPORTED
+    features.sign_p2sh_p2wpkh = DeviceFeature.SUPPORTED
+    features.sign_p2wpkh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2sh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2sh_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_multi_p2wsh = DeviceFeature.SUPPORTED
+    features.sign_multi_bare = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_bare = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_p2sh = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_p2sh_p2wsh = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_arbitrary_p2wsh = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.sign_coinjoin = DeviceFeature.SUPPORTED
+    features.sign_mixed_segwit = DeviceFeature.FIRMWARE_NOT_SUPPORTED
+    features.display_address = DeviceFeature.SUPPORTED
+
     def __init__(self, path, password='', expert=False):
         super(TrezorTClient, self).__init__(path, password, expert)
         self.type = 'Trezor T'
+
+    @classmethod
+    def get_features(self):
+        return self.features.get_printable_dict()
 
 def enumerate(password=''):
     results = []

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -4,6 +4,60 @@ from .base58 import get_xpub_fingerprint_hex
 from .descriptor import Descriptor
 from .serializations import PSBT
 
+from enum import IntEnum
+
+class DeviceFeature(IntEnum):
+    SUPPORTED = 1 # The device supports the feature and so does HWI
+    NOT_SUPPORTED = 2 # The device supports the feature but HWI has not implemented it yet
+    FIRMWARE_NOT_SUPPORTED = 3 # The firmware does not support the feature so HWI cannot
+
+class SupportedFeatures(object):
+
+    def __init__(self) -> None:
+        self.getxpub = DeviceFeature.NOT_SUPPORTED
+        self.signmessage = DeviceFeature.NOT_SUPPORTED
+        self.setup = DeviceFeature.NOT_SUPPORTED
+        self.wipe = DeviceFeature.NOT_SUPPORTED
+        self.recover = DeviceFeature.NOT_SUPPORTED
+        self.backup = DeviceFeature.NOT_SUPPORTED
+        self.sign_p2pkh = DeviceFeature.NOT_SUPPORTED
+        self.sign_p2sh_p2wpkh = DeviceFeature.NOT_SUPPORTED
+        self.sign_p2wpkh = DeviceFeature.NOT_SUPPORTED
+        self.sign_multi_p2sh = DeviceFeature.NOT_SUPPORTED
+        self.sign_multi_p2sh_p2wsh = DeviceFeature.NOT_SUPPORTED
+        self.sign_multi_p2wsh = DeviceFeature.NOT_SUPPORTED
+        self.sign_multi_bare = DeviceFeature.NOT_SUPPORTED
+        self.sign_arbitrary_bare = DeviceFeature.NOT_SUPPORTED
+        self.sign_arbitrary_p2sh = DeviceFeature.NOT_SUPPORTED
+        self.sign_arbitrary_p2sh_p2wsh = DeviceFeature.NOT_SUPPORTED
+        self.sign_arbitrary_p2wsh = DeviceFeature.NOT_SUPPORTED
+        self.sign_coinjoin = DeviceFeature.NOT_SUPPORTED
+        self.sign_mixed_segwit = DeviceFeature.NOT_SUPPORTED
+        self.display_address = DeviceFeature.NOT_SUPPORTED
+
+    def get_printable_dict(self) -> Dict[str, DeviceFeature]:
+        d = {}
+        d['getxpub'] = self.getxpub
+        d['signmessage'] = self.signmessage
+        d['setup'] = self.setup
+        d['wipe'] = self.wipe
+        d['recover'] = self.recover
+        d['backup'] = self.backup
+        d['sign_p2pkh'] = self.sign_p2pkh
+        d['sign_p2sh_p2wpkh'] = self.sign_p2sh_p2wpkh
+        d['sign_p2wpkh'] = self.sign_p2wpkh
+        d['sign_multi_p2sh'] = self.sign_multi_p2sh
+        d['sign_multi_p2sh_p2wsh'] = self.sign_multi_p2sh_p2wsh
+        d['sign_multi_p2wsh'] = self.sign_multi_p2wsh
+        d['sign_multi_bare'] = self.sign_multi_bare
+        d['sign_arbitrary_bare'] = self.sign_arbitrary_bare
+        d['sign_arbitrary_p2sh'] = self.sign_arbitrary_p2sh
+        d['sign_arbitrary_p2sh_p2wsh'] = self.sign_arbitrary_p2sh_p2wsh
+        d['sign_arbitrary_p2wsh'] = self.sign_arbitrary_p2wsh
+        d['sign_coinjoin'] = self.sign_coinjoin
+        d['sign_mixed_segwit'] = self.sign_mixed_segwit
+        d['display_address'] = self.display_address
+        return d
 
 class HardwareWalletClient(object):
     """Create a client for a HID device that has already been opened.
@@ -182,6 +236,16 @@ class HardwareWalletClient(object):
         {"success": bool, "error": srt, "code": int}.
 
         Raise UnavailableActionError if appropriate for the device.
+        """
+        raise NotImplementedError("The HardwareWalletClient base class "
+                                  "does not implement this method")
+
+    @classmethod
+    def get_features(self) -> 'SupportedFeatures':
+        """
+        Get features.
+
+        Returns an object with a listing of the features supported by this device.
         """
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")

--- a/test/test_ledger.py
+++ b/test/test_ledger.py
@@ -63,41 +63,41 @@ def ledger_test_suite(emulator, rpc, userpass, interface):
             result = self.do_command(self.dev_args + ['promptpin'])
             self.assertIn('error', result)
             self.assertIn('code', result)
-            self.assertEqual(result['error'], 'The Ledger Nano S and X do not need a PIN sent from the host')
+            self.assertEqual(result['error'], 'The Ledger Nano S does not need a PIN sent from the host')
             self.assertEqual(result['code'], -9)
 
             result = self.do_command(self.dev_args + ['sendpin', '1234'])
             self.assertIn('error', result)
             self.assertIn('code', result)
-            self.assertEqual(result['error'], 'The Ledger Nano S and X do not need a PIN sent from the host')
+            self.assertEqual(result['error'], 'The Ledger Nano S does not need a PIN sent from the host')
             self.assertEqual(result['code'], -9)
 
         def test_setup(self):
             result = self.do_command(self.dev_args + ['-i', 'setup'])
             self.assertIn('error', result)
             self.assertIn('code', result)
-            self.assertEqual(result['error'], 'The Ledger Nano S and X do not support software setup')
+            self.assertEqual(result['error'], 'The Ledger Nano S does not support software setup')
             self.assertEqual(result['code'], -9)
 
         def test_wipe(self):
             result = self.do_command(self.dev_args + ['wipe'])
             self.assertIn('error', result)
             self.assertIn('code', result)
-            self.assertEqual(result['error'], 'The Ledger Nano S and X do not support wiping via software')
+            self.assertEqual(result['error'], 'The Ledger Nano S does not support wiping via software')
             self.assertEqual(result['code'], -9)
 
         def test_restore(self):
             result = self.do_command(self.dev_args + ['-i', 'restore'])
             self.assertIn('error', result)
             self.assertIn('code', result)
-            self.assertEqual(result['error'], 'The Ledger Nano S and X do not support restoring via software')
+            self.assertEqual(result['error'], 'The Ledger Nano S does not support restoring via software')
             self.assertEqual(result['code'], -9)
 
         def test_backup(self):
             result = self.do_command(self.dev_args + ['backup'])
             self.assertIn('error', result)
             self.assertIn('code', result)
-            self.assertEqual(result['error'], 'The Ledger Nano S and X do not support creating a backup via software')
+            self.assertEqual(result['error'], 'The Ledger Nano S does not support creating a backup via software')
             self.assertEqual(result['code'], -9)
 
     class TestLedgerGetXpub(DeviceTestCase):


### PR DESCRIPTION
Adds a `getfeatures` command to retrieve the feature support for a given device. The result of this should match the table in the README. To handle the 3 levels of support (supported, not supported by HWI, and not supported by device firmware), a `DeviceFeature` enum is used. We can add more possible levels of support to this in the future. A `SupportedFeatures` class is also added to handle the support listing for a device so that we are sure that no feature is not listed for a given device.

Because some device models that have the same type have different feature support, additional changes are made to have model specific `HWWClient` classes which will have their own feature listings. This will also make it easier in the future to do different things for different models if/when they diverge. In particular, this is used for Trezor 1 and Trezor T as Trezor T has some firmware bugs preventing it from having the same feature set as the Trezor 1.

Closes #273