### PR TITLE
Add get fingerprint function to device class

### DIFF
--- a/hwilib/base58.py
+++ b/hwilib/base58.py
@@ -82,11 +82,6 @@ def get_xpub_fingerprint_hex(xpub: str) -> str:
     fingerprint = data[5:9]
     return hexlify(fingerprint).decode()
 
-def get_xpub_fingerprint_as_id(xpub: str) -> str:
-    data = decode(xpub)
-    fingerprint = data[5:9]
-    return hexlify(fingerprint).decode()
-
 def to_address(b: bytes, version: bytes) -> str:
     data = version + b
     checksum = hash256(data)[0:4]

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -6,7 +6,7 @@ import importlib
 import platform
 
 from .serializations import PSBT
-from .base58 import get_xpub_fingerprint_as_id, get_xpub_fingerprint_hex, xpub_to_pub_hex
+from .base58 import xpub_to_pub_hex
 from .errors import UnknownDeviceError, BAD_ARGUMENT, NOT_IMPLEMENTED
 from .descriptor import Descriptor
 from .devices import __all__ as all_devs
@@ -53,15 +53,12 @@ def find_device(password='', device_type=None, fingerprint=None, expert=False):
 
             master_fpr = d.get('fingerprint', None)
             if master_fpr is None:
-                master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
-                master_fpr = get_xpub_fingerprint_hex(master_xpub)
+                master_fpr = client.get_master_fingerprint_hex()
 
             if fingerprint and master_fpr != fingerprint:
                 client.close()
                 continue
-            else:
-                client.fingerprint = master_fpr
-                return client
+            return client
         except:
             if client:
                 client.close()
