### PR TITLE
Strip all local symbols to avoid xcode complaint

### DIFF
--- a/contrib/build_bin.sh
+++ b/contrib/build_bin.sh
@@ -11,7 +11,7 @@ poetry install
 
 # We now need to remove debugging symbols and build id from the hidapi SO file
 so_dir=`dirname $(dirname $(poetry run which python))`/lib/python3.6/site-packages
-strip ${so_dir}/hid*.so
+strip -x ${so_dir}/hid*.so
 if [[ $OSTYPE != *"darwin"* ]]; then
     strip -R .note.gnu.build-id ${so_dir}/hid*.so
 fi


### PR DESCRIPTION
Fixes https://github.com/bitcoin-core/HWI/issues/335 at least locally for my build on Catalina. Didn't test if it breaks linux et al but the option appears to be the same.

Alternative I tried was `-u -r` which ended up with identical binaries.