### PR TITLE
Remove several system libraries from PyInstaller build

### DIFF
--- a/contrib/build.Dockerfile
+++ b/contrib/build.Dockerfile
@@ -33,10 +33,11 @@ RUN apt-get install -y \
 RUN curl https://pyenv.run | bash
 ENV PATH="/root/.pyenv/bin:$PATH"
 COPY contrib/reproducible-python.diff /opt/reproducible-python.diff
+COPY contrib/exclude-zlib.diff /opt/exclude-zlib.diff
 ENV PYTHON_CONFIGURE_OPTS="--enable-shared"
 ENV BUILD_DATE="Jan  1 2019"
 ENV BUILD_TIME="00:00:00"
-RUN eval "$(pyenv init -)" && eval "$(pyenv virtualenv-init -)" && cat /opt/reproducible-python.diff | pyenv install -kp 3.6.8
+RUN eval "$(pyenv init -)" && eval "$(pyenv virtualenv-init -)" && cat /opt/reproducible-python.diff /opt/exclude-zlib.diff | pyenv install -kp 3.6.8
 
 RUN dpkg --add-architecture i386 
 RUN wget -nc https://dl.winehq.org/wine-builds/winehq.key

--- a/contrib/exclude-zlib.diff
+++ b/contrib/exclude-zlib.diff
@@ -1,0 +1,13 @@
+# Don't include zlib
+
+--- setup.py
++++ setup.py
+@@ -1479,7 +1479,7 @@ class PyBuildExt(build_ext):
+ 
+         # Helper module for various ascii-encoders.  Uses zlib for an optimized
+         # crc32 if we have it.  Otherwise binascii uses its own.
+-        if have_zlib:
++        if False:
+             extra_compile_args = ['-DUSE_ZLIB_CRC32']
+             libraries = ['z']
+             extra_link_args = zlib_extra_link_args

--- a/hwi.spec
+++ b/hwi.spec
@@ -14,13 +14,20 @@ elif platform.system() == 'Darwin':
     libusb_path = find_brew_libusb_proc.communicate()[0]
     binaries = [(libusb_path.rstrip().decode() + "/lib/libusb-1.0.dylib", ".")]
 
+excludes = [
+    'zlib',
+    'bz2',
+    'lzma',
+    'readline'
+]
+
 a = Analysis(['hwi.py'],
              binaries=binaries,
              datas=[],
              hiddenimports=[],
              hookspath=['contrib/pyinstaller-hooks/'],
              runtime_hooks=[],
-             excludes=[],
+             excludes=excludes,
              win_no_prefer_redirects=False,
              win_private_assemblies=False,
              cipher=block_cipher,


### PR DESCRIPTION
PyInstaller was including a bunch of system libraries that we don't need. Removing them makes the final build smaller and lets us not have to worry about them when it comes to reproducibility. These libraries are not used by HWI but are imported by python built-ins that we aren't using. These all have handling for the libraries not being there so it is fine to exclude them.

The libraries being excluded are:
* libz
* libbz2
* libzma
* libreadline

libz (zlib) has to be handled more specially when python is being built during the docker container setup. The python compilation will include it if it detects it, so we apply an additional patch to CPython for it to not do that.