@@ -88,11 +85,11 @@ def getkeypool_inner(client, path, start, end, internal=False, keypool=True, acc
         return {'error': 'Both `--wpkh` and `--sh_wpkh` can not be selected at the same time.', 'code': BAD_ARGUMENT}
 
     try:
-        master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
+        master_fpr = client.get_master_fingerprint_hex()
     except NotImplementedError as e:
         return {'error': str(e), 'code': NOT_IMPLEMENTED}
 
-    desc = getdescriptor(client, master_xpub, client.is_testnet, path, internal, sh_wpkh, wpkh, account, start, end)
+    desc = getdescriptor(client, master_fpr, client.is_testnet, path, internal, sh_wpkh, wpkh, account, start, end)
 
     if not isinstance(desc, Descriptor):
         return desc
@@ -107,8 +104,7 @@ def getkeypool_inner(client, path, start, end, internal=False, keypool=True, acc
     this_import['watchonly'] = True
     return [this_import]
 
-def getdescriptor(client, master_xpub, testnet=False, path=None, internal=False, sh_wpkh=False, wpkh=True, account=0, start=None, end=None):
-    master_fpr = get_xpub_fingerprint_as_id(master_xpub)
+def getdescriptor(client, master_fpr, testnet=False, path=None, internal=False, sh_wpkh=False, wpkh=True, account=0, start=None, end=None):
     testnet = client.is_testnet
 
     if not path:
@@ -175,7 +171,7 @@ def getkeypool(client, path, start, end, internal=False, keypool=True, account=0
 
 def getdescriptors(client, account=0):
     try:
-        master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
+        master_fpr = client.get_master_fingerprint_hex()
     except NotImplementedError as e:
         return {'error': str(e), 'code': NOT_IMPLEMENTED}
 
@@ -183,9 +179,9 @@ def getdescriptors(client, account=0):
 
     for internal in [False, True]:
         descriptors = []
-        desc1 = getdescriptor(client, master_xpub=master_xpub, testnet=client.is_testnet, internal=internal, sh_wpkh=False, wpkh=False, account=account)
-        desc2 = getdescriptor(client, master_xpub=master_xpub, testnet=client.is_testnet, internal=internal, sh_wpkh=True, wpkh=False, account=account)
-        desc3 = getdescriptor(client, master_xpub=master_xpub, testnet=client.is_testnet, internal=internal, sh_wpkh=False, wpkh=True, account=account)
+        desc1 = getdescriptor(client, master_fpr=master_fpr, testnet=client.is_testnet, internal=internal, sh_wpkh=False, wpkh=False, account=account)
+        desc2 = getdescriptor(client, master_fpr=master_fpr, testnet=client.is_testnet, internal=internal, sh_wpkh=True, wpkh=False, account=account)
+        desc3 = getdescriptor(client, master_fpr=master_fpr, testnet=client.is_testnet, internal=internal, sh_wpkh=False, wpkh=True, account=account)
         for desc in [desc1, desc2, desc3]:
             if not isinstance(desc, Descriptor):
                 return desc
@@ -203,10 +199,6 @@ def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False):
             return {'error': 'Both `--wpkh` and `--sh_wpkh` can not be selected at the same time.', 'code': BAD_ARGUMENT}
         return client.display_address(path, sh_wpkh, wpkh)
     elif desc is not None:
-        if client.fingerprint is None:
-            master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
-            client.fingerprint = get_xpub_fingerprint_hex(master_xpub)
-
         if sh_wpkh or wpkh:
             return {'error': ' `--wpkh` and `--sh_wpkh` can not be combined with --desc', 'code': BAD_ARGUMENT}
         descriptor = Descriptor.parse(desc, client.is_testnet)
@@ -214,7 +206,7 @@ def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False):
             return {'error': 'Unable to parse descriptor: ' + desc, 'code': BAD_ARGUMENT}
         if descriptor.m_path is None:
             return {'error': 'Descriptor missing origin info: ' + desc, 'code': BAD_ARGUMENT}
-        if descriptor.origin_fingerprint != client.fingerprint:
+        if descriptor.origin_fingerprint != client.get_master_fingerprint_hex():
             return {'error': 'Descriptor fingerprint does not match device: ' + desc, 'code': BAD_ARGUMENT}
         xpub = client.get_pubkey_at_path(descriptor.m_path_base)['xpub']
         if descriptor.base_key != xpub and descriptor.base_key != xpub_to_pub_hex(xpub):

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -64,7 +64,7 @@ class ColdcardClient(HardwareWalletClient):
             result.update(xpub_obj.get_printable_dict())
         return result
 
-    def _get_fingerprint_hex(self):
+    def get_master_fingerprint_hex(self):
         # quick method to get fingerprint of wallet
         return hexlify(struct.pack('<I', self.device.master_fingerprint)).decode()
 
@@ -263,7 +263,7 @@ def enumerate(password=''):
         with handle_errors(common_err_msgs["enumerate"], d_data):
             try:
                 client = ColdcardClient(path)
-                d_data['fingerprint'] = client._get_fingerprint_hex()
+                d_data['fingerprint'] = client.get_master_fingerprint_hex()
             except RuntimeError as e:
                 # Skip the simulator if it's not there
                 if str(e) == 'Cannot connect to simulator. Is it running?':

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -17,7 +17,7 @@ import time
 from ..hwwclient import HardwareWalletClient
 from ..errors import ActionCanceledError, BadArgumentError, DeviceFailureError, DeviceAlreadyInitError, DEVICE_NOT_INITIALIZED, DeviceNotReadyError, NoPasswordError, UnavailableActionError, common_err_msgs, handle_errors
 from ..serializations import CTransaction, ExtendedKey, hash256, ser_sig_der, ser_sig_compact, ser_compact_size
-from ..base58 import get_xpub_fingerprint, xpub_main_2_test, get_xpub_fingerprint_hex
+from ..base58 import get_xpub_fingerprint, xpub_main_2_test
 
 applen = 225280 # flash size minus bootloader length
 chunksize = 8 * 512
@@ -616,8 +616,7 @@ def enumerate(password=''):
                     d_data['error'] = 'Not initialized'
                     d_data['code'] = DEVICE_NOT_INITIALIZED
                 else:
-                    master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
-                    d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
+                    d_data['fingerprint'] = client.get_master_fingerprint_hex()
                 d_data['needs_pin_sent'] = False
                 d_data['needs_passphrase_sent'] = True
 

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -3,7 +3,6 @@
 from ..errors import DEVICE_NOT_INITIALIZED, DeviceNotReadyError, common_err_msgs, handle_errors
 from .trezorlib.transport import enumerate_devices, KEEPKEY_VENDOR_IDS
 from .trezor import TrezorClient
-from ..base58 import get_xpub_fingerprint_hex
 
 py_enumerate = enumerate # Need to use the enumerate built-in but there's another function already named that
 
@@ -43,8 +42,7 @@ def enumerate(password=''):
             if d_data['needs_passphrase_sent'] and not password:
                 raise DeviceNotReadyError("Passphrase needs to be specified before the fingerprint information can be retrieved")
             if client.client.features.initialized:
-                master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
-                d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
+                d_data['fingerprint'] = client.get_master_fingerprint_hex()
                 d_data['needs_passphrase_sent'] = False # Passphrase is always needed for the above to have worked, so it's already sent
             else:
                 d_data['error'] = 'Not initialized'

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -11,7 +11,6 @@ import base64
 import hid
 import struct
 from .. import base58
-from ..base58 import get_xpub_fingerprint_hex
 from ..serializations import ExtendedKey, hash256, hash160, CTransaction
 import logging
 import re
@@ -378,8 +377,7 @@ def enumerate(password=''):
             with handle_errors(common_err_msgs["enumerate"], d_data):
                 try:
                     client = LedgerClient(path, password)
-                    master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
-                    d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
+                    d_data['fingerprint'] = client.get_master_fingerprint_hex()
                     d_data['needs_pin_sent'] = False
                     d_data['needs_passphrase_sent'] = False
                 except BTChipException:

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -9,7 +9,7 @@ from .trezorlib.transport import enumerate_devices, get_transport, TREZOR_VENDOR
 from .trezorlib.ui import echo, PassphraseUI, mnemonic_words, PIN_CURRENT, PIN_NEW, PIN_CONFIRM, PIN_MATRIX_DESCRIPTION, prompt
 from .trezorlib import tools, btc, device
 from .trezorlib import messages as proto
-from ..base58 import get_xpub_fingerprint, to_address, xpub_main_2_test, get_xpub_fingerprint_hex
+from ..base58 import get_xpub_fingerprint, to_address, xpub_main_2_test
 from ..serializations import CTxOut, ExtendedKey, ser_uint256
 from .. import bech32
 from usb1 import USBErrorNoDevice
@@ -467,8 +467,7 @@ def enumerate(password=''):
             if d_data['needs_passphrase_sent'] and not password:
                 raise DeviceNotReadyError("Passphrase needs to be specified before the fingerprint information can be retrieved")
             if client.client.features.initialized:
-                master_xpub = client.get_pubkey_at_path('m/0h')['xpub']
-                d_data['fingerprint'] = get_xpub_fingerprint_hex(master_xpub)
+                d_data['fingerprint'] = client.get_master_fingerprint_hex()
                 d_data['needs_passphrase_sent'] = False # Passphrase is always needed for the above to have worked, so it's already sent
             else:
                 d_data['error'] = 'Not initialized'

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -1,3 +1,5 @@
+from .base58 import get_xpub_fingerprint_hex
+
 # This is an abstract class that defines all of the methods that each Hardware
 # wallet subclass must implement.
 class HardwareWalletClient(object):
@@ -15,6 +17,11 @@ class HardwareWalletClient(object):
     # Get the master BIP 44 pubkey
     def get_master_xpub(self):
         return self.get_pubkey_at_path('m/44\'/0\'/0\'')
+
+    # Get the master fingerprint
+    def get_master_fingerprint_hex(self):
+        master_xpub = self.get_pubkey_at_path('m/0h')['xpub']
+        return get_xpub_fingerprint_hex(master_xpub)
 
     # Must return a dict with the xpub
     # Retrieves the public key at the specified BIP 32 derivation path


### PR DESCRIPTION
As pre-work for the bitbox02 integration, add a function to the device class to get the master fingerprint. It can later be overloaded by the bitbox02 definitions.

Also removes the `get_xpub_fingerprint_as_id` function, since it does the same as `get_xpub_fingerprint_hex`.