### PR TITLE
tests: Add missing self.seen_msg_hash to speculos patch

### DIFF
--- a/test/data/speculos-auto-button.patch
+++ b/test/data/speculos-auto-button.patch
@@ -1,14 +1,14 @@
-From bd251085fa85ad20e90fa055e7487b5c73d3dc7d Mon Sep 17 00:00:00 2001
+From 5622600c3cd28b4eb1fc7b6bb29e5b906674339e Mon Sep 17 00:00:00 2001
 From: Andrew Chow <achow101-github@achow101.com>
 Date: Thu, 12 Mar 2020 17:25:09 -0400
 Subject: [PATCH] Do button presses within seproxyhal
 
 ---
- mcu/seproxyhal.py | 34 ++++++++++++++++++++++++++++++++++
- 1 file changed, 34 insertions(+)
+ mcu/seproxyhal.py | 35 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 35 insertions(+)
 
 diff --git a/mcu/seproxyhal.py b/mcu/seproxyhal.py
-index 8ed3fec..1a6bfb6 100644
+index 8ed3fec..77d3ede 100644
 --- a/mcu/seproxyhal.py
 +++ b/mcu/seproxyhal.py
 @@ -2,6 +2,7 @@ import binascii
@@ -19,7 +19,15 @@ index 8ed3fec..1a6bfb6 100644
  import sys
  import time
  import threading
-@@ -144,6 +145,39 @@ class SeProxyHal:
+@@ -58,6 +59,7 @@ class SeProxyHal:
+         self.status_received = True
+         self.usb = usb.USB(self._queue_event_packet)
+         self.logger = logging.getLogger("seproxyhal")
++        self.seen_msg_hash = False
+ 
+     def _recvall(self, size):
+         data = b''
+@@ -144,6 +146,39 @@ class SeProxyHal:
                  #self.logger.debug(f"DISPLAY_STATUS {data!r}")
                  screen.display_status(data)
                  self._queue_event_packet(SephTag.DISPLAY_PROCESSED_EVENT)


### PR DESCRIPTION
This was missing and could cause problems in the future. We appear to not run into issues with it due to test order.