### PR TITLE
Fix macOS hwi-qt build

### DIFF
--- a/contrib/generate-ui.sh
+++ b/contrib/generate-ui.sh
@@ -5,6 +5,6 @@ for file in *.ui
 do
     gen_file=ui_`echo $file| cut -d. -f1`.py
     pyside2-uic $file -o $gen_file
-    sed -i 's/raise()/raise_()/g' $gen_file
+    sed -i '' -e 's/raise()/raise_()/g' $gen_file
 done
 popd


### PR DESCRIPTION
Fix `sed` command used in the `contrib/generate-ui.sh` script for generating the `hwi-qt` build.

The current build exists in the [release](https://github.com/bitcoin-core/HWI/releases/tag/1.1.0) is broken on macOS, generating a new one with this fix should solve the issue.