### PR TITLE
travis: Remove macOS binary upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,9 +118,6 @@ jobs:
             stage: test
             os: osx
             language: generic
-            addons:
-                artifacts:
-                    working_dir: dist
             before_install:
             install:
                 - brew update && brew upgrade pyenv


### PR DESCRIPTION
Got a mac, don't need travis to do the release build anymore. Will merge when travis completes and I verify it doesn't upload anything.