### PR TITLE
Multisig display address

### DIFF
--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -40,7 +40,7 @@ def backup_device_handler(args, client):
     return backup_device(client, label=args.label, backup_passphrase=args.backup_passphrase)
 
 def displayaddress_handler(args, client):
-    return displayaddress(client, desc=args.desc, path=args.path, sh_wpkh=args.sh_wpkh, wpkh=args.wpkh)
+    return displayaddress(client, desc=args.desc, path=args.path, sh_wpkh=args.sh_wpkh, wpkh=args.wpkh, redeem_script=args.redeem_script)
 
 def enumerate_handler(args):
     return enumerate(password=args.password)
@@ -177,6 +177,7 @@ def process_commands(cli_args):
     group.add_argument('--path', help='The BIP 32 derivation path of the key embedded in the address, default follows BIP43 convention, e.g. m/84h/0h/0h/1/*')
     displayaddr_parser.add_argument('--sh_wpkh', action='store_true', help='Display the p2sh-nested segwit address associated with this key path')
     displayaddr_parser.add_argument('--wpkh', action='store_true', help='Display the bech32 version of the address associated with this key path')
+    displayaddr_parser.add_argument('--redeem_script', help='P2SH redeem script')
     displayaddr_parser.set_defaults(func=displayaddress_handler)
 
     setupdev_parser = subparsers.add_parser('setup', help='Setup a device. Passphrase protection uses the password given by -p. Requires interactive mode')

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -228,9 +228,23 @@ def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False, rede
     elif desc is not None:
         if sh_wpkh or wpkh:
             return {'error': ' `--wpkh` and `--sh_wpkh` can not be combined with --desc', 'code': BAD_ARGUMENT}
+        if redeem_script:
+            return {'error': ' `--redeem_script` can not be combined with --desc', 'code': BAD_ARGUMENT}
         descriptor = Descriptor.parse(desc, client.is_testnet)
         if descriptor is None:
             return {'error': 'Unable to parse descriptor: ' + desc, 'code': BAD_ARGUMENT}
+        if descriptor.sh or descriptor.sh_wsh or descriptor.wsh:
+            path = ''
+            redeem_script = format(80 + int(descriptor.multisig_M), 'x')
+            for i in range(0, descriptor.multisig_N):
+                path += descriptor.origin_fingerprint[i] + descriptor.origin_path[i] + ','
+                if not descriptor.path_suffix[i]:
+                    redeem_script += '21' + descriptor.base_key[i]
+                else:
+                    return {'error': 'Multisig descriptor must include all pubkeys', 'code': BAD_ARGUMENT}
+            path = path[0:-1]
+            redeem_script += format(80 + descriptor.multisig_N, 'x') + 'ae'
+            return client.display_address(path, descriptor.sh_wpkh or descriptor.sh_wsh, descriptor.wpkh or descriptor.wsh, redeem_script)
         if descriptor.m_path is None:
             return {'error': 'Descriptor missing origin info: ' + desc, 'code': BAD_ARGUMENT}
         if descriptor.origin_fingerprint != client.get_master_fingerprint_hex():

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -220,11 +220,11 @@ def getdescriptors(client, account=0):
 
     return result
 
-def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False):
+def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False, redeem_script=None):
     if path is not None:
         if sh_wpkh and wpkh:
             return {'error': 'Both `--wpkh` and `--sh_wpkh` can not be selected at the same time.', 'code': BAD_ARGUMENT}
-        return client.display_address(path, sh_wpkh, wpkh)
+        return client.display_address(path, sh_wpkh, wpkh, redeem_script=redeem_script)
     elif desc is not None:
         if sh_wpkh or wpkh:
             return {'error': ' `--wpkh` and `--sh_wpkh` can not be combined with --desc', 'code': BAD_ARGUMENT}

