### PR TITLE
Support multisig xpub descriptors on Trezor

### DIFF
--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -236,15 +236,18 @@ def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False, rede
         if descriptor.sh or descriptor.sh_wsh or descriptor.wsh:
             path = ''
             redeem_script = format(80 + int(descriptor.multisig_M), 'x')
+            xpubs_descriptor = False
             for i in range(0, descriptor.multisig_N):
-                path += descriptor.origin_fingerprint[i] + descriptor.origin_path[i] + ','
+                path += descriptor.origin_fingerprint[i] + descriptor.origin_path[i]
                 if not descriptor.path_suffix[i]:
                     redeem_script += '21' + descriptor.base_key[i]
                 else:
-                    return {'error': 'Multisig descriptor must include all pubkeys', 'code': BAD_ARGUMENT}
+                    path += descriptor.path_suffix[i]
+                    xpubs_descriptor = True
+                path += ','
             path = path[0:-1]
             redeem_script += format(80 + descriptor.multisig_N, 'x') + 'ae'
-            return client.display_address(path, descriptor.sh_wpkh or descriptor.sh_wsh, descriptor.wpkh or descriptor.wsh, redeem_script)
+            return client.display_address(path, descriptor.sh_wpkh or descriptor.sh_wsh, descriptor.wpkh or descriptor.wsh, redeem_script, descriptor=descriptor if xpubs_descriptor else None)
         if descriptor.m_path is None:
             return {'error': 'Descriptor missing origin info: ' + desc, 'code': BAD_ARGUMENT}
         if descriptor.origin_fingerprint != client.get_master_fingerprint_hex():

--- a/hwilib/descriptor.py
+++ b/hwilib/descriptor.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 import re
 
 # From: https://github.com/bitcoin/bitcoin/blob/master/src/script/descriptor.cpp
@@ -82,6 +83,12 @@ class Descriptor:
         if origin_path and not isinstance(origin_path, list):
             self.m_path_base = "m" + origin_path
             self.m_path = "m" + origin_path + (path_suffix or "")
+        elif isinstance(origin_path, list):
+            self.m_path_base = []
+            self.m_path = []
+            for i in range(0, len(origin_path)):
+                self.m_path_base.append("m" + origin_path[i])
+                self.m_path.append("m" + origin_path[i] + (path_suffix[i] or ""))
 
     @classmethod
     def parse(cls, desc, testnet=False):

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -205,7 +205,7 @@ class ColdcardClient(HardwareWalletClient):
 
     # Display address of specified type on the device.
     @coldcard_exception
-    def display_address(self, keypath, p2sh_p2wpkh, bech32, redeem_script=None):
+    def display_address(self, keypath, p2sh_p2wpkh, bech32, redeem_script=None, descriptor=None):
         self.device.check_mitm()
         keypath = keypath.replace('h', '\'')
         keypath = keypath.replace('H', '\'')

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -549,7 +549,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         return {"signature": base64.b64encode(compact_sig).decode('utf-8')}
 
     # Display address of specified type on the device.
-    def display_address(self, keypath, p2sh_p2wpkh, bech32, redeem_script=None):
+    def display_address(self, keypath, p2sh_p2wpkh, bech32, redeem_script=None, descriptor=None):
         raise UnavailableActionError('The Digital Bitbox does not have a screen to display addresses on')
 
     # Setup a new device

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -340,7 +340,7 @@ class LedgerClient(HardwareWalletClient):
 
     # Display address of specified type on the device. Only supports single-key based addresses.
     @ledger_exception
-    def display_address(self, keypath, p2sh_p2wpkh, bech32, redeem_script=None):
+    def display_address(self, keypath, p2sh_p2wpkh, bech32, redeem_script=None, descriptor=None):
         if not check_keypath(keypath):
             raise BadArgumentError("Invalid keypath")
         if redeem_script is not None:

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -410,11 +410,20 @@ class TrezorClient(HardwareWalletClient):
 
     # Display address of specified type on the device.
     @trezor_exception
