### PR TITLE
Cleaned up log messages

### DIFF
--- a/hwilib/devices/trezorlib/client.py
+++ b/hwilib/devices/trezorlib/client.py
@@ -72,7 +72,7 @@ class TrezorClient:
     """
 
     def __init__(self, transport, ui=None, state=None):
-        LOG.info("creating client instance for device: {}".format(transport.get_path()))
+        LOG.debug("creating client instance for device: {}".format(transport.get_path()))
         self.transport = transport
         self.ui = ui
         self.state = state

--- a/hwilib/devices/trezorlib/device.py
+++ b/hwilib/devices/trezorlib/device.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the License along with this library.
 # If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.
 
+import logging
 import os
 import time
 import warnings
@@ -24,6 +25,8 @@ from .tools import expect, session
 from .transport import enumerate_devices, get_transport
 
 RECOVERY_BACK = "\x08"  # backspace character, sent literally
+
+LOG = logging.getLogger(__name__)
 
 
 class TrezorDevice:
@@ -192,7 +195,7 @@ def reset(
         raise RuntimeError("Invalid response, expected EntropyRequest")
 
     external_entropy = os.urandom(32)
-    # LOG.debug("Computer generated entropy: " + external_entropy.hex())
+    LOG.debug("Computer generated entropy: " + external_entropy.hex())
     ret = client.call(proto.EntropyAck(entropy=external_entropy))
     client.init_device()
     return ret

--- a/hwilib/devices/trezorlib/transport/__init__.py
+++ b/hwilib/devices/trezorlib/transport/__init__.py
@@ -121,7 +121,7 @@ def enumerate_devices() -> Iterable[Transport]:
         name = transport.__name__
         try:
             found = list(transport.enumerate())
-            LOG.info("Enumerating {}: found {} devices".format(name, len(found)))
+            LOG.debug("Enumerating {}: found {} devices".format(name, len(found)))
             devices.extend(found)
         except NotImplementedError:
             LOG.error("{} does not implement device enumeration".format(name))
@@ -144,7 +144,7 @@ def get_transport(path: str = None, prefix_search: bool = False) -> Transport:
     def match_prefix(a: str, b: str) -> bool:
         return a.startswith(b) or b.startswith(a)
 
-    LOG.info(
+    LOG.debug(
         "looking for device by {}: {}".format(
             "prefix" if prefix_search else "full path", path
         )

--- a/hwilib/devices/trezorlib/transport/hid.py
+++ b/hwilib/devices/trezorlib/transport/hid.py
@@ -27,7 +27,7 @@ LOG = logging.getLogger(__name__)
 try:
     import hid
 except Exception as e:
-    LOG.info("HID transport is disabled: {}".format(e))
+    LOG.warning("HID transport is disabled: {}".format(e))
     hid = None
 
 


### PR DESCRIPTION
In my team, we comment out that line to avoid Trezor writing to our LOG.info

As they say "your mileage may vary", but a final user's LOG.info should not be polluted by third party library.