### PR TITLE
build: import subprocess in hwi-qt.spec

### DIFF
--- a/hwi-qt.spec
+++ b/hwi-qt.spec
@@ -1,6 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
 
 import platform
+import subprocess
 
 block_cipher = None
 


### PR DESCRIPTION
This was missing and resulting in hwi-qt not being built for macOS.