### PR TITLE
Updates for new Trezor and Ledger firmware

### DIFF
--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -1,15 +1,32 @@
 #! /usr/bin/env python3
 
-from .commands import backup_device, displayaddress, enumerate, find_device, \
-    get_client, getmasterxpub, getxpub, getkeypool, getdescriptors, prompt_pin, toggle_passphrase, restore_device, send_pin, setup_device, \
-    signmessage, signtx, wipe_device, install_udev_rules
+from .commands import (
+    backup_device,
+    displayaddress,
+    enumerate,
+    find_device,
+    get_client,
+    getmasterxpub,
+    getxpub,
+    getkeypool,
+    getdescriptors,
+    prompt_pin,
+    toggle_passphrase,
+    restore_device,
+    send_pin,
+    setup_device,
+    signmessage,
+    signtx,
+    wipe_device,
+    install_udev_rules,
+)
 from .errors import (
     handle_errors,
     DEVICE_CONN_ERROR,
     HELP_TEXT,
     MISSING_ARGUMENTS,
     NO_DEVICE_TYPE,
-    UNAVAILABLE_ACTION
+    UNAVAILABLE_ACTION,
 )
 from . import __version__
 

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -7,7 +7,11 @@ import platform
 
 from .serializations import PSBT
 from .base58 import xpub_to_pub_hex
-from .errors import UnknownDeviceError, BAD_ARGUMENT, NOT_IMPLEMENTED
+from .errors import (
+    UnknownDeviceError,
+    BAD_ARGUMENT,
+    NOT_IMPLEMENTED,
+)
 from .descriptor import Descriptor
 from .devices import __all__ as all_devs
 from enum import Enum

--- a/hwilib/devices/btchip/btchip.py
+++ b/hwilib/devices/btchip/btchip.py
@@ -397,5 +397,8 @@ class btchip:
 				raise
 		result['compressedKeys'] = (response[0] == 0x01)
 		result['version'] = "%d.%d.%d" % (response[2], response[3], response[4])
+		result['major_version'] = response[2]
+		result['minor_version'] = response[3]
+		result['patch_version'] = response[4]
 		result['specialVersion'] = response[1]
 		return result

--- a/hwilib/devices/btchip/btchip.py
+++ b/hwilib/devices/btchip/btchip.py
@@ -203,10 +203,10 @@ class btchip:
 			apdu = [ self.BTCHIP_CLA, self.BTCHIP_INS_HASH_INPUT_START, 0x80, 0x00 ]
 			params = []
 			script = bytearray(redeemScript)
-			if ('witness' in passedOutput) and passedOutput['witness']:
-				params.append(0x02)
-			elif ('trustedInput' in passedOutput) and passedOutput['trustedInput']:
+			if ('trustedInput' in passedOutput) and passedOutput['trustedInput']:
 				params.append(0x01)
+			elif ('witness' in passedOutput) and passedOutput['witness']:
+				params.append(0x02)
 			else:
 				params.append(0x00)
 			if ('trustedInput' in passedOutput) and passedOutput['trustedInput']:

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -2,12 +2,40 @@
 
 from binascii import b2a_hex
 from ..hwwclient import HardwareWalletClient
-from ..errors import ActionCanceledError, BadArgumentError, DeviceBusyError, DeviceFailureError, UnavailableActionError, common_err_msgs, handle_errors
-from .ckcc.client import ColdcardDevice, COINKITE_VID, CKCC_PID
-from .ckcc.protocol import CCProtocolPacker, CCBusyError, CCProtoError, CCUserRefused
-from .ckcc.constants import MAX_BLK_LEN, AF_P2WPKH, AF_CLASSIC, AF_P2WPKH_P2SH
-from ..base58 import get_xpub_fingerprint, xpub_main_2_test
-from ..serializations import ExtendedKey, PSBT
+from ..errors import (
+    ActionCanceledError,
+    BadArgumentError,
+    DeviceBusyError,
+    DeviceFailureError,
+    UnavailableActionError,
+    common_err_msgs,
+    handle_errors,
+)
+from .ckcc.client import (
+    ColdcardDevice,
+    COINKITE_VID,
+    CKCC_PID,
+)
+from .ckcc.protocol import (
+    CCProtocolPacker,
+    CCBusyError,
+    CCProtoError,
+    CCUserRefused,
+)
+from .ckcc.constants import (
+    MAX_BLK_LEN,
+    AF_P2WPKH,
+    AF_CLASSIC,
+    AF_P2WPKH_P2SH,
+)
+from ..base58 import (
+    get_xpub_fingerprint,
+    xpub_main_2_test,
+)
+from ..serializations import (
+    ExtendedKey,
+    PSBT,
+)
 from hashlib import sha256
 
 import base64

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -15,10 +15,30 @@ import sys
 import time
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import ActionCanceledError, BadArgumentError, DeviceFailureError, DeviceAlreadyInitError, DEVICE_NOT_INITIALIZED, DeviceNotReadyError, NoPasswordError, UnavailableActionError, common_err_msgs, handle_errors
-from ..serializations import CTransaction, ExtendedKey, hash256, ser_sig_der, ser_sig_compact, ser_compact_size
-from ..base58 import get_xpub_fingerprint, xpub_main_2_test
-
+from ..errors import (
+    ActionCanceledError,
+    BadArgumentError,
+    DeviceFailureError,
+    DeviceAlreadyInitError,
+    DEVICE_NOT_INITIALIZED,
+    DeviceNotReadyError,
+    NoPasswordError,
+    UnavailableActionError,
+    common_err_msgs,
+    handle_errors,
+)
+from ..serializations import (
+    CTransaction,
+    ExtendedKey,
+    hash256,
+    ser_sig_der,
+    ser_sig_compact,
+    ser_compact_size,
+)
+from ..base58 import (
+    get_xpub_fingerprint,
+    xpub_main_2_test,
+)
 applen = 225280 # flash size minus bootloader length
 chunksize = 8 * 512
 usb_report_size = 64 # firmware > v2.0

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -1,7 +1,15 @@
 # KeepKey interaction script
 
-from ..errors import DEVICE_NOT_INITIALIZED, DeviceNotReadyError, common_err_msgs, handle_errors
-from .trezorlib.transport import enumerate_devices, KEEPKEY_VENDOR_IDS
+from ..errors import (
+    DEVICE_NOT_INITIALIZED,
+    DeviceNotReadyError,
+    common_err_msgs,
+    handle_errors,
+)
+from .trezorlib.transport import (
+    enumerate_devices,
+    KEEPKEY_VENDOR_IDS,
+)
 from .trezor import TrezorClient
 
 py_enumerate = enumerate # Need to use the enumerate built-in but there's another function already named that

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -1,17 +1,33 @@
 # Ledger interaction script
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import ActionCanceledError, BadArgumentError, DeviceConnectionError, DeviceFailureError, UnavailableActionError, common_err_msgs, handle_errors
+from ..errors import (
+    ActionCanceledError,
+    BadArgumentError,
+    DeviceConnectionError,
+    DeviceFailureError,
+    UnavailableActionError,
+    common_err_msgs,
+    handle_errors,
+)
 from .btchip.bitcoinTransaction import bitcoinTransaction
 from .btchip.btchip import btchip
