### PR TITLE
add is_witness check before is_p2sh for non-witness utxos

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -257,7 +257,7 @@ class TrezorClient(HardwareWalletClient):
                 if is_ms:
                     # Add to txinputtype
                     txinputtype.multisig = multisig
-                    if not psbt_in.witness_utxo:
+                    if not is_wit:
                         if utxo.is_p2sh:
                             txinputtype.script_type = proto.InputScriptType.SPENDMULTISIG
                         else:


### PR DESCRIPTION
Fixes #360 

Correctly assigns the script type of an input when an input has a witnessScript but no witnessUtxo.