### PR TITLE
coldcard: Fix needs_pin_sent and needs_passphrase_sent and consolidate simulator enumeration

### DIFF
--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -246,7 +246,8 @@ def enumerate(password=''):
         d_data['type'] = 'coldcard'
         d_data['model'] = 'coldcard'
         d_data['path'] = path
-        d_data['needs_passphrase'] = False
+        d_data['needs_pin_sent'] = False
+        d_data['needs_passphrase_sent'] = False
 
         client = None
         with handle_errors(common_err_msgs["enumerate"], d_data):

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -349,52 +349,42 @@ class LedgerClient(HardwareWalletClient):
 
 def enumerate(password=''):
     results = []
+    devices = []
     for device_id in LEDGER_DEVICE_IDS:
-        for d in hid.enumerate(LEDGER_VENDOR_ID, device_id):
-            if ('interface_number' in d and d['interface_number'] == 0
-                    or ('usage_page' in d and d['usage_page'] == 0xffa0)):
-                d_data = {}
+        devices.extend(hid.enumerate(LEDGER_VENDOR_ID, device_id))
+    devices.append({'path': SIMULATOR_PATH.encode(), 'interface_number': 0, 'product_id': 1})
 
-                path = d['path'].decode()
-                d_data['type'] = 'ledger'
-                d_data['model'] = 'ledger_nano_x' if device_id == 0x0004 else 'ledger_nano_s'
-                d_data['path'] = path
+    for d in devices:
+        if ('interface_number' in d and d['interface_number'] == 0
+                or ('usage_page' in d and d['usage_page'] == 0xffa0)):
+            d_data = {}
 
-                client = None
-                with handle_errors(common_err_msgs["enumerate"], d_data):
+            path = d['path'].decode()
+            d_data['type'] = 'ledger'
+            d_data['model'] = 'ledger_nano_x' if d['product_id'] == 0x0004 else 'ledger_nano_s'
+            d_data['path'] = path
+
+            if path == SIMULATOR_PATH:
+                d_data['model'] += '_simulator'
+
+            client = None
+            with handle_errors(common_err_msgs["enumerate"], d_data):
+                try:
                     client = LedgerClient(path, password)
                     master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
                     d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
                     d_data['needs_pin_sent'] = False
                     d_data['needs_passphrase_sent'] = False
+                except BTChipException:
+                    # Ignore simulator if there's an exception, means it isn't there
+                    if path == SIMULATOR_PATH:
+                        continue
+                    else:
+                        raise
 
-                if client:
-                    client.close()
+            if client:
+                client.close()
 
-                results.append(d_data)
-
-    # Check if the simulator is there
-    client = None
-    try:
-        client = LedgerClient(SIMULATOR_PATH, password)
-
-        d_data = {}
-        d_data['type'] = 'ledger'
-        d_data['model'] = 'ledger_nano_s_simulator'
-        d_data['path'] = SIMULATOR_PATH
-        d_data['needs_pin_sent'] = False
-        d_data['needs_passphrase_sent'] = False
-
-        master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
-        d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
-        d_data['needs_pin_sent'] = False
-        d_data['needs_passphrase_sent'] = False
-
-        results.append(d_data)
-    except BTChipException:
-        pass
-
-    if client:
-        client.close()
+            results.append(d_data)
 
     return results

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -125,7 +125,13 @@ class TestDeviceConnect(DeviceTestCase):
         found = False
         for device in enum_res:
             if (device['type'] == self.type or device['model'] == self.type) and device['path'] == self.path and device['fingerprint'] == self.fingerprint:
+                self.assertIn('type', device)
+                self.assertIn('model', device)
+                self.assertIn('path', device)
+                self.assertIn('needs_pin_sent', device)
+                self.assertIn('needs_passphrase_sent', device)
                 self.assertNotIn('error', device)
+                self.assertNotIn('code', device)
                 found = True
         self.assertTrue(found)
 


### PR DESCRIPTION
`needs_pin_sent` was missing. `needs_passphrase_sent` was misnamed as `needs_passphrase`.

A test has been added to ensure that all enumerate fields are present in the enumerate result. However, because Coldcard and Ledger simulators had separate enumeration logic for simulators, additional changes were made to merge those code paths with the normal enumeration logic. This is achieved by adding the simulator to the list of devices enumerated, and just ignoring it if an error occurs while trying to connect to it so it is ignored if it isn't running.