-from .btchip.btchipComm import DongleServer, HIDDongleHIDAPI
+from .btchip.btchipComm import (
+    DongleServer,
+    HIDDongleHIDAPI,
+)
 from .btchip.btchipException import BTChipException
 from .btchip.btchipUtils import compress_public_key
 import base64
 import hid
 import struct
 from .. import base58
-from ..serializations import ExtendedKey, hash256, hash160, CTransaction
+from ..serializations import (
+    ExtendedKey,
+    hash256,
+    hash160,
+    CTransaction,
+)
 import logging
 import re
 

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -26,6 +26,10 @@ from ..serializations import (
     ExtendedKey,
     hash256,
     hash160,
+    is_p2sh,
+    is_p2wpkh,
+    is_p2wsh,
+    is_witness,
     CTransaction,
 )
 import logging
@@ -207,59 +211,54 @@ class LedgerClient(HardwareWalletClient):
             seq.reverse()
             seq_hex = ''.join('{:02x}'.format(x) for x in seq)
 
+            scriptcode = b""
+            utxo = None
+            if psbt_in.witness_utxo:
+                utxo = psbt_in.witness_utxo
             if psbt_in.non_witness_utxo:
-                segwit_inputs.append({"value": txin.prevout.serialize() + struct.pack("<Q", psbt_in.non_witness_utxo.vout[txin.prevout.n].nValue), "witness": True, "sequence": seq_hex})
+                if txin.prevout.hash != psbt_in.non_witness_utxo.sha256:
+                    raise BadArgumentError('Input {} has a non_witness_utxo with the wrong hash'.format(i_num))
+                utxo = psbt_in.non_witness_utxo.vout[txin.prevout.n]
+            if utxo is None:
+                raise Exception("PSBT is missing input utxo information, cannot sign")
+            scriptcode = utxo.scriptPubKey
+
+            if is_p2sh(scriptcode):
+                if len(psbt_in.redeem_script) == 0:
+                    continue
+                scriptcode = psbt_in.redeem_script
+
+            is_wit, _, _ = is_witness(scriptcode)
+
+            segwit_inputs.append({"value": txin.prevout.serialize() + struct.pack("<Q", utxo.nValue), "witness": True, "sequence": seq_hex})
+            if is_wit:
+                if is_p2wsh(scriptcode):
+                    if len(psbt_in.witness_script) == 0:
+                        continue
+                    scriptcode = psbt_in.witness_script
+                elif is_p2wpkh(scriptcode):
+                    _, _, wit_prog = is_witness(scriptcode)
+                    scriptcode = b"\x76\xa9\x14" + wit_prog + b"\x88\xac"
+                else:
+                    continue
+                has_segwit = True
+            else:
                 # We only need legacy inputs in the case where all inputs are legacy, we check
                 # later
                 ledger_prevtx = bitcoinTransaction(psbt_in.non_witness_utxo.serialize())
                 legacy_inputs.append(self.app.getTrustedInput(ledger_prevtx, txin.prevout.n))
                 legacy_inputs[-1]["sequence"] = seq_hex
                 has_legacy = True
-            else:
-                segwit_inputs.append({"value": txin.prevout.serialize() + struct.pack("<Q", psbt_in.witness_utxo.nValue), "witness": True, "sequence": seq_hex})
-                has_segwit = True
 
             pubkeys = []
             signature_attempts = []
 
-            scriptCode = b""
-            witness_program = b""
-            if psbt_in.witness_utxo is not None and psbt_in.witness_utxo.is_p2sh():
-                redeemscript = psbt_in.redeem_script
-                witness_program += redeemscript
-            elif psbt_in.non_witness_utxo is not None and psbt_in.non_witness_utxo.vout[txin.prevout.n].is_p2sh():
-                redeemscript = psbt_in.redeem_script
-            elif psbt_in.witness_utxo is not None:
-                witness_program += psbt_in.witness_utxo.scriptPubKey
-            elif psbt_in.non_witness_utxo is not None:
-                # No-op
-                redeemscript = b""
-                witness_program = b""
-            else:
-                raise Exception("PSBT is missing input utxo information, cannot sign")
-
-            # Check if witness_program is script hash
-            if len(witness_program) == 34 and witness_program[0] == 0x00 and witness_program[1] == 0x20:
-                # look up witnessscript and set as scriptCode
-                witnessscript = psbt_in.witness_script
-                scriptCode += witnessscript
-            elif len(witness_program) > 0:
-                # p2wpkh
-                scriptCode += b"\x76\xa9\x14"
-                scriptCode += witness_program[2:]
-                scriptCode += b"\x88\xac"
-            elif len(witness_program) == 0:
-                if len(redeemscript) > 0:
-                    scriptCode = redeemscript
-                else:
-                    scriptCode = psbt_in.non_witness_utxo.vout[txin.prevout.n].scriptPubKey
-
             # Save scriptcode for later signing
-            script_codes[i_num] = scriptCode
+            script_codes[i_num] = scriptcode
 
             # Find which pubkeys could sign this input (should be all?)
             for pubkey in psbt_in.hd_keypaths.keys():
-                if hash160(pubkey) in scriptCode or pubkey in scriptCode:
+                if hash160(pubkey) in scriptcode or pubkey in scriptcode:
                     pubkeys.append(pubkey)
 
             # Figure out which keys in inputs are from our wallet
@@ -287,9 +286,6 @@ class LedgerClient(HardwareWalletClient):
 
             # For each input we control do segwit signature
             for i in range(len(segwit_inputs)):
-                # Don't try to sign legacy inputs
-                if tx.inputs[i].non_witness_utxo is not None:
-                    continue
                 for signature_attempt in all_signature_attempts[i]:
                     self.app.startUntrustedTransaction(False, 0, [segwit_inputs[i]], script_codes[i], c_tx.nVersion)
                     tx.inputs[i].partial_sigs[signature_attempt[1]] = self.app.untrustedHashSign(signature_attempt[0], "", c_tx.nLockTime, 0x01)

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -164,12 +164,7 @@ class TrezorClient(HardwareWalletClient):
 
                 # Detrermine spend type
                 scriptcode = b''
