### PR TITLE
tests: emulator logging and speculos updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ pip-wheel-metadata
 # Qt stuff
 hwiqt.pyproject.user
 hwilib/ui/ui_*.py
+
+*.stderr
+*.stdout

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,8 @@ install:
     - cd test; ./setup_environment.sh; cd ..
     - pip uninstall -y trezor # Hack to get rid of master branch version of trezor that is installed for trezor-mcu build
     - poetry install
+after_failure:
+    - tail -v -n +1 *.std*
 jobs:
     include:
         -   name: lint

--- a/test/data/speculos-auto-button.patch
+++ b/test/data/speculos-auto-button.patch
@@ -1,4 +1,4 @@
-From 5622600c3cd28b4eb1fc7b6bb29e5b906674339e Mon Sep 17 00:00:00 2001
+From b3156bb4705a55dd03fe40465bd5574c472ba335 Mon Sep 17 00:00:00 2001
 From: Andrew Chow <achow101-github@achow101.com>
 Date: Thu, 12 Mar 2020 17:25:09 -0400
 Subject: [PATCH] Do button presses within seproxyhal
@@ -8,7 +8,7 @@ Subject: [PATCH] Do button presses within seproxyhal
  1 file changed, 35 insertions(+)
 
 diff --git a/mcu/seproxyhal.py b/mcu/seproxyhal.py
-index 8ed3fec..77d3ede 100644
+index fffba52..462456a 100644
 --- a/mcu/seproxyhal.py
 +++ b/mcu/seproxyhal.py
 @@ -2,6 +2,7 @@ import binascii
@@ -19,18 +19,18 @@ index 8ed3fec..77d3ede 100644
  import sys
  import time
  import threading
-@@ -58,6 +59,7 @@ class SeProxyHal:
-         self.status_received = True
-         self.usb = usb.USB(self._queue_event_packet)
-         self.logger = logging.getLogger("seproxyhal")
+@@ -129,6 +130,7 @@ class SeProxyHal:
+                                               daemon=True)
+         self.ticker_thread.start()
+         self.usb = usb.USB(self.packet_thread.queue_packet)
 +        self.seen_msg_hash = False
  
      def _recvall(self, size):
          data = b''
-@@ -144,6 +146,39 @@ class SeProxyHal:
+@@ -168,6 +170,39 @@ class SeProxyHal:
                  #self.logger.debug(f"DISPLAY_STATUS {data!r}")
                  screen.display_status(data)
-                 self._queue_event_packet(SephTag.DISPLAY_PROCESSED_EVENT)
+                 self.packet_thread.queue_packet(SephTag.DISPLAY_PROCESSED_EVENT, priority=True)
 +                data_type, _, x, y, = struct.unpack('bbhh', data[:6])
 +                if data_type == 7:
 +                    if y == 12 or y ==28:

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -87,17 +87,17 @@ if args.trezor or args.trezor_t or args.coldcard or args.ledger or args.keepkey 
     # Start bitcoind
     rpc, userpass = start_bitcoind(args.bitcoind)
 
-    if args.bitbox:
+    if success and args.bitbox:
         success &= digitalbitbox_test_suite(args.bitbox_path, rpc, userpass, args.interface)
-    if args.coldcard:
+    if success and args.coldcard:
         success &= coldcard_test_suite(args.coldcard_path, rpc, userpass, args.interface)
-    if args.trezor:
+    if success and args.trezor:
         success &= trezor_test_suite(args.trezor_path, rpc, userpass, args.interface)
-    if args.trezor_t:
+    if success and args.trezor_t:
         success &= trezor_test_suite(args.trezor_t_path, rpc, userpass, args.interface, True)
-    if args.keepkey:
+    if success and args.keepkey:
         success &= keepkey_test_suite(args.keepkey_path, rpc, userpass, args.interface)
-    if args.ledger:
+    if success and args.ledger:
         success &= ledger_test_suite(args.ledger_path, rpc, userpass, args.interface)
 
 sys.exit(not success)

--- a/test/test_coldcard.py
+++ b/test/test_coldcard.py
@@ -13,8 +13,13 @@ from hwilib.cli import process_commands
 from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestDisplayAddress, TestGetKeypool, TestGetDescriptors, TestSignMessage, TestSignTx
 
 def coldcard_test_suite(simulator, rpc, userpass, interface):
+    try:
+        os.unlink('coldcard-emulator.stdout')
+    except FileNotFoundError:
+        pass
+    coldcard_log = open('coldcard-emulator.stdout', 'a')
     # Start the Coldcard simulator
-    coldcard_proc = subprocess.Popen(['python3', os.path.basename(simulator), '--ms'], cwd=os.path.dirname(simulator), stdout=subprocess.DEVNULL, preexec_fn=os.setsid)
+    coldcard_proc = subprocess.Popen(['python3', os.path.basename(simulator), '--ms'], cwd=os.path.dirname(simulator), stdout=coldcard_log, preexec_fn=os.setsid)
     # Wait for simulator to be up
     while True:
         try:
