### PR TITLE
added gitignore directives for virtual environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,12 @@ hwilib/ui/ui_*.py
 
 *.stderr
 *.stdout
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/


### PR DESCRIPTION
virtual environments are routinely created in the root project (sub)folder(s) and should be ignored by Git