### PR TITLE
Doc: Readme: mention calling --help after command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ All output will be in JSON form and sent to `stdout`.
 Additional information or prompts will be sent to `stderr` and will not necessarily be in JSON.
 This additional information is for debugging purposes.
 
+To see a complete list of available commands and global parameters, run
+`./hwi.py --help`.  To see options specific to a particular command,
+pass the `--help` parameter after the command name; for example:
+
+```
+./hwi.py getdescriptors --help
+```
+
 ## Device Support
 
 The below table lists what devices and features are supported for each device.


### PR DESCRIPTION
Reading through the tutorials, it was apparent to me that commands could accept parameters that weren't documented in the main `--help` text, but it was unclear to me how I could learn about those parameters without reading the source code; after some digging I figured it out and so this PR adds a short description to the readme about how to use the help.