-                if psbt_in.non_witness_utxo:
-                    utxo = psbt_in.non_witness_utxo.vout[txin.prevout.n]
-                    txinputtype.script_type = proto.InputScriptType.SPENDADDRESS
-                    scriptcode = utxo.scriptPubKey
-                    txinputtype.amount = psbt_in.non_witness_utxo.vout[txin.prevout.n].nValue
-                elif psbt_in.witness_utxo:
+                if psbt_in.witness_utxo:
                     utxo = psbt_in.witness_utxo
                     # Check if the output is p2sh
                     if psbt_in.witness_utxo.is_p2sh():
@@ -178,6 +173,11 @@ class TrezorClient(HardwareWalletClient):
                         txinputtype.script_type = proto.InputScriptType.SPENDWITNESS
                     scriptcode = psbt_in.witness_utxo.scriptPubKey
                     txinputtype.amount = psbt_in.witness_utxo.nValue
+                elif psbt_in.non_witness_utxo:
+                    utxo = psbt_in.non_witness_utxo.vout[txin.prevout.n]
+                    txinputtype.script_type = proto.InputScriptType.SPENDADDRESS
+                    scriptcode = utxo.scriptPubKey
+                    txinputtype.amount = psbt_in.non_witness_utxo.vout[txin.prevout.n].nValue
 
                 # Set the script
                 if psbt_in.witness_script:
@@ -197,7 +197,7 @@ class TrezorClient(HardwareWalletClient):
                 if is_ms:
                     # Add to txinputtype
                     txinputtype.multisig = multisig
-                    if psbt_in.non_witness_utxo:
+                    if not psbt_in.witness_utxo:
                         if utxo.is_p2sh:
                             txinputtype.script_type = proto.InputScriptType.SPENDMULTISIG
                         else:

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -1,16 +1,52 @@
 # Trezor interaction script
 
 from ..hwwclient import HardwareWalletClient
-from ..errors import ActionCanceledError, BadArgumentError, DeviceAlreadyInitError, DeviceAlreadyUnlockedError, DeviceConnectionError, DEVICE_NOT_INITIALIZED, DeviceNotReadyError, UnavailableActionError, common_err_msgs, handle_errors
+from ..errors import (
+    ActionCanceledError,
+    BadArgumentError,
+    DeviceAlreadyInitError,
+    DeviceAlreadyUnlockedError,
+    DeviceConnectionError,
+    DEVICE_NOT_INITIALIZED,
+    DeviceNotReadyError,
+    UnavailableActionError,
+    common_err_msgs,
+    handle_errors,
+)
 from .trezorlib.client import TrezorClient as Trezor
 from .trezorlib.debuglink import TrezorClientDebugLink
 from .trezorlib.exceptions import Cancelled
-from .trezorlib.transport import enumerate_devices, get_transport, TREZOR_VENDOR_IDS
-from .trezorlib.ui import echo, PassphraseUI, mnemonic_words, PIN_CURRENT, PIN_NEW, PIN_CONFIRM, PIN_MATRIX_DESCRIPTION, prompt
-from .trezorlib import tools, btc, device
+from .trezorlib.transport import (
+    enumerate_devices,
+    get_transport,
+    TREZOR_VENDOR_IDS,
+)
+from .trezorlib.ui import (
+    echo,
+    PassphraseUI,
+    mnemonic_words,
+    PIN_CURRENT,
+    PIN_NEW,
+    PIN_CONFIRM,
+    PIN_MATRIX_DESCRIPTION,
+    prompt,
+)
+from .trezorlib import (
+    tools,
+    btc,
+    device,
+)
 from .trezorlib import messages as proto
-from ..base58 import get_xpub_fingerprint, to_address, xpub_main_2_test
-from ..serializations import CTxOut, ExtendedKey, ser_uint256
+from ..base58 import (
+    get_xpub_fingerprint,
+    to_address,
+    xpub_main_2_test,
+)
+from ..serializations import (
+    CTxOut,
+    ExtendedKey,
+    ser_uint256,
+)
 from .. import bech32
 from usb1 import USBErrorNoDevice
 from types import MethodType

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -186,7 +186,7 @@ class TrezorClient(HardwareWalletClient):
                     scriptcode = psbt_in.redeem_script
 
                 def ignore_input():
