### PR TITLE
Toggle Passphrase GUI

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -438,7 +438,14 @@ class TrezorClient(HardwareWalletClient):
     @trezor_exception
     def toggle_passphrase(self):
         self._check_unlocked()
-        return device.apply_settings(self.client, use_passphrase=not self.client.features.passphrase_protection)
+        try:
+            device.apply_settings(self.client, use_passphrase=not self.client.features.passphrase_protection)
+        except:
+            if self.type == 'Keepkey':
+                print('Confirm the action by entering your PIN', file=sys.stderr)
+                print('Use \'sendpin\' to provide the number positions for the PIN as displayed on your device\'s screen', file=sys.stderr)
+                print(PIN_MATRIX_DESCRIPTION, file=sys.stderr)
+        return {'success': True}
 
 def enumerate(password=''):
     results = []

--- a/hwilib/ui/mainwindow.ui
+++ b/hwilib/ui/mainwindow.ui
@@ -177,6 +177,16 @@
          </property>
         </widget>
        </item>
+       <item row="3" column="1">
+        <widget class="QPushButton" name="toggle_passphrase_button">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Toggle Passphrase</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
      <item>


### PR DESCRIPTION
Adds a "Toggle Passphrase" button to the GUI, enabled for Trezor and Keepkey devices (0075e7f).

This PR also fixes Keepkey error where the command finished with an error message while it should have told the user to use `sendpin` to confirm the change, since unlike Trezor, Keepkey requires to send the pin to confirm the change of device settings (ff6cdfa).