### PR TITLE
Trezor and Keepkey: Fix empty passphrase behavior

### DIFF
--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -119,7 +119,7 @@ def process_commands(cli_args):
     parser = HWIArgumentParser(description='Hardware Wallet Interface, version {}.\nAccess and send commands to a hardware wallet device. Responses are in JSON format.'.format(__version__))
     parser.add_argument('--device-path', '-d', help='Specify the device path of the device to connect to')
     parser.add_argument('--device-type', '-t', help='Specify the type of device that will be connected. If `--device-path` not given, the first device of this type enumerated is used.')
-    parser.add_argument('--password', '-p', help='Device password if it has one (e.g. DigitalBitbox)', default='')
+    parser.add_argument('--password', '-p', help='Device password if it has one (e.g. DigitalBitbox)', default=None)
     parser.add_argument('--stdinpass', help='Enter the device password on the command line', action='store_true')
     parser.add_argument('--testnet', help='Use testnet prefixes', action='store_true')
     parser.add_argument('--debug', help='Print debug statements', action='store_true')

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -22,7 +22,7 @@ class AddressType(Enum):
     SH_WPKH = 3
 
 # Get the client for the device
-def get_client(device_type, device_path, password='', expert=False):
+def get_client(device_type, device_path, password=None, expert=False):
     device_type = device_type.split('_')[0]
     class_name = device_type.capitalize()
     module = device_type.lower()
@@ -40,7 +40,7 @@ def get_client(device_type, device_path, password='', expert=False):
     return client
 
 # Get a list of all available hardware wallets
-def enumerate(password=''):
+def enumerate(password=None):
     result = []
 
     for module in all_devs:
@@ -52,7 +52,7 @@ def enumerate(password=''):
     return result
 
 # Fingerprint or device type required
-def find_device(password='', device_type=None, fingerprint=None, expert=False):
+def find_device(password=None, device_type=None, fingerprint=None, expert=False):
     devices = enumerate(password)
     for d in devices:
         if device_type is not None and d['type'] != device_type and d['model'] != device_type:

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -69,7 +69,9 @@ def coldcard_exception(f):
 # This class extends the HardwareWalletClient for ColdCard specific things
 class ColdcardClient(HardwareWalletClient):
 
-    def __init__(self, path, password='', expert=False):
+    def __init__(self, path, password=None, expert=False):
+        if password is None:
+            password = ''
         super(ColdcardClient, self).__init__(path, password, expert)
         # Simulator hard coded pipe socket
         if path == CC_SIMULATOR_SOCK:
@@ -313,7 +315,7 @@ class ColdcardClient(HardwareWalletClient):
     def toggle_passphrase(self):
         raise UnavailableActionError('The Coldcard does not support toggling passphrase from the host')
 
-def enumerate(password=''):
+def enumerate(password=None):
     results = []
     devices = hid.enumerate(COINKITE_VID, CKCC_PID)
     devices.append({'path': CC_SIMULATOR_SOCK.encode()})

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -620,7 +620,7 @@ class DigitalbitboxClient(HardwareWalletClient):
     def toggle_passphrase(self):
         raise UnavailableActionError('The Digital Bitbox does not support toggling passphrase from the host')
 
-def enumerate(password=''):
+def enumerate(password=None):
     results = []
     devices = hid.enumerate(DBB_VENDOR_ID, DBB_DEVICE_ID)
     # Try connecting to simulator

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -15,11 +15,11 @@ from .trezor import TrezorClient
 py_enumerate = enumerate # Need to use the enumerate built-in but there's another function already named that
 
 class KeepkeyClient(TrezorClient):
-    def __init__(self, path, password='', expert=False):
+    def __init__(self, path, password=None, expert=False):
         super(KeepkeyClient, self).__init__(path, password, expert)
         self.type = 'Keepkey'
 
-def enumerate(password=''):
+def enumerate(password=None):
     results = []
     for dev in enumerate_devices():
         # enumerate_devices filters to Trezors and Keepkeys.
@@ -47,7 +47,7 @@ def enumerate(password=''):
             d_data['needs_passphrase_sent'] = client.client.features.passphrase_protection # always need the passphrase sent for Keepkey if it has passphrase protection enabled
             if d_data['needs_pin_sent']:
                 raise DeviceNotReadyError('Keepkey is locked. Unlock by using \'promptpin\' and then \'sendpin\'.')
-            if d_data['needs_passphrase_sent'] and not password:
+            if d_data['needs_passphrase_sent'] and password is None:
                 raise DeviceNotReadyError("Passphrase needs to be specified before the fingerprint information can be retrieved")
             if client.client.features.initialized:
                 d_data['fingerprint'] = client.get_master_fingerprint_hex()

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -91,7 +91,7 @@ def ledger_exception(f):
 # This class extends the HardwareWalletClient for Ledger Nano S and Nano X specific things
 class LedgerClient(HardwareWalletClient):
 