-                    txinputtype.address_n = [0x80000000]
+                    txinputtype.address_n = [0x80000000 | 84, 0x80000000 | (1 if self.is_testnet else 0)]
                     txinputtype.multisig = None
                     txinputtype.script_type = proto.InputScriptType.SPENDWITNESS
                     inputs.append(txinputtype)

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -45,6 +45,10 @@ from ..base58 import (
 from ..serializations import (
     CTxOut,
     ExtendedKey,
+    is_p2pkh,
+    is_p2sh,
+    is_p2wsh,
+    is_witness,
     ser_uint256,
 )
 from .. import bech32
@@ -200,26 +204,46 @@ class TrezorClient(HardwareWalletClient):
 
                 # Detrermine spend type
                 scriptcode = b''
+                utxo = None
                 if psbt_in.witness_utxo:
                     utxo = psbt_in.witness_utxo
-                    # Check if the output is p2sh
-                    if psbt_in.witness_utxo.is_p2sh():
+                if psbt_in.non_witness_utxo:
+                    if txin.prevout.hash != psbt_in.non_witness_utxo.sha256:
+                        raise BadArgumentError('Input {} has a non_witness_utxo with the wrong hash'.format(input_num))
+                    utxo = psbt_in.non_witness_utxo.vout[txin.prevout.n]
+                if utxo is None:
+                    continue
+                scriptcode = utxo.scriptPubKey
+
+                # Check if P2SH
+                p2sh = False
+                if is_p2sh(scriptcode):
+                    # Look up redeemscript
+                    if len(psbt_in.redeem_script) == 0:
+                        continue
+                    scriptcode = psbt_in.redeem_script
+                    p2sh = True
+
+                # Check segwit
+                is_wit, _, _ = is_witness(scriptcode)
+
+                if is_wit:
+                    if p2sh:
                         txinputtype.script_type = proto.InputScriptType.SPENDP2SHWITNESS
                     else:
                         txinputtype.script_type = proto.InputScriptType.SPENDWITNESS
-                    scriptcode = psbt_in.witness_utxo.scriptPubKey
-                    txinputtype.amount = psbt_in.witness_utxo.nValue
-                elif psbt_in.non_witness_utxo:
-                    utxo = psbt_in.non_witness_utxo.vout[txin.prevout.n]
+                else:
                     txinputtype.script_type = proto.InputScriptType.SPENDADDRESS
-                    scriptcode = utxo.scriptPubKey
-                    txinputtype.amount = psbt_in.non_witness_utxo.vout[txin.prevout.n].nValue
+                txinputtype.amount = utxo.nValue
 
-                # Set the script
-                if psbt_in.witness_script:
+                # Check if P2WSH
+                p2wsh = False
+                if is_p2wsh(scriptcode):
+                    # Look up witnessscript
+                    if len(psbt_in.witness_script) == 0:
+                        continue
                     scriptcode = psbt_in.witness_script
-                elif psbt_in.redeem_script:
-                    scriptcode = psbt_in.redeem_script
+                    p2wsh = True
 
                 def ignore_input():
                     txinputtype.address_n = [0x80000000 | 84, 0x80000000 | (1 if self.is_testnet else 0)]
@@ -240,11 +264,11 @@ class TrezorClient(HardwareWalletClient):
                             # Cannot sign bare multisig, ignore it
                             ignore_input()
                             continue
-                elif not is_ms and psbt_in.non_witness_utxo and not utxo.is_p2pkh:
+                elif not is_ms and not is_wit and not is_p2pkh(scriptcode):
                     # Cannot sign unknown spk, ignore it
                     ignore_input()
                     continue
-                elif not is_ms and psbt_in.witness_utxo and psbt_in.witness_script:
+                elif not is_ms and is_wit and p2wsh:
                     # Cannot sign unknown witness script, ignore it
                     ignore_input()
                     continue
@@ -273,7 +297,8 @@ class TrezorClient(HardwareWalletClient):
                     ignore_input()
                     continue
                 elif not found and found_in_sigs: # All of our keys are in partial_sigs, ignore whatever signature is produced for this input
-                    to_ignore.append(input_num)
+                    ignore_input()
+                    continue
 
                 # append to inputs
                 inputs.append(txinputtype)

--- a/hwilib/devices/trezorlib/btc.py
+++ b/hwilib/devices/trezorlib/btc.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the License along with this library.
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
+import binascii
+
 from . import messages
 from .tools import CallException, expect, normalize_nfc, session
 
@@ -119,6 +121,8 @@ def sign_tx(client, coin_name, inputs, outputs, details=None, prev_txes=None):
 
         # Device asked for one more information, let's process it.
         if res.details.tx_hash is not None:
+            if res.details.tx_hash not in prev_txes:
+                raise ValueError('Previous transaction {} not available'.format(binascii.hexlify(res.details.tx_hash)))
             current_tx = prev_txes[res.details.tx_hash]
         else:
             current_tx = this_tx

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -582,7 +582,7 @@ class PartiallySignedInput:
             tx = self.non_witness_utxo.serialize_with_witness()
             r += ser_string(tx)
 
-        elif self.witness_utxo:
+        if self.witness_utxo:
             r += ser_string(b"\x01")
             tx = self.witness_utxo.serialize()
             r += ser_string(tx)
@@ -622,19 +622,6 @@ class PartiallySignedInput:
         r += b"\x00"
 
         return r
-
-    def is_sane(self):
-        # Cannot have both witness and non-witness utxos
-        if self.witness_utxo and self.non_witness_utxo:
-            return False
-
-        # if we have witness script or scriptwitness, must have witness utxo
-        if len(self.witness_script) != 0 and not self.witness_utxo:
-            return False
-        if not self.final_script_witness.is_null() and not self.witness_utxo:
-            return False
-
-        return True
 
 class PartiallySignedOutput:
     def __init__(self):
@@ -795,9 +782,6 @@ class PSBT(object):
         if len(self.outputs) != len(self.tx.vout):
             raise PSBTSerializationError("Outputs provided does not match the number of outputs in transaction")
 
-        if not self.is_sane():
-            raise PSBTSerializationError("PSBT is not sane")
-
     def serialize(self):
         r = b""
 
@@ -830,12 +814,6 @@ class PSBT(object):
 
         # return hex string
         return HexToBase64(binascii.hexlify(r)).decode()
-
-    def is_sane(self):
-        for input in self.inputs:
-            if not input.is_sane():
-                return False
-        return True
 
 # An extended public key (xpub) or private key (xprv). Just a data container for now.
 # Only handles deserialization of extended keys into component data to be handled by something else

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -242,6 +242,42 @@ class CTxIn(object):
                self.nSequence)
 
 
+def is_p2sh(script):
+    return len(script) == 23 and script[0] == 0xa9 and script[1] == 0x14 and script[22] == 0x87
+
+def is_p2pkh(script):
+    return len(script) == 25 and script[0] == 0x76 and script[1] == 0xa9 and script[2] == 0x14 and script[23] == 0x88 and script[24] == 0xac
+
+def is_p2pk(script):
+    return (len(script) == 35 or len(script) == 67) and (script[0] == 0x21 or script[0] == 0x41) and script[-1] == 0xac
+
+def is_witness(script):
+    if len(script) < 4 or len(script) > 42:
+        return (False, None, None)
+
+    if script[0] != 0 and (script[0] < 81 or script[0] > 96):
+        return (False, None, None)
+
+    if script[1] + 2 == len(script):
+        return (True, script[0] - 0x50 if script[0] else 0, script[2:])
+
+def is_p2wpkh(script):
+    is_wit, wit_ver, wit_prog = is_witness(script)
+    if not is_wit:
+        return False
+    elif wit_ver != 0:
+        return False
+    return len(wit_prog) == 20
+
+def is_p2wsh(script):
+    is_wit, wit_ver, wit_prog = is_witness(script)
+    if not is_wit:
+        return False
+    elif wit_ver != 0:
+        return False
+    return len(wit_prog) == 32
+
+
 class CTxOut(object):
     def __init__(self, nValue=0, scriptPubKey=b""):
         self.nValue = nValue
@@ -258,25 +294,16 @@ class CTxOut(object):
         return r
 
     def is_p2sh(self):
-        return len(self.scriptPubKey) == 23 and self.scriptPubKey[0] == 0xa9 and self.scriptPubKey[1] == 0x14 and self.scriptPubKey[22] == 0x87
+        return is_p2sh(self.scriptPubKey)
 
     def is_p2pkh(self):
-        return len(self.scriptPubKey) == 25 and self.scriptPubKey[0] == 0x76 and self.scriptPubKey[1] == 0xa9 and self.scriptPubKey[2] == 0x14 and self.scriptPubKey[23] == 0x88 and self.scriptPubKey[24] == 0xac
+        return is_p2pkh(self.scriptPubKey)
 
     def is_p2pk(self):
-        return (len(self.scriptPubKey) == 35 or len(self.scriptPubKey) == 67) and (self.scriptPubKey[0] == 0x21 or self.scriptPubKey[0] == 0x41) and self.scriptPubKey[-1] == 0xac
+        return is_p2pk(self.scriptPubKey)
 
     def is_witness(self):