--- a/hwilib/descriptor.py
+++ b/hwilib/descriptor.py
@@ -50,7 +50,21 @@ def AddChecksum(desc):
     return desc + "#" + DescriptorChecksum(desc)
 
 class Descriptor:
-    def __init__(self, origin_fingerprint, origin_path, base_key, path_suffix, testnet, sh_wpkh, wpkh):
+    def __init__(
+        self,
+        origin_fingerprint,
+        origin_path,
+        base_key,
+        path_suffix,
+        testnet,
+        sh_wpkh=None,
+        wpkh=None,
+        sh=None,
+        sh_wsh=None,
+        wsh=None,
+        multisig_M=None,
+        multisig_N=None
+    ):
         self.origin_fingerprint = origin_fingerprint
         self.origin_path = origin_path
         self.path_suffix = path_suffix
@@ -58,9 +72,14 @@ class Descriptor:
         self.testnet = testnet
         self.sh_wpkh = sh_wpkh
         self.wpkh = wpkh
+        self.sh = sh
+        self.sh_wsh = sh_wsh
+        self.wsh = wsh
+        self.multisig_M = multisig_M
+        self.multisig_N = multisig_N
         self.m_path = None
 
-        if origin_path:
+        if origin_path and not isinstance(origin_path, list):
             self.m_path_base = "m" + origin_path
             self.m_path = "m" + origin_path + (path_suffix or "")
 
@@ -68,11 +87,16 @@ class Descriptor:
     def parse(cls, desc, testnet=False):
         sh_wpkh = None
         wpkh = None
+        sh = None
+        sh_wsh = None
+        wsh = None
         origin_fingerprint = None
         origin_path = None
         base_key_and_path_match = None
         base_key = None
         path_suffix = None
+        multisig_M = None
+        multisig_N = None
 
         # Check the checksum
         check_split = desc.split('#')
@@ -92,31 +116,70 @@ class Descriptor:
             sh_wpkh = True
         elif desc.startswith("wpkh("):
             wpkh = True
+        elif desc.startswith("sh(wsh("):
+            sh_wsh = True
+        elif desc.startswith("wsh("):
+            wsh = True
+        elif desc.startswith("sh("):
+            sh = True
 
-        origin_match = re.search(r"\[(.*)\]", desc)
-        if origin_match:
-            origin = origin_match.group(1)
-            match = re.search(r"^([0-9a-fA-F]{8})(\/.*)", origin)
-            if match:
-                origin_fingerprint = match.group(1)
-                origin_path = match.group(2)
-                # Replace h with '
-                origin_path = origin_path.replace('h', '\'')
-
-            base_key_and_path_match = re.search(r"\[.*\](\w+)([\/\)][\d'\/\*]*)", desc)
-        else:
-            base_key_and_path_match = re.search(r"\((\w+)([\/\)][\d'\/\*]*)", desc)
-
-        if base_key_and_path_match:
-            base_key = base_key_and_path_match.group(1)
-            path_suffix = base_key_and_path_match.group(2)
-            if path_suffix == ")":
-                path_suffix = None
-        else:
-            if origin_match is None:
+        if sh or sh_wsh or wsh:
+            if 'multi(' not in desc:
+                # only multisig scripts are supported
                 return None
+            # get the list of keys only
+            keys = desc.split(',', 1)[1].split(')', 1)[0].split(',')
+            if 'sortedmulti' in desc:
+                keys.sort(key=lambda x: x if ']' not in x else x.split(']')[1])
+            multisig_M = desc.split(',')[0].split('(')[-1]
+            multisig_N = len(keys)
+        else:
+            keys = [desc.split('(')[-1].split(')', 1)[0]]
 