-    def __init__(self, path, password='', expert=False):
+    def __init__(self, path, password=None, expert=False):
         super(LedgerClient, self).__init__(path, password, expert)
 
         if path.startswith('tcp'):
@@ -380,7 +380,7 @@ class LedgerClient(HardwareWalletClient):
     def toggle_passphrase(self):
         raise UnavailableActionError('The Ledger Nano S and X do not support toggling passphrase from the host')
 
-def enumerate(password=''):
+def enumerate(password=None):
     results = []
     devices = []
     for device_id in LEDGER_DEVICE_IDS:
@@ -403,6 +403,8 @@ def enumerate(password=''):
             client = None
             with handle_errors(common_err_msgs["enumerate"], d_data):
                 try:
+                    if password is None:
+                        password = ''
                     client = LedgerClient(path, password)
                     d_data['fingerprint'] = client.get_master_fingerprint_hex()
                     d_data['needs_pin_sent'] = False

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -129,7 +129,7 @@ def interactive_get_pin(self, code=None):
 # This class extends the HardwareWalletClient for Trezor specific things
 class TrezorClient(HardwareWalletClient):
 
-    def __init__(self, path, password='', expert=False):
+    def __init__(self, path, password=None, expert=False):
         super(TrezorClient, self).__init__(path, password, expert)
         self.simulator = False
         if path.startswith('udp'):
@@ -541,7 +541,7 @@ class TrezorClient(HardwareWalletClient):
                 print(PIN_MATRIX_DESCRIPTION, file=sys.stderr)
         return {'success': True}
 
-def enumerate(password=''):
+def enumerate(password=None):
     results = []
     for dev in enumerate_devices():
         # enumerate_devices filters to Trezors and Keepkeys.
@@ -571,7 +571,7 @@ def enumerate(password=''):
                 d_data['needs_passphrase_sent'] = False
             if d_data['needs_pin_sent']:
                 raise DeviceNotReadyError('Trezor is locked. Unlock by using \'promptpin\' and then \'sendpin\'.')
-            if d_data['needs_passphrase_sent'] and not password:
+            if d_data['needs_passphrase_sent'] and password is None:
                 raise DeviceNotReadyError("Passphrase needs to be specified before the fingerprint information can be retrieved")
             if client.client.features.initialized:
                 d_data['fingerprint'] = client.get_master_fingerprint_hex()

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -69,7 +69,7 @@ class DeviceTestCase(unittest.TestCase):
             self.emulator = emulator
         else:
             self.emulator = DeviceEmulator()
-        if password:
+        if password is not None:
             self.dev_args.extend(['-p', password])
         self.interface = interface
 
@@ -103,7 +103,7 @@ class DeviceTestCase(unittest.TestCase):
             return process_commands(args)
 
     def get_password_args(self):
-        if self.password:
+        if self.password is not None:
             return ['-p', self.password]
         return []
 

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -142,16 +142,16 @@ class TestKeepkeyGetxpub(KeepkeyTestCase):
                 load_device_by_xprv(client=self.client, xprv=vec['xprv'], pin='', passphrase_protection=False, label='test', language='english')
 
                 # Test getmasterxpub
-                gmxp_res = self.do_command(['-t', 'keepkey', '-d', 'udp:127.0.0.1:21324', 'getmasterxpub'])
+                gmxp_res = self.do_command(['-t', 'keepkey', '-d', 'udp:127.0.0.1:21324', '-p', '', 'getmasterxpub'])
                 self.assertEqual(gmxp_res['xpub'], vec['master_xpub'])
 
                 # Test the path derivs
                 for path_vec in vec['vectors']:
-                    gxp_res = self.do_command(['-t', 'keepkey', '-d', 'udp:127.0.0.1:21324', 'getxpub', path_vec['path']])
+                    gxp_res = self.do_command(['-t', 'keepkey', '-d', 'udp:127.0.0.1:21324', '-p', '', 'getxpub', path_vec['path']])
                     self.assertEqual(gxp_res['xpub'], path_vec['xpub'])
 
     def test_expert_getxpub(self):
-        result = self.do_command(['-t', 'keepkey', '-d', 'udp:127.0.0.1:21324', '--expert', 'getxpub', 'm/44h/0h/0h/3'])
+        result = self.do_command(['-t', 'keepkey', '-d', 'udp:127.0.0.1:21324', '-p', '', '--expert', 'getxpub', 'm/44h/0h/0h/3'])
         self.assertEqual(result['xpub'], 'xpub6FMafWAi3n3ET2rU5yQr16UhRD1Zx4dELmcEw3NaYeBaNnipcr2zjzYp1sNdwR3aTN37hxAqRWQ13AWUZr6L9jc617mU6EvgYXyBjXrEhgr')
         self.assertFalse(result['testnet'])
         self.assertFalse(result['private'])
