### PR TITLE
extended sign_message to also sign bytes, not only string

### DIFF
--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -13,6 +13,7 @@ import logging
 import socket
 import sys
 import time
+from typing import Dict, Union
 
 from ..hwwclient import HardwareWalletClient
 from ..errors import (
@@ -512,14 +513,15 @@ class DigitalbitboxClient(HardwareWalletClient):
 
         return {'psbt': tx.serialize()}
 
-    # Must return a base64 encoded string with the signed message
-    # The message can be any string
     @digitalbitbox_exception
-    def sign_message(self, message, keypath):
+    def sign_message(self, message: Union[str, bytes], keypath: str) -> Dict[str, str]:
         to_hash = b""
         to_hash += self.message_magic
         to_hash += ser_compact_size(len(message))
-        to_hash += message.encode()
+        if isinstance(message, bytes):
+            to_hash += message
+        else:
+            to_hash += message.encode()
 
         hashed_message = hash256(to_hash)
 

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -1,5 +1,7 @@
 # Ledger interaction script
 
+from typing import Dict, Union
+
 from ..hwwclient import HardwareWalletClient
 from ..errors import (
     ActionCanceledError,
@@ -311,13 +313,14 @@ class LedgerClient(HardwareWalletClient):
         # Send PSBT back
         return {'psbt': tx.serialize()}
 
-    # Must return a base64 encoded string with the signed message
-    # The message can be any string
     @ledger_exception
-    def sign_message(self, message, keypath):
+    def sign_message(self, message: Union[str, bytes], keypath: str) -> Dict[str, str]:
         if not check_keypath(keypath):
             raise BadArgumentError("Invalid keypath")
-        message = bytearray(message, 'utf-8')
+        if isinstance(message, str):
+            message = bytearray(message, 'utf-8')
+        else:
+            message = bytearray(message)
         keypath = keypath[2:]
         # First display on screen what address you're signing for
         self.app.getWalletPublicKey(keypath, True)

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -1,5 +1,7 @@
 # Trezor interaction script
 
+from typing import Dict, Union
+
 from ..hwwclient import HardwareWalletClient
 from ..errors import (
     ActionCanceledError,
@@ -399,10 +401,8 @@ class TrezorClient(HardwareWalletClient):
 
         return {'psbt': tx.serialize()}
 
-    # Must return a base64 encoded string with the signed message
-    # The message can be any string
     @trezor_exception
-    def sign_message(self, message, keypath):
+    def sign_message(self, message: Union[str, bytes], keypath: str) -> Dict[str, str]:
         self._check_unlocked()
         path = tools.parse_path(keypath)
         result = btc.sign_message(self.client, self.coin_name, path, message)

--- a/hwilib/devices/trezorlib/btc.py
+++ b/hwilib/devices/trezorlib/btc.py
@@ -15,9 +15,10 @@
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
 import binascii
+from typing import Union
 
 from . import messages
-from .tools import CallException, expect, normalize_nfc, session
+from .tools import expect, normalize_nfc, session
 
 
 @expect(messages.PublicKey)
@@ -62,7 +63,11 @@ def get_address(
 
 @expect(messages.MessageSignature)
 def sign_message(
-    client, coin_name, n, message, script_type=messages.InputScriptType.SPENDADDRESS
+    client,
+    coin_name,
+    n,
+    message: Union[str, bytes],
+    script_type=messages.InputScriptType.SPENDADDRESS,
 ):
     message = normalize_nfc(message)
     return client.call(
@@ -70,6 +75,7 @@ def sign_message(
             coin_name=coin_name, address_n=n, message=message, script_type=script_type
         )
     )
+
 
 @session
 def sign_tx(client, coin_name, inputs, outputs, details=None, prev_txes=None):

--- a/hwilib/devices/trezorlib/tools.py
+++ b/hwilib/devices/trezorlib/tools.py
@@ -19,7 +19,7 @@ import hashlib
 import re
 import struct
 import unicodedata
-from typing import List, NewType
+from typing import List, NewType, Union
 
 from .exceptions import TrezorFailure
 
@@ -181,13 +181,13 @@ def parse_path(nstr: str) -> Address:
         raise ValueError("Invalid BIP32 path", nstr)
 
 
-def normalize_nfc(txt):
+def normalize_nfc(txt: Union[str, bytes]) -> bytes:
     """
     Normalize message to NFC and return bytes suitable for protobuf.
     This seems to be bitcoin-qt standard of doing things.
     """
     if isinstance(txt, bytes):
-        txt = txt.decode()
+        return txt
     return unicodedata.normalize("NFC", txt).encode()
 
 

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -55,10 +55,14 @@ class HardwareWalletClient(object):
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")
 
-    def sign_message(self, message: str, bip32_path: str) -> Dict[str, str]:
+    def sign_message(
+        self, message: Union[str, bytes], bip32_path: str
+    ) -> Dict[str, str]:
         """Sign a message (bitcoin message signing).
 
-        Sign the message according to the bitcoin message signing standard.
+        Sign the message according to the bitcoin message signing standard:
+        usually, the message is a string that is encoded to bytes;
+        anyway, if the message is already bytes it is processed untouched.
 
         Retrieve the signing key at the specified BIP32 derivation path.
 


### PR DESCRIPTION
Bitcoin message signing is usually used to sign an input string which, as first step, is encoded to bytes. The rest of the implementation assumes bytes, operates on bytes, ecdsa-signs bytes.

This PR proposes to skip the string encoding if bytes, instead of a string, are provided as input: this allow to "bitcoin message sign" an arbitrary byte sequence (note that arbitrary byte sequences cannot be always decoded to strings). 

The changes to trezorlib/btc.py are only cosmetic and that file could actually be left untouched