-        return cls(origin_fingerprint, origin_path, base_key, path_suffix, testnet, sh_wpkh, wpkh)
+        descriptors = []
+        for key in keys:
+            origin_match = re.search(r"\[(.*)\]", key)
+            if origin_match:
+                origin = origin_match.group(1)
+                match = re.search(r"^([0-9a-fA-F]{8})(\/.*)", origin)
+                if match:
+                    origin_fingerprint = match.group(1)
+                    origin_path = match.group(2)
+                    # Replace h with '
+                    origin_path = origin_path.replace('h', '\'')
+
+                base_key_and_path_match = re.search(r"\[.*\](\w+)([\d'\/\*]*)", key)
+            else:
+                base_key_and_path_match = re.search(r"(\w+)([\d'\/\*]*)", key)
+
+            if base_key_and_path_match:
+                base_key = base_key_and_path_match.group(1)
+                path_suffix = base_key_and_path_match.group(2)
+                if path_suffix == '':
+                    path_suffix = None
+            else:
+                if origin_match is None:
+                    return None
+
+            descriptors.append(cls(origin_fingerprint, origin_path, base_key, path_suffix, testnet, sh_wpkh, wpkh, sh, sh_wsh, wsh))
+        if len(descriptors) == 1:
+            return descriptors[0]
+        else:
+            # for multisig scripts save as lists all keypaths fields
+            return cls(
+                [descriptor.origin_fingerprint for descriptor in descriptors],
+                [descriptor.origin_path for descriptor in descriptors],
+                [descriptor.base_key for descriptor in descriptors],
+                [descriptor.path_suffix for descriptor in descriptors],
+                testnet,
+                sh_wpkh,
+                wpkh,
+                sh,
+                sh_wsh,
+                wsh,
+                multisig_M,
+                multisig_N
+            )
 
     def serialize(self):
         descriptor_open = 'pkh('
@@ -129,6 +192,9 @@ class Descriptor:
         elif self.sh_wpkh:
             descriptor_open = 'sh(wpkh('
             descriptor_close = '))'
+        elif self.sh or self.sh_wsh or self.wsh:
+            # serialize multisig descriptor is not supported yet.
+            return None
 
         if self.origin_fingerprint and self.origin_path:
             origin = '[' + self.origin_fingerprint + self.origin_path + ']'

--- a/hwilib/devices/ckcc/protocol.py
+++ b/hwilib/devices/ckcc/protocol.py
@@ -110,6 +110,28 @@ class CCProtocolPacker:
         return pack('<4sI', b'show', addr_fmt) + subpath.encode('ascii')
 
     @staticmethod
+    def show_p2sh_address(M, xfp_paths, witdeem_script, addr_fmt=AF_P2SH):
+        # For multisig (aka) P2SH cases, you will need all the info required to build
+        # the redeem script, and the Coldcard must already have been enrolled 
+        # into the wallet.
+        # - redeem script must be provided
+        # - full subkey paths for each involved key is required in a list of lists of ints, where
+        #   is a XFP and derivation path, like in BIP174
+        # - the order of xfp_paths must match the order of pubkeys in
+        #   redeem script (after BIP67 sort). This allows for dup xfp values.
+        assert addr_fmt & AFC_SCRIPT
+        assert 30 <= len(witdeem_script) <= 520
+
+        rv = pack('<4sIBBH', b'p2sh', addr_fmt, M, len(xfp_paths), len(witdeem_script))
+        rv += witdeem_script
+
+        for xfp_path in xfp_paths:
+            ln = len(xfp_path)
+            rv += pack('<B%dI' % ln, ln, *xfp_path)
+
+        return rv
+
+    @staticmethod
     def sim_keypress(key):
         # Simulator ONLY: pretend a key is pressed
         return b'XKEY' + key

--- a/hwilib/devices/ckcc/utils.py
+++ b/hwilib/devices/ckcc/utils.py
@@ -85,4 +85,24 @@ def get_pubkey_string(b):
         y = p - y
     return x.to_bytes(32, byteorder="big") + y.to_bytes(32, byteorder="big")
 
+def str_to_int_path(xfp, path):
+    # convert text  m/34'/33/44 into BIP174 binary compat format
+    # - include hex for fingerprint (m) as first arg
+
+    rv = [struct.unpack('<I', binascii.a2b_hex(xfp))[0]]
+    for i in path.split('/'):
+        if i == 'm': continue
+        if not i: continue      # trailing or duplicated slashes
+        
+        if i[-1] in "'phHP":
+            assert len(i) >= 2, i
+            here = int(i[:-1]) | 0x80000000
+        else:
+            here = int(i)
+            assert 0 <= here < 0x80000000, here
+        
+        rv.append(here)
+
+    return rv
+
 # EOF

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -548,8 +548,8 @@ class DigitalbitboxClient(HardwareWalletClient):
 
         return {"signature": base64.b64encode(compact_sig).decode('utf-8')}
 
-    # Display address of specified type on the device. Only supports single-key based addresses.
-    def display_address(self, keypath, p2sh_p2wpkh, bech32):
+    # Display address of specified type on the device.
+    def display_address(self, keypath, p2sh_p2wpkh, bech32, redeem_script=None):
         raise UnavailableActionError('The Digital Bitbox does not have a screen to display addresses on')
 
     # Setup a new device

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -338,10 +338,13 @@ class LedgerClient(HardwareWalletClient):
 
         return {"signature": base64.b64encode(sig).decode('utf-8')}
 
+    # Display address of specified type on the device. Only supports single-key based addresses.
     @ledger_exception
-    def display_address(self, keypath, p2sh_p2wpkh, bech32):
+    def display_address(self, keypath, p2sh_p2wpkh, bech32, redeem_script=None):
         if not check_keypath(keypath):
             raise BadArgumentError("Invalid keypath")
+        if redeem_script is not None:
+            raise BadArgumentError("The Ledger Nano S and X do not support P2SH address display")
         output = self.app.getWalletPublicKey(keypath[2:], True, (p2sh_p2wpkh or bech32), bech32)
         return {'address': output['address'][12:-2]} # HACK: A bug in getWalletPublicKey results in the address being returned as the string "bytearray(b'<address>')". This extracts the actual address to work around this.
 

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -41,6 +41,11 @@ class HardwareWalletClient(object):
         raise NotImplementedError('The HardwareWalletClient base class does not '
                                   'implement this method')
 
+    # Display address of specified type on the device.
+    def display_address(self, keypath, p2sh_p2wpkh, bech32, redeem_script=None):
+        raise NotImplementedError('The HardwareWalletClient base class does not '
+                                  'implement this method')
+
     # Setup a new device
     def setup_device(self, label='', passphrase=''):
         raise NotImplementedError('The HardwareWalletClient base class does not '


### PR DESCRIPTION
Added support for multisig addresses in the `displayaddress` command for Coldcard, Trezor, and Keepkey.

This PR is based on #279 and should replace it.
For now, I mostly preserved justinmoon's API as he described it in [this message](https://github.com/bitcoin-core/HWI/pull/279#issue-341248821). I'll just add a few notes on that:
- To prevent Coldcard format of sending all paths from being inconsistent with that of Trezor I allowed sending multiple paths to the Trezor too and it will simply find the correct one. That shouldn't be necessary but I just chose to add that to maintain consistency. That's not mandatory on Trezor though, so it still works just fine with either a single or multiple paths.
- I also left the `--sh_wpkh` and `--wpkh` flags for now. I think it will be best to rename them to something like `--wrapped-segwit` and `bech32` or `--native-segwit`, but wanted to raise that up here too before changing.
- ~~As for descriptor support, I did not add it yet since I didn't want this PR to be too big. I plan to add that support in a separate PR after this one is done, but if you think I should have it all in this PR that's possible too.~~
**Edit:** I also added descriptor support for multisig, [see this comment](https://github.com/bitcoin-core/HWI/pull/324#issuecomment-621926077).

The tests should cover Coldcard, Trezor, and Keepkey with 2-3 multi-sig. The setup for the test is borrowed mostly from the `sign_tx` tests code.