@@ -165,7 +165,7 @@ class TestKeepkeyGetxpub(KeepkeyTestCase):
 class TestKeepkeyManCommands(KeepkeyTestCase):
     def setUp(self):
         self.client = self.emulator.start()
-        self.dev_args = ['-t', 'keepkey', '-d', 'udp:127.0.0.1:21324']
+        self.dev_args = ['-t', 'keepkey', '-d', 'udp:127.0.0.1:21324', '-p', '']
 
     def test_setup_wipe(self):
         # Device is init, setup should fail
@@ -262,7 +262,7 @@ class TestKeepkeyManCommands(KeepkeyTestCase):
         self.do_command(self.dev_args + ['togglepassphrase'])
 
         # A passphrase will need to be sent
-        result = self.do_command(self.dev_args + ['enumerate'])
+        result = self.do_command(self.dev_args[0:-2] + ['enumerate'])
         for dev in result:
             if dev['type'] == 'keepkey' and dev['path'] == 'udp:127.0.0.1:21324':
                 self.assertTrue(dev['needs_passphrase_sent'])

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -150,16 +150,16 @@ class TestTrezorGetxpub(TrezorTestCase):
                 load_device_by_mnemonic(client=self.client, mnemonic=vec['mnemonic'], pin='', passphrase_protection=False, label='test', language='english')
 
                 # Test getmasterxpub
-                gmxp_res = self.do_command(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', 'getmasterxpub'])
+                gmxp_res = self.do_command(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', '-p', '', 'getmasterxpub'])
                 self.assertEqual(gmxp_res['xpub'], vec['master_xpub'])
 
                 # Test the path derivs
                 for path_vec in vec['vectors']:
-                    gxp_res = self.do_command(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', 'getxpub', path_vec['path']])
+                    gxp_res = self.do_command(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', '-p', '', 'getxpub', path_vec['path']])
                     self.assertEqual(gxp_res['xpub'], path_vec['xpub'])
 
     def test_expert_getxpub(self):
-        result = self.do_command(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', '--expert', 'getxpub', 'm/44h/0h/0h/3'])
+        result = self.do_command(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', '-p', '', '--expert', 'getxpub', 'm/44h/0h/0h/3'])
         self.assertEqual(result['xpub'], 'xpub6FMafWAi3n3ET2rU5yQr16UhRD1Zx4dELmcEw3NaYeBaNnipcr2zjzYp1sNdwR3aTN37hxAqRWQ13AWUZr6L9jc617mU6EvgYXyBjXrEhgr')
         self.assertFalse(result['testnet'])
         self.assertFalse(result['private'])
@@ -173,7 +173,7 @@ class TestTrezorGetxpub(TrezorTestCase):
 class TestTrezorManCommands(TrezorTestCase):
     def setUp(self):
         self.client = self.emulator.start()
-        self.dev_args = ['-t', 'trezor', '-d', 'udp:127.0.0.1:21324']
+        self.dev_args = ['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', '-p', '']
 
     def test_setup_wipe(self):
         # Device is init, setup should fail
@@ -270,7 +270,7 @@ class TestTrezorManCommands(TrezorTestCase):
         self.do_command(self.dev_args + ['togglepassphrase'])
 
         # A passphrase will need to be sent
-        result = self.do_command(self.dev_args + ['enumerate'])
+        result = self.do_command(self.dev_args[0:-2] + ['enumerate'])
         for dev in result:
             if dev['type'] == 'trezor' and dev['path'] == 'udp:127.0.0.1:21324':
                 self.assertTrue(dev['needs_passphrase_sent'])


### PR DESCRIPTION
Fix empty passphrase behavior for Trezor and Keepkey. Currently, it is not possible to get the details of a passphrase-enabled Trezor One or KeepKey with `enumerate` for an empty passphrase, while other commands use an empty passphrase by default. This PR differentiates between an empty passphrase (i.e. an empty string), and no passphrase (`None`). 
This, on the one hand, will allow using an empty passphrase with all commands, while by default, if no passphrase was passed at all, the device will not be usable (if passphrase is enabled), as compared to the present state where it is usable for all commands except enumerate.

As for the default passphrase option, I decided to set it to `None` as, while it could be just an empty passphrase, I think it is better to enforce user input for passphrase if is enabled. But if you think an empty passphrase as default is better I could change that, but choosing either of these options is better than the current state for consistency and usability.