-        if len(self.scriptPubKey) < 4 or len(self.scriptPubKey) > 42:
-            return (False, None, None)
-
-        if self.scriptPubKey[0] != 0 and (self.scriptPubKey[0] < 81 or self.scriptPubKey[0] > 96):
-            return (False, None, None)
-
-        if self.scriptPubKey[1] + 2 == len(self.scriptPubKey):
-            return (True, self.scriptPubKey[0] - 0x50 if self.scriptPubKey[0] else 0, self.scriptPubKey[2:])
-
-        return (False, None, None)
+        return is_witness(self.scriptPubKey)
 
     def __repr__(self):
         return "CTxOut(nValue=%i.%08i scriptPubKey=%s)" \

--- a/test/data/psbt_non_witness_utxo_segwit.patch
+++ b/test/data/psbt_non_witness_utxo_segwit.patch
@@ -1,0 +1,431 @@
+From 30477b10795dc3e819cc852823f2e00e4e23f770 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Thu, 4 Jun 2020 23:43:25 -0400
+Subject: [PATCH 1/3] rpc: show both UTXOs in decodepsbt
+
+---
+ src/rpc/rawtransaction.cpp | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/src/rpc/rawtransaction.cpp b/src/rpc/rawtransaction.cpp
+index e14217c307..45cf6be3a0 100644
+--- a/src/rpc/rawtransaction.cpp
++++ b/src/rpc/rawtransaction.cpp
+@@ -1104,6 +1104,7 @@ UniValue decodepsbt(const JSONRPCRequest& request)
+         const PSBTInput& input = psbtx.inputs[i];
+         UniValue in(UniValue::VOBJ);
+         // UTXOs
++        bool have_a_utxo = false;
+         if (!input.witness_utxo.IsNull()) {
+             const CTxOut& txout = input.witness_utxo;
+ 
+@@ -1121,7 +1122,9 @@ UniValue decodepsbt(const JSONRPCRequest& request)
+             ScriptToUniv(txout.scriptPubKey, o, true);
+             out.pushKV("scriptPubKey", o);
+             in.pushKV("witness_utxo", out);
+-        } else if (input.non_witness_utxo) {
++            have_a_utxo = true;
++        }
++        if (input.non_witness_utxo) {
+             UniValue non_wit(UniValue::VOBJ);
+             TxToUniv(*input.non_witness_utxo, uint256(), non_wit, false);
+             in.pushKV("non_witness_utxo", non_wit);
+@@ -1132,7 +1135,9 @@ UniValue decodepsbt(const JSONRPCRequest& request)
+                 // Hack to just not show fee later
+                 have_all_utxos = false;
+             }
+-        } else {
++            have_a_utxo = true;
++        }
++        if (!have_a_utxo) {
+             have_all_utxos = false;
+         }
+ 
+-- 
+2.27.0
+
+
+From fcf1ef6529a010d05a79f9ba6dbfbc480de99af5 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Thu, 4 Jun 2020 23:43:39 -0400
+Subject: [PATCH 2/3] psbt: Allow both non_witness_utxo and witness_utxo
+
+---
+ src/psbt.cpp                   | 29 -----------------------------
+ src/psbt.h                     |  7 -------
+ src/test/fuzz/psbt.cpp         |  2 --
+ src/wallet/scriptpubkeyman.cpp | 10 ----------
+ src/wallet/wallet.cpp          |  5 -----
+ 5 files changed, 53 deletions(-)
+
+diff --git a/src/psbt.cpp b/src/psbt.cpp
+index ef9781817a..4c8b40ca0b 100644
+--- a/src/psbt.cpp
++++ b/src/psbt.cpp
+@@ -35,14 +35,6 @@ bool PartiallySignedTransaction::Merge(const PartiallySignedTransaction& psbt)
+     return true;
+ }
+ 
+-bool PartiallySignedTransaction::IsSane() const
+-{
+-    for (PSBTInput input : inputs) {
+-        if (!input.IsSane()) return false;
+-    }
+-    return true;
+-}
+-
+ bool PartiallySignedTransaction::AddInput(const CTxIn& txin, PSBTInput& psbtin)
+ {
+     if (std::find(tx->vin.begin(), tx->vin.end(), txin) != tx->vin.end()) {
+@@ -158,18 +150,6 @@ void PSBTInput::Merge(const PSBTInput& input)
+     if (final_script_witness.IsNull() && !input.final_script_witness.IsNull()) final_script_witness = input.final_script_witness;
+ }
+ 
+-bool PSBTInput::IsSane() const
+-{
+-    // Cannot have both witness and non-witness utxos
+-    if (!witness_utxo.IsNull() && non_witness_utxo) return false;
+-
+-    // If we have a witness_script or a scriptWitness, we must also have a witness utxo
+-    if (!witness_script.empty() && witness_utxo.IsNull()) return false;
+-    if (!final_script_witness.IsNull() && witness_utxo.IsNull()) return false;
+-
+-    return true;
+-}
+-
+ void PSBTOutput::FillSignatureData(SignatureData& sigdata) const
+ {
+     if (!redeem_script.empty()) {
+@@ -250,11 +230,6 @@ bool SignPSBTInput(const SigningProvider& provider, PartiallySignedTransaction&
+     bool require_witness_sig = false;
+     CTxOut utxo;
+ 
+-    // Verify input sanity, which checks that at most one of witness or non-witness utxos is provided.
+-    if (!input.IsSane()) {
+-        return false;
+-    }
+-
+     if (input.non_witness_utxo) {
+         // If we're taking our information from a non-witness UTXO, verify that it matches the prevout.
+         COutPoint prevout = tx.vin[index].prevout;
+@@ -345,10 +320,6 @@ TransactionError CombinePSBTs(PartiallySignedTransaction& out, const std::vector
+             return TransactionError::PSBT_MISMATCH;
+         }
+     }
+-    if (!out.IsSane()) {
+-        return TransactionError::INVALID_PSBT;
+-    }
+-
+     return TransactionError::OK;
+ }
+ 
+diff --git a/src/psbt.h b/src/psbt.h
+index 888e0fd119..cbf4296bd2 100644
+--- a/src/psbt.h
++++ b/src/psbt.h
+@@ -62,7 +62,6 @@ struct PSBTInput
+     void FillSignatureData(SignatureData& sigdata) const;
+     void FromSignatureData(const SignatureData& sigdata);
+     void Merge(const PSBTInput& input);
+-    bool IsSane() const;
+     PSBTInput() {}
+ 
+     template <typename Stream>
+@@ -284,7 +283,6 @@ struct PSBTOutput
+     void FillSignatureData(SignatureData& sigdata) const;
+     void FromSignatureData(const SignatureData& sigdata);
+     void Merge(const PSBTOutput& output);
+-    bool IsSane() const;
+     PSBTOutput() {}
+ 
+     template <typename Stream>
+@@ -401,7 +399,6 @@ struct PartiallySignedTransaction
+     /** Merge psbt into this. The two psbts must have the same underlying CTransaction (i.e. the
+       * same actual Bitcoin transaction.) Returns true if the merge succeeded, false otherwise. */
+     NODISCARD bool Merge(const PartiallySignedTransaction& psbt);
+-    bool IsSane() const;
+     bool AddInput(const CTxIn& txin, PSBTInput& psbtin);
+     bool AddOutput(const CTxOut& txout, const PSBTOutput& psbtout);
+     PartiallySignedTransaction() {}
+@@ -551,10 +548,6 @@ struct PartiallySignedTransaction
+         if (outputs.size() != tx->vout.size()) {
+             throw std::ios_base::failure("Outputs provided does not match the number of outputs in transaction.");
+         }
+-        // Sanity check
+-        if (!IsSane()) {
+-            throw std::ios_base::failure("PSBT is not sane.");
+-        }
+     }
+ 
+     template <typename Stream>
+diff --git a/src/test/fuzz/psbt.cpp b/src/test/fuzz/psbt.cpp
+index 64328fb66e..908e2b16f2 100644
+--- a/src/test/fuzz/psbt.cpp
++++ b/src/test/fuzz/psbt.cpp
+@@ -39,7 +39,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
+     }
+ 
+     (void)psbt.IsNull();
+-    (void)psbt.IsSane();
+ 
+     Optional<CMutableTransaction> tx = psbt.tx;
+     if (tx) {
+@@ -50,7 +49,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
+     for (const PSBTInput& input : psbt.inputs) {
+         (void)PSBTInputSigned(input);
+         (void)input.IsNull();
+-        (void)input.IsSane();
+     }
+ 
+     for (const PSBTOutput& output : psbt.outputs) {
+diff --git a/src/wallet/scriptpubkeyman.cpp b/src/wallet/scriptpubkeyman.cpp
+index 8a2a798644..9fae27975d 100644
+--- a/src/wallet/scriptpubkeyman.cpp
++++ b/src/wallet/scriptpubkeyman.cpp
+@@ -595,11 +595,6 @@ TransactionError LegacyScriptPubKeyMan::FillPSBT(PartiallySignedTransaction& psb
+             continue;
+         }
+ 
+-        // Verify input looks sane. This will check that we have at most one uxto, witness or non-witness.
+-        if (!input.IsSane()) {
+-            return TransactionError::INVALID_PSBT;
+-        }
+-
+         // Get the Sighash type
+         if (sign && input.sighash_type > 0 && input.sighash_type != sighash_type) {
+             return TransactionError::SIGHASH_MISMATCH;
+@@ -2074,11 +2069,6 @@ TransactionError DescriptorScriptPubKeyMan::FillPSBT(PartiallySignedTransaction&
+             continue;
+         }
+ 
+-        // Verify input looks sane. This will check that we have at most one uxto, witness or non-witness.
+-        if (!input.IsSane()) {
+-            return TransactionError::INVALID_PSBT;
+-        }
+-
+         // Get the Sighash type
+         if (sign && input.sighash_type > 0 && input.sighash_type != sighash_type) {
+             return TransactionError::SIGHASH_MISMATCH;
+diff --git a/src/wallet/wallet.cpp b/src/wallet/wallet.cpp
+index 89737ca7b5..054b312cd7 100644
+--- a/src/wallet/wallet.cpp
++++ b/src/wallet/wallet.cpp
+@@ -2490,11 +2490,6 @@ TransactionError CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bool& comp
+             continue;
+         }
+ 
+-        // Verify input looks sane. This will check that we have at most one uxto, witness or non-witness.
+-        if (!input.IsSane()) {
+-            return TransactionError::INVALID_PSBT;
+-        }
+-
+         // If we have no utxo, grab it from the wallet.
+         if (!input.non_witness_utxo && input.witness_utxo.IsNull()) {
+             const uint256& txhash = txin.prevout.hash;
+-- 
+2.27.0
+
+
+From 946b5c010fa23103c1ee5f584bd5be240e42c4c9 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Thu, 4 Jun 2020 23:43:43 -0400
+Subject: [PATCH 3/3] psbt: always put a non_witness_utxo and don't remove it
+
+Offline signers will always need a non_witness_utxo so make sure it is
+there.
+---
+ src/psbt.cpp                          |  7 +-
+ src/psbt.h                            |  4 +-
+ src/wallet/test/psbt_wallet_tests.cpp |  2 +-
+ src/wallet/wallet.cpp                 |  2 +-
+ test/functional/rpc_psbt.py           | 94 ++++++++++++++-------------
+ 5 files changed, 56 insertions(+), 53 deletions(-)
+
+diff --git a/src/psbt.cpp b/src/psbt.cpp
+index 4c8b40ca0b..51f829d533 100644
+--- a/src/psbt.cpp
++++ b/src/psbt.cpp
+@@ -136,8 +136,8 @@ void PSBTInput::Merge(const PSBTInput& input)
+ {
+     if (!non_witness_utxo && input.non_witness_utxo) non_witness_utxo = input.non_witness_utxo;
+     if (witness_utxo.IsNull() && !input.witness_utxo.IsNull()) {
++        // TODO: For segwit v1, we will want to clear out the non-witness utxo when setting a witness one. For v0 and non-segwit, this is not safe
+         witness_utxo = input.witness_utxo;
+-        non_witness_utxo = nullptr; // Clear out any non-witness utxo when we set a witness one.
+     }
+ 
+     partial_sigs.insert(input.partial_sigs.begin(), input.partial_sigs.end());
+@@ -263,10 +263,11 @@ bool SignPSBTInput(const SigningProvider& provider, PartiallySignedTransaction&
+     if (require_witness_sig && !sigdata.witness) return false;
+     input.FromSignatureData(sigdata);
+ 
+-    // If we have a witness signature, use the smaller witness UTXO.
++    // If we have a witness signature, put a witness UTXO.
++    // TODO: For segwit v1, we should remove the non_witness_utxo
+     if (sigdata.witness) {
+         input.witness_utxo = utxo;
+-        input.non_witness_utxo = nullptr;
++        // input.non_witness_utxo = nullptr;
+     }
+ 
+     // Fill in the missing info
+diff --git a/src/psbt.h b/src/psbt.h
+index cbf4296bd2..275fb03cd8 100644
+--- a/src/psbt.h
++++ b/src/psbt.h
+@@ -67,12 +67,12 @@ struct PSBTInput
+     template <typename Stream>
+     inline void Serialize(Stream& s) const {
+         // Write the utxo
+-        // If there is a non-witness utxo, then don't add the witness one.
+         if (non_witness_utxo) {
+             SerializeToVector(s, PSBT_IN_NON_WITNESS_UTXO);
+             OverrideStream<Stream> os(&s, s.GetType(), s.GetVersion() | SERIALIZE_TRANSACTION_NO_WITNESS);
+             SerializeToVector(os, non_witness_utxo);
+-        } else if (!witness_utxo.IsNull()) {
++        }
++        if (!witness_utxo.IsNull()) {
+             SerializeToVector(s, PSBT_IN_WITNESS_UTXO);
+             SerializeToVector(s, witness_utxo);
+         }
+diff --git a/src/wallet/test/psbt_wallet_tests.cpp b/src/wallet/test/psbt_wallet_tests.cpp
+index b4c65a8665..119457aadf 100644
+--- a/src/wallet/test/psbt_wallet_tests.cpp
++++ b/src/wallet/test/psbt_wallet_tests.cpp
+@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(psbt_updater_test)
+     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+     ssTx << psbtx;
+     std::string final_hex = HexStr(ssTx.begin(), ssTx.end());
+-    BOOST_CHECK_EQUAL(final_hex, "70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f00000000000100bb0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f6187650000000104475221029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f2102dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d752ae2206029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f10d90c6a4f000000800000008000000080220602dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d710d90c6a4f0000008000000080010000800001012000c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e88701042200208c2353173743b595dfb4a07b72ba8e42e3797da74e87fe7d9d7497e3b2028903010547522103089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc21023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7352ae2206023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7310d90c6a4f000000800000008003000080220603089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc10d90c6a4f00000080000000800200008000220203a9a4c37f5996d3aa25dbac6b570af0650394492942460b354753ed9eeca5877110d90c6a4f000000800000008004000080002202027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b5005109610d90c6a4f00000080000000800500008000");
++    BOOST_CHECK_EQUAL(final_hex, "70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f00000000000100bb0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f6187650000000104475221029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f2102dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d752ae2206029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f10d90c6a4f000000800000008000000080220602dab61ff49a14db6a7d02b0cd1fbb78fc4b18312b5b4e54dae4dba2fbfef536d710d90c6a4f0000008000000080010000800001008a020000000158e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd7501000000171600145f275f436b09a8cc9a2eb2a2f528485c68a56323feffffff02d8231f1b0100000017a914aed962d6654f9a2b36608eb9d64d2b260db4f1118700c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e8876500000001012000c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e88701042200208c2353173743b595dfb4a07b72ba8e42e3797da74e87fe7d9d7497e3b2028903010547522103089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc21023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7352ae2206023add904f3d6dcf59ddb906b0dee23529b7ffb9ed50e5e86151926860221f0e7310d90c6a4f000000800000008003000080220603089dc10c7ac6db54f91329af617333db388cead0c231f723379d1b99030b02dc10d90c6a4f00000080000000800200008000220203a9a4c37f5996d3aa25dbac6b570af0650394492942460b354753ed9eeca5877110d90c6a4f000000800000008004000080002202027f6399757d2eff55a136ad02c684b1838b6556e5f1b6b34282a94b6b5005109610d90c6a4f00000080000000800500008000");
+ 
+     // Mutate the transaction so that one of the inputs is invalid
+     psbtx.tx->vin[0].prevout.n = 2;
+diff --git a/src/wallet/wallet.cpp b/src/wallet/wallet.cpp
+index 054b312cd7..7816a39ec1 100644
+--- a/src/wallet/wallet.cpp
++++ b/src/wallet/wallet.cpp
+@@ -2491,7 +2491,7 @@ TransactionError CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bool& comp
+         }
+ 
+         // If we have no utxo, grab it from the wallet.
+-        if (!input.non_witness_utxo && input.witness_utxo.IsNull()) {
++        if (!input.non_witness_utxo) {
+             const uint256& txhash = txin.prevout.hash;
+             const auto it = mapWallet.find(txhash);
+             if (it != mapWallet.end()) {
+diff --git a/test/functional/rpc_psbt.py b/test/functional/rpc_psbt.py
+index 51d136d26a..735293bbc7 100755
+--- a/test/functional/rpc_psbt.py
++++ b/test/functional/rpc_psbt.py
+@@ -37,51 +37,52 @@ class PSBTTest(BitcoinTestFramework):
+     def skip_test_if_missing_module(self):
+         self.skip_if_no_wallet()
+ 
+-    def test_utxo_conversion(self):
+-        mining_node = self.nodes[2]
+-        offline_node = self.nodes[0]
+-        online_node = self.nodes[1]
+-
+-        # Disconnect offline node from others
+-        disconnect_nodes(offline_node, 1)
+-        disconnect_nodes(online_node, 0)
+-        disconnect_nodes(offline_node, 2)
+-        disconnect_nodes(mining_node, 0)
+-
+-        # Create watchonly on online_node
+-        online_node.createwallet(wallet_name='wonline', disable_private_keys=True)
+-        wonline = online_node.get_wallet_rpc('wonline')
+-        w2 = online_node.get_wallet_rpc('')
+-
+-        # Mine a transaction that credits the offline address
+-        offline_addr = offline_node.getnewaddress(address_type="p2sh-segwit")
+-        online_addr = w2.getnewaddress(address_type="p2sh-segwit")
+-        wonline.importaddress(offline_addr, "", False)
+-        mining_node.sendtoaddress(address=offline_addr, amount=1.0)
+-        mining_node.generate(nblocks=1)
+-        self.sync_blocks([mining_node, online_node])
+-
+-        # Construct an unsigned PSBT on the online node (who doesn't know the output is Segwit, so will include a non-witness UTXO)
+-        utxos = wonline.listunspent(addresses=[offline_addr])
+-        raw = wonline.createrawtransaction([{"txid":utxos[0]["txid"], "vout":utxos[0]["vout"]}],[{online_addr:0.9999}])
+-        psbt = wonline.walletprocesspsbt(online_node.converttopsbt(raw))["psbt"]
+-        assert "non_witness_utxo" in mining_node.decodepsbt(psbt)["inputs"][0]
+-
+-        # Have the offline node sign the PSBT (which will update the UTXO to segwit)
+-        signed_psbt = offline_node.walletprocesspsbt(psbt)["psbt"]
+-        assert "witness_utxo" in mining_node.decodepsbt(signed_psbt)["inputs"][0]
+-
+-        # Make sure we can mine the resulting transaction
+-        txid = mining_node.sendrawtransaction(mining_node.finalizepsbt(signed_psbt)["hex"])
+-        mining_node.generate(1)
+-        self.sync_blocks([mining_node, online_node])
+-        assert_equal(online_node.gettxout(txid,0)["confirmations"], 1)
+-
+-        wonline.unloadwallet()
+-
+-        # Reconnect
+-        connect_nodes(self.nodes[0], 1)
+-        connect_nodes(self.nodes[0], 2)
++    # TODO: Re-enable this test with segwit v1
++    # def test_utxo_conversion(self):
++    #     mining_node = self.nodes[2]
++    #     offline_node = self.nodes[0]
++    #     online_node = self.nodes[1]
++    #
++    #     # Disconnect offline node from others
++    #     disconnect_nodes(offline_node, 1)
++    #     disconnect_nodes(online_node, 0)
++    #     disconnect_nodes(offline_node, 2)
++    #     disconnect_nodes(mining_node, 0)
++    #
++    #     # Create watchonly on online_node
++    #     online_node.createwallet(wallet_name='wonline', disable_private_keys=True)
++    #     wonline = online_node.get_wallet_rpc('wonline')
++    #     w2 = online_node.get_wallet_rpc('')
++    #
++    #     # Mine a transaction that credits the offline address
++    #     offline_addr = offline_node.getnewaddress(address_type="p2sh-segwit")
++    #     online_addr = w2.getnewaddress(address_type="p2sh-segwit")
++    #     wonline.importaddress(offline_addr, "", False)
++    #     mining_node.sendtoaddress(address=offline_addr, amount=1.0)
++    #     mining_node.generate(nblocks=1)
++    #     self.sync_blocks([mining_node, online_node])
++    #
++    #     # Construct an unsigned PSBT on the online node (who doesn't know the output is Segwit, so will include a non-witness UTXO)
++    #     utxos = wonline.listunspent(addresses=[offline_addr])
++    #     raw = wonline.createrawtransaction([{"txid":utxos[0]["txid"], "vout":utxos[0]["vout"]}],[{online_addr:0.9999}])
++    #     psbt = wonline.walletprocesspsbt(online_node.converttopsbt(raw))["psbt"]
++    #    assert "non_witness_utxo" in mining_node.decodepsbt(psbt)["inputs"][0]
++    #
++    #     # Have the offline node sign the PSBT (which will update the UTXO to segwit)
++    #     signed_psbt = offline_node.walletprocesspsbt(psbt)["psbt"]
++    #     assert "witness_utxo" in mining_node.decodepsbt(signed_psbt)["inputs"][0]
++    #
++    #     # Make sure we can mine the resulting transaction
++    #     txid = mining_node.sendrawtransaction(mining_node.finalizepsbt(signed_psbt)["hex"])
++    #     mining_node.generate(1)
++    #     self.sync_blocks([mining_node, online_node])
++    #     assert_equal(online_node.gettxout(txid,0)["confirmations"], 1)
++    #
++    #     wonline.unloadwallet()
++    #
++    #     # Reconnect
++    #     connect_nodes(self.nodes[0], 1)
++    #     connect_nodes(self.nodes[0], 2)
+ 
+     def run_test(self):
+         # Create and fund a raw tx for sending 10 BTC
+@@ -346,7 +347,8 @@ class PSBTTest(BitcoinTestFramework):
+         for i, signer in enumerate(signers):
+             self.nodes[2].unloadwallet("wallet{}".format(i))
+ 
+-        self.test_utxo_conversion()
++        # TODO: Re-enable this for segwit v1
++        # self.test_utxo_conversion()
+ 
+         # Test that psbts with p2pkh outputs are created properly
+         p2pkh = self.nodes[0].getnewaddress(address_type='legacy')
+-- 
+2.27.0
+

--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -216,6 +216,7 @@ else
         bitcoind_setup_needed=true
     fi
 fi
+git am ../../data/psbt_non_witness_utxo_segwit.patch
 
 # Build bitcoind. This is super slow, but it is cached so it runs fairly quickly.
 if [ "$bitcoind_setup_needed" == true ] ; then

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -456,6 +456,11 @@ class TestSignTx(DeviceTestCase):
                 pass
 
 class TestDisplayAddress(DeviceTestCase):
+    def setUp(self):
+        if '--testnet' not in self.dev_args:
+            self.dev_args.append('--testnet')
+        self.emulator.start()
+
     def test_display_address_bad_args(self):
         result = self.do_command(self.dev_args + ['displayaddress', '--sh_wpkh', '--wpkh', '--path', 'm/49h/1h/0h/0/0'])
         self.assertIn('error', result)

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -420,10 +420,9 @@ class TestSignTx(DeviceTestCase):
         supports_mixed = {'coldcard', 'trezor_1', 'digitalbitbox', 'keepkey'}
         supports_multisig = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t'}
         supports_external = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard'}
-        if self.full_type not in supports_mixed:
-            self._test_signtx("legacy", self.full_type in supports_multisig, self.full_type in supports_external)
-            self._test_signtx("segwit", self.full_type in supports_multisig, self.full_type in supports_external)
-        else:
+        self._test_signtx("legacy", self.full_type in supports_multisig, self.full_type in supports_external)
+        self._test_signtx("segwit", self.full_type in supports_multisig, self.full_type in supports_external)
+        if self.full_type in supports_mixed:
             self._test_signtx("all", self.full_type in supports_multisig, self.full_type in supports_external)
 
     # Make a huge transaction which might cause some problems with different interfaces

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -335,10 +335,10 @@ class TestSignTx(DeviceTestCase):
 
     def _test_signtx(self, input_type, multisig, external):
         # Import some keys to the watch only wallet and send coins to them
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--sh_wpkh', '30', '40'])
+        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--sh_wpkh', '30', '50'])
         import_result = self.wrpc.importmulti(keypool_desc)
         self.assertTrue(import_result[0]['success'])
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--sh_wpkh', '--internal', '30', '40'])
+        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--sh_wpkh', '--internal', '30', '50'])
         import_result = self.wrpc.importmulti(keypool_desc)
         self.assertTrue(import_result[0]['success'])
         sh_wpkh_addr = self.wrpc.getnewaddress('', 'p2sh-segwit')


### PR DESCRIPTION
This is a general update to fix many issues related to newly released signing behavior in Trezors and Ledgers.

* The PSBT module is updated to handle PSBT inputs that include both `non_witness_utxo` and `witness_utxo`
* For Trezor, Ledger, and Bitbox, instead of checking for existence of `witness_utxo`, `witness_script`, and `redeem_script` to determine signing behavior, we instead inspect the scripts using existing template functions to determine their type and base our behavior on that.
* For Trezor and Ledger, the signing behavior is updated to pass in the full previous transaction for segwit inputs if they are available.
* For Trezor, all of the derivation paths are updated to fit within Trezor's "known paths".
* In the tests, a patch to bitcoind is added that allows for PSBTs with inputs that have both UTXO types. This is mostly from https://github.com/bitcoin/bitcoin/pull/19215 and should be removed once that PR is merged.

Note that the Ledger emulator has not been updated to include the Bitcoin app that has the segwit requirements. Also note that the updated app with those requirements seems to have a [bug](https://github.com/LedgerHQ/app-bitcoin/issues/154) when a transaction has multiple segwit inputs.

Closes #338 and #337