### PR TITLE
Support setting word count for `restore_device`

### DIFF
--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -42,7 +42,7 @@ def getdescriptors_handler(args, client):
 
 def restore_device_handler(args, client):
     if args.interactive:
-        return restore_device(client, label=args.label)
+        return restore_device(client, label=args.label, word_count=args.word_count)
     return {'error': 'restore requires interactive mode', 'code': UNAVAILABLE_ACTION}
 
 def setup_device_handler(args, client):
@@ -166,6 +166,7 @@ def process_commands(cli_args):
     wipedev_parser.set_defaults(func=wipe_device_handler)
 
     restore_parser = subparsers.add_parser('restore', help='Initiate the device restoring process. Requires interactive mode')
+    restore_parser.add_argument('--word_count', '-w', help='Word count of your BIP39 recovery phrase (options: 12/18/24)', type=int, default=24)
     restore_parser.add_argument('--label', '-l', help='The name to give to the device', default='')
     restore_parser.set_defaults(func=restore_device_handler)
 

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -228,8 +228,8 @@ def setup_device(client, label='', backup_passphrase=''):
 def wipe_device(client):
     return client.wipe_device()
 
-def restore_device(client, label):
-    return client.restore_device(label)
+def restore_device(client, label='', word_count=24):
+    return client.restore_device(label, word_count)
 
 def backup_device(client, label='', backup_passphrase=''):
     return client.backup_device(label, backup_passphrase)

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -197,7 +197,7 @@ class ColdcardClient(HardwareWalletClient):
         raise UnavailableActionError('The Coldcard does not support wiping via software')
 
     # Restore device from mnemonic or xprv
-    def restore_device(self, label=''):
+    def restore_device(self, label='', word_count=24):
         raise UnavailableActionError('The Coldcard does not support restoring via software')
 
     # Begin backup process

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -553,7 +553,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         return {'success': True}
 
     # Restore device from mnemonic or xprv
-    def restore_device(self, label=''):
+    def restore_device(self, label='', word_count=24):
         raise UnavailableActionError('The Digital Bitbox does not support restoring via software')
 
     # Begin backup process

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -335,7 +335,7 @@ class LedgerClient(HardwareWalletClient):
         raise UnavailableActionError('The Ledger Nano S and X do not support wiping via software')
 
     # Restore device from mnemonic or xprv
-    def restore_device(self, label=''):
+    def restore_device(self, label='', word_count=24):
         raise UnavailableActionError('The Ledger Nano S and X do not support restoring via software')
 
     # Begin backup process

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -385,13 +385,13 @@ class TrezorClient(HardwareWalletClient):
 
     # Restore device from mnemonic or xprv
     @trezor_exception
-    def restore_device(self, label=''):
+    def restore_device(self, label='', word_count=24):
         self.client.init_device()
         if not self.simulator:
             # Use interactive_get_pin
             self.client.ui.get_pin = MethodType(interactive_get_pin, self.client.ui)
 
-        device.recover(self.client, label=label, input_callback=mnemonic_words(), passphrase_protection=bool(self.password))
+        device.recover(self.client, word_count=word_count, label=label, input_callback=mnemonic_words(), passphrase_protection=bool(self.password))
         return {'success': True}
 
     # Begin backup process

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -45,7 +45,7 @@ class HardwareWalletClient(object):
                                   'implement this method')
 
     # Restore device from mnemonic or xprv
-    def restore_device(self, label=''):
+    def restore_device(self, label='', word_count=24):
         raise NotImplementedError('The HardwareWalletClient base class does not implement this method')
 
     # Begin backup process


### PR DESCRIPTION
The current behavior of the `restore` command does not allow the user to select the word count of the seed phrased, despite the code already supporting this for Trezor and KeepKey.

This PR adds the option to pass a `word_count` parameter to the `restore` command. 
The CLI command will accept this input as `--word_count`/ `-w` parameter.
The default remains 24 and the possible options remain 12, 18 or 24 (as the code already approves of).