-    def display_address(self, keypath, p2sh_p2wpkh, bech32, redeem_script=None):
+    def display_address(self, keypath, p2sh_p2wpkh, bech32, redeem_script=None, descriptor=None):
         self._check_unlocked()
 
+        # descriptor means multisig with xpubs
+        if descriptor:
+            pubkeys = []
+            xpub = ExtendedKey()
+            for i in range(0, descriptor.multisig_N):
+                xpub.deserialize(descriptor.base_key[i])
+                hd_node = proto.HDNodeType(depth=xpub.depth, fingerprint=int.from_bytes(xpub.parent_fingerprint, 'big'), child_num=xpub.child_num, chain_code=xpub.chaincode, public_key=xpub.pubkey)
+                pubkeys.append(proto.HDNodePathType(node=hd_node, address_n=tools.parse_path('m' + descriptor.path_suffix[i])))
+            multisig = proto.MultisigRedeemScriptType(m=int(descriptor.multisig_M), signatures=[b''] * int(descriptor.multisig_N), pubkeys=pubkeys)
         # redeem_script means p2sh/multisig
-        if redeem_script:
+        elif redeem_script:
             # Get multisig object required by Trezor's get_address
             multisig = parse_multisig(bytes.fromhex(redeem_script))
             if not multisig[0]:

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -1,6 +1,7 @@
 from typing import Dict, Optional, Union
 
 from .base58 import get_xpub_fingerprint_hex
+from .descriptor import Descriptor
 from .serializations import PSBT
 
 
@@ -73,6 +74,7 @@ class HardwareWalletClient(object):
         p2sh_p2wpkh: bool,
         bech32: bool,
         redeem_script: Optional[str] = None,
+        descriptor: Optional[Descriptor] = None,
     ) -> Dict[str, str]:
         """Display and return the address of specified type.
 

--- a/test/test_descriptor.py
+++ b/test/test_descriptor.py
@@ -16,6 +16,18 @@ class TestDescriptor(unittest.TestCase):
         self.assertEqual(desc.testnet, True)
         self.assertEqual(desc.m_path, "m/84'/1'/0'/0/0")
 
+    def test_parse_multisig_descriptor_with_origin(self):
+        desc = Descriptor.parse("wsh(multi(2,[00000001/48'/0'/0'/2']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0,[00000002/48'/0'/0'/2']tpubDFHiBJDeNvqPWNJbzzxqDVXmJZoNn2GEtoVcFhMjXipQiorGUmps3e5ieDGbRrBPTFTh9TXEKJCwbAGW9uZnfrVPbMxxbFohuFzfT6VThty/0/0))", True)
+        self.assertIsNotNone(desc)
+        self.assertEqual(desc.wsh, True)
+        self.assertEqual(desc.origin_fingerprint, ["00000001", "00000002"])
+        self.assertEqual(desc.origin_path, ["/48'/0'/0'/2'", "/48'/0'/0'/2'"])
+        self.assertEqual(desc.base_key, ["tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B", "tpubDFHiBJDeNvqPWNJbzzxqDVXmJZoNn2GEtoVcFhMjXipQiorGUmps3e5ieDGbRrBPTFTh9TXEKJCwbAGW9uZnfrVPbMxxbFohuFzfT6VThty"])
+        self.assertEqual(desc.path_suffix, ["/0/0", "/0/0"])
+        self.assertEqual(desc.testnet, True)
+        self.assertEqual(desc.m_path_base, ["m/48'/0'/0'/2'", "m/48'/0'/0'/2'"])
+        self.assertEqual(desc.m_path, ["m/48'/0'/0'/2'/0/0", "m/48'/0'/0'/2'/0/0"])
+
     def test_parse_descriptor_without_origin(self):
         desc = Descriptor.parse("wpkh(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0)", True)
         self.assertIsNotNone(desc)


### PR DESCRIPTION
Trezor Model T has an option when displaying a multisig address to also show all xpubs used as cosigners of the multisig. Currently, the display address function did not support using xpubs, so here I added support in Trezor for such descriptors, which will make xpubs show up correctly.