@@ -35,6 +40,7 @@ def coldcard_test_suite(simulator, rpc, userpass, interface):
         if coldcard_proc.poll() is None:
             os.killpg(os.getpgid(coldcard_proc.pid), signal.SIGTERM)
             os.waitpid(os.getpgid(coldcard_proc.pid), 0)
+        coldcard_log.close()
     atexit.register(cleanup_simulator)
 
     # Coldcard specific management command tests

--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -14,8 +14,13 @@ from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestG
 from hwilib.devices.digitalbitbox import BitboxSimulator, send_plain, send_encrypt
 
 def digitalbitbox_test_suite(simulator, rpc, userpass, interface):
+    try:
+        os.unlink('bitbox-emulator.stderr')
+    except FileNotFoundError:
+        pass
+    bitbox_log = open('bitbox-emulator.stderr', 'a')
     # Start the Digital bitbox simulator
-    simulator_proc = subprocess.Popen(['./' + os.path.basename(simulator), '../../tests/sd_files/'], cwd=os.path.dirname(simulator), stderr=subprocess.DEVNULL)
+    simulator_proc = subprocess.Popen(['./' + os.path.basename(simulator), '../../tests/sd_files/'], cwd=os.path.dirname(simulator), stderr=bitbox_log)
     # Wait for simulator to be up
     while True:
         try:
@@ -31,6 +36,7 @@ def digitalbitbox_test_suite(simulator, rpc, userpass, interface):
     def cleanup_simulator():
         simulator_proc.terminate()
         simulator_proc.wait()
+        bitbox_log.close()
     atexit.register(cleanup_simulator)
 
     # Set password and load from backup

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -32,10 +32,16 @@ class KeepkeyEmulator(DeviceEmulator):
     def __init__(self, path):
         self.emulator_path = path
         self.emulator_proc = None
+        self.keepkey_log = None
+        try:
+            os.unlink('keepkey-emulator.stdout')
+        except FileNotFoundError:
+            pass
 
     def start(self):
+        self.keepkey_log = open('keepkey-emulator.stdout', 'a')
         # Start the Keepkey emulator
-        self.emulator_proc = subprocess.Popen(['./' + os.path.basename(self.emulator_path)], cwd=os.path.dirname(self.emulator_path), stdout=subprocess.DEVNULL)
+        self.emulator_proc = subprocess.Popen(['./' + os.path.basename(self.emulator_path)], cwd=os.path.dirname(self.emulator_path), stdout=self.keepkey_log)
         # Wait for emulator to be up
         # From https://github.com/trezor/trezor-mcu/blob/master/script/wait_for_emulator.py
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -71,6 +77,9 @@ class KeepkeyEmulator(DeviceEmulator):
         emulator_img = os.path.dirname(self.emulator_path) + "/emulator.img"
         if os.path.isfile(emulator_img):
             os.unlink(emulator_img)
+
+        if self.keepkey_log is not None:
+            self.keepkey_log.close()
 
         atexit.unregister(self.stop)
 

--- a/test/test_ledger.py
+++ b/test/test_ledger.py
@@ -53,7 +53,7 @@ class LedgerEmulator(DeviceEmulator):
         if self.emulator_stdout is not None:
             self.emulator_stdout.close()
 
-def ledger_test_suite(emulator, rpc, userpass, interface, signtx=False):
+def ledger_test_suite(emulator, rpc, userpass, interface):
 
     # Ledger specific disabled command tests
     class TestLedgerDisabledCommands(DeviceTestCase):
@@ -127,8 +127,7 @@ def ledger_test_suite(emulator, rpc, userpass, interface, signtx=False):
     suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestSignMessage, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
-    if signtx:
-        suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
 
     result = unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)
     dev_emulator.stop()
@@ -140,11 +139,10 @@ if __name__ == '__main__':
     parser.add_argument('emulator', help='Path to the ledger emulator')
     parser.add_argument('bitcoind', help='Path to bitcoind binary')
     parser.add_argument('--interface', help='Which interface to send commands over', choices=['library', 'cli', 'bindist'], default='library')
-    parser.add_argument('--signtx', help='Run the transaction signing tests too', action='store_true')
 
     args = parser.parse_args()
 
     # Start bitcoind
     rpc, userpass = start_bitcoind(args.bitcoind)
 
-    sys.exit(not ledger_test_suite(args.emulator, rpc, userpass, args.interface, args.signtx))
+    sys.exit(not ledger_test_suite(args.emulator, rpc, userpass, args.interface))


### PR DESCRIPTION
Instead of redirecting the output of the emulators to /dev/null, redirect them to log files. If travis fails, print out those log files.

Speculos has pushed a fix for the timeout issues that we were seeing. Something about race conditions. So the Ledger tests should no longer timeout. Our patch to Speculos needs to be updated because of this fix. This also means that we can enable the signtx tests, so those have been enabled for Ledger as well.