### PR TITLE
Support Trezor and KeepKey toggle passphrase protection

### DIFF
--- a/docs/keepkey.md
+++ b/docs/keepkey.md
@@ -13,6 +13,7 @@ Current implemented commands are:
 - `signtx`
 - `displayaddress`
 - `signmessage`
+- `togglepassphrase`
 
 ## `signtx` Caveats
 

--- a/docs/trezor.md
+++ b/docs/trezor.md
@@ -12,6 +12,7 @@ Current implemented commands are:
 - `wipe`
 - `restore`
 - `backup`
+- `togglepassphrase`
 
 ## `signtx` Caveats
 

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 
 from .commands import backup_device, displayaddress, enumerate, find_device, \
-    get_client, getmasterxpub, getxpub, getkeypool, getdescriptors, prompt_pin, restore_device, send_pin, setup_device, \
+    get_client, getmasterxpub, getxpub, getkeypool, getdescriptors, prompt_pin, toggle_passphrase, restore_device, send_pin, setup_device, \
     signmessage, signtx, wipe_device, install_udev_rules
 from .errors import (
     handle_errors,
@@ -61,6 +61,9 @@ def wipe_device_handler(args, client):
 
 def prompt_pin_handler(args, client):
     return prompt_pin(client)
+
+def toggle_passphrase_handler(args, client):
+    return toggle_passphrase(client)
 
 def send_pin_handler(args, client):
     return send_pin(client, pin=args.pin)
@@ -176,6 +179,9 @@ def process_commands(cli_args):
 
     promptpin_parser = subparsers.add_parser('promptpin', help='Have the device prompt for your PIN')
     promptpin_parser.set_defaults(func=prompt_pin_handler)
+
+    togglepassphrase_parser = subparsers.add_parser('togglepassphrase', help='Toggle BIP39 passphrase protection')
+    togglepassphrase_parser.set_defaults(func=toggle_passphrase_handler)
 
     sendpin_parser = subparsers.add_parser('sendpin', help='Send the numeric positions for your PIN to the device')
     sendpin_parser.add_argument('pin', help='The numeric positions of the PIN')

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -240,6 +240,9 @@ def prompt_pin(client):
 def send_pin(client, pin):
     return client.send_pin(pin)
 
+def toggle_passphrase(client):
+    return client.toggle_passphrase()
+
 def install_udev_rules(source, location):
     if platform.system() == "Linux":
         from .udevinstaller import UDevInstaller

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -242,6 +242,10 @@ class ColdcardClient(HardwareWalletClient):
     def send_pin(self, pin):
         raise UnavailableActionError('The Coldcard does not need a PIN sent from the host')
 
+    # Toggle passphrase
+    def toggle_passphrase(self):
+        raise UnavailableActionError('The Coldcard does not support toggling passphrase from the host')
+
 def enumerate(password=''):
     results = []
     devices = hid.enumerate(COINKITE_VID, CKCC_PID)

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -583,6 +583,10 @@ class DigitalbitboxClient(HardwareWalletClient):
     def send_pin(self, pin):
         raise UnavailableActionError('The Digital Bitbox does not need a PIN sent from the host')
 
+    # Toggle passphrase
+    def toggle_passphrase(self):
+        raise UnavailableActionError('The Digital Bitbox does not support toggling passphrase from the host')
+
 def enumerate(password=''):
     results = []
     devices = hid.enumerate(DBB_VENDOR_ID, DBB_DEVICE_ID)

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -354,6 +354,10 @@ class LedgerClient(HardwareWalletClient):
     def send_pin(self, pin):
         raise UnavailableActionError('The Ledger Nano S and X do not need a PIN sent from the host')
 
+    # Toggle passphrase
+    def toggle_passphrase(self):
+        raise UnavailableActionError('The Ledger Nano S and X do not support toggling passphrase from the host')
+
 def enumerate(password=''):
     results = []
     devices = []

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -434,6 +434,12 @@ class TrezorClient(HardwareWalletClient):
             return {'success': False}
         return {'success': True}
 
+    # Toggle passphrase
+    @trezor_exception
+    def toggle_passphrase(self):
+        self._check_unlocked()
+        return device.apply_settings(self.client, use_passphrase=not self.client.features.passphrase_protection)
+
 def enumerate(password=''):
     results = []
     for dev in enumerate_devices():

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -64,3 +64,7 @@ class HardwareWalletClient(object):
     # Send pin
     def send_pin(self):
         raise NotImplementedError('The HardwareWalletClient base class does not implement this method')
+
+    # Toggle passphrase
+    def toggle_passphrase(self):
+        raise NotImplementedError('The HardwareWalletClient base class does not implement this method')

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -258,24 +258,8 @@ class TestKeepkeyManCommands(KeepkeyTestCase):
         self.assertEqual(result['code'], -11)
 
     def test_passphrase(self):
-        # There's no passphrase
-        result = self.do_command(self.dev_args + ['enumerate'])
-        for dev in result:
-            if dev['type'] == 'keepkey' and dev['path'] == 'udp:127.0.0.1:21324':
-                self.assertFalse(dev['needs_passphrase_sent'])
-                self.assertEquals(dev['fingerprint'], '95d8f670')
-        # Setting a passphrase won't change the fingerprint
-        result = self.do_command(self.dev_args + ['-p', 'pass', 'enumerate'])
-        for dev in result:
-            if dev['type'] == 'keepkey' and dev['path'] == 'udp:127.0.0.1:21324':
-                self.assertFalse(dev['needs_passphrase_sent'])
-                self.assertEquals(dev['fingerprint'], '95d8f670')
-
-        # Set a passphrase
-        device.wipe(self.client)
-        self.client.set_passphrase('pass')
-        load_device_by_mnemonic(client=self.client, mnemonic='alcohol woman abuse must during monitor noble actual mixed trade anger aisle', pin='', passphrase_protection=True, label='test')
-        self.client.call(messages.ClearSession())
+        # Enable passphrase
+        self.do_command(self.dev_args + ['togglepassphrase'])
 
         # A passphrase will need to be sent
         result = self.do_command(self.dev_args + ['enumerate'])
@@ -301,6 +285,22 @@ class TestKeepkeyManCommands(KeepkeyTestCase):
             if dev['type'] == 'keepkey' and dev['path'] == 'udp:127.0.0.1:21324':
                 self.assertFalse(dev['needs_passphrase_sent'])
                 self.assertNotEqual(dev['fingerprint'], fpr)
+
+        # Disable passphrase
+        self.do_command(self.dev_args + ['togglepassphrase'])
+
+        # There's no passphrase
+        result = self.do_command(self.dev_args + ['enumerate'])
+        for dev in result:
+            if dev['type'] == 'keepkey' and dev['path'] == 'udp:127.0.0.1:21324':
+                self.assertFalse(dev['needs_passphrase_sent'])
+                self.assertEquals(dev['fingerprint'], '95d8f670')
+        # Setting a passphrase won't change the fingerprint
+        result = self.do_command(self.dev_args + ['-p', 'pass', 'enumerate'])
+        for dev in result:
+            if dev['type'] == 'keepkey' and dev['path'] == 'udp:127.0.0.1:21324':
+                self.assertFalse(dev['needs_passphrase_sent'])
+                self.assertEquals(dev['fingerprint'], '95d8f670')
 
 def keepkey_test_suite(emulator, rpc, userpass, interface):
     # Redirect stderr to /dev/null as it's super spammy

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -266,23 +266,8 @@ class TestTrezorManCommands(TrezorTestCase):
         self.assertEqual(result['code'], -11)
 
     def test_passphrase(self):
-        # There's no passphrase
-        result = self.do_command(self.dev_args + ['enumerate'])
-        for dev in result:
-            if dev['type'] == 'trezor' and dev['path'] == 'udp:127.0.0.1:21324':
-                self.assertFalse(dev['needs_passphrase_sent'])
-                self.assertEquals(dev['fingerprint'], '95d8f670')
-        # Setting a passphrase won't change the fingerprint
-        result = self.do_command(self.dev_args + ['-p', 'pass', 'enumerate'])
-        for dev in result:
-            if dev['type'] == 'trezor' and dev['path'] == 'udp:127.0.0.1:21324':
-                self.assertFalse(dev['needs_passphrase_sent'])
-                self.assertEquals(dev['fingerprint'], '95d8f670')
-
-        # Set a passphrase
-        device.wipe(self.client)
-        load_device_by_mnemonic(client=self.client, mnemonic='alcohol woman abuse must during monitor noble actual mixed trade anger aisle', pin='', passphrase_protection=True, label='test')
-        self.client.call(messages.ClearSession())
+        # Enable passphrase
+        self.do_command(self.dev_args + ['togglepassphrase'])
 
         # A passphrase will need to be sent
         result = self.do_command(self.dev_args + ['enumerate'])
@@ -317,6 +302,22 @@ class TestTrezorManCommands(TrezorTestCase):
             if dev['type'] == 'trezor' and dev['path'] == 'udp:127.0.0.1:21324':
                 self.assertFalse(dev['needs_passphrase_sent'])
                 self.assertNotEqual(dev['fingerprint'], fpr)
+
+        # Disable passphrase
+        self.do_command(self.dev_args + ['togglepassphrase'])
+
+        # There's no passphrase
+        result = self.do_command(self.dev_args + ['enumerate'])
+        for dev in result:
+            if dev['type'] == 'trezor' and dev['path'] == 'udp:127.0.0.1:21324':
+                self.assertFalse(dev['needs_passphrase_sent'])
+                self.assertEquals(dev['fingerprint'], '95d8f670')
+        # Setting a passphrase won't change the fingerprint
+        result = self.do_command(self.dev_args + ['-p', 'pass', 'enumerate'])
+        for dev in result:
+            if dev['type'] == 'trezor' and dev['path'] == 'udp:127.0.0.1:21324':
+                self.assertFalse(dev['needs_passphrase_sent'])
+                self.assertEquals(dev['fingerprint'], '95d8f670')
 
 def trezor_test_suite(emulator, rpc, userpass, interface, model_t=False):
     # Redirect stderr to /dev/null as it's super spammy


### PR DESCRIPTION
Adds `togglepassphrase` command which toggles the passphrase protection functionality for Trezor and KeepKey devices. This will allow to enable and disable passphrase protection without having to wipe the device as is now required when using the HWI tool.