### PR TITLE
Avoided bare except

### DIFF
--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -69,7 +69,7 @@ def find_device(password='', device_type=None, fingerprint=None, expert=False):
                 client.close()
                 continue
             return client
-        except:
+        except Exception:
             if client:
                 client.close()
             pass # Ignore things we wouldn't get fingerprints for

--- a/hwilib/devices/btchip/btchip.py
+++ b/hwilib/devices/btchip/btchip.py
@@ -84,7 +84,7 @@ class btchip:
 				self.scriptBlockLength = 50
 			else:
 				self.scriptBlockLength = 255
-		except:
+		except Exception:
 			pass			
 
 	def getWalletPublicKey(self, path, showOnScreen=False, segwit=False, segwitNative=False, cashAddr=False):
@@ -271,7 +271,7 @@ class btchip:
 					response = self.dongle.exchange(bytearray(apdu))
 					offset += dataLength
 				alternateEncoding = True
-			except:
+			except Exception:
 				pass
 		if not alternateEncoding:
 			apdu = [ self.BTCHIP_CLA, self.BTCHIP_INS_HASH_INPUT_FINALIZE, 0x02, 0x00 ]

--- a/hwilib/devices/btchip/btchipComm.py
+++ b/hwilib/devices/btchip/btchipComm.py
@@ -142,7 +142,7 @@ class HIDDongleHIDAPI(Dongle, DongleWait):
 		if self.opened:
 			try:
 				self.device.close()
-			except:
+			except Exception:
 				pass
 		self.opened = False
 
@@ -155,7 +155,7 @@ class DongleServer(Dongle):
 		self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		try:
 			self.socket.connect((self.server, self.port))
-		except:
+		except Exception:
 			raise BTChipException("Proxy connection failed")
 
 	def exchange(self, apdu, timeout=20000):
@@ -175,5 +175,5 @@ class DongleServer(Dongle):
 	def close(self):
 		try:
 			self.socket.close()
-		except:
+		except Exception:
 			pass

--- a/hwilib/devices/ckcc/client.py
+++ b/hwilib/devices/ckcc/client.py
@@ -162,7 +162,7 @@ class ColdcardDevice:
         except CCProtoError:
             if expect_errors: raise
             raise
-        except:
+        except Exception:
             #print("Corrupt response: %r" % resp)
             raise
 
@@ -376,7 +376,8 @@ class UnixSimulatorPipe:
         self.pipe.close()
         try:
             os.unlink(self.pipe_name)
-        except: pass
+        except Exception:
+            pass
 
     def get_serial_number_string(self):
         return 'simulator'

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -631,7 +631,7 @@ def enumerate(password=''):
         dev.send_recv(b'{"device" : "info"}')
         devices.append({'path': b'udp:127.0.0.1:35345', 'interface_number': 0})
         dev.close()
-    except:
+    except Exception:
         pass
     for d in devices:
         if ('interface_number' in d and d['interface_number'] == 0

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -460,7 +460,7 @@ class TrezorClient(HardwareWalletClient):
                     multisig=multisig,
                 )
                 return {'address': address}
-            except:
+            except Exception:
                 pass
 
         raise BadArgumentError("No path supplied matched device keys")
@@ -543,7 +543,7 @@ class TrezorClient(HardwareWalletClient):
         self._check_unlocked()
         try:
             device.apply_settings(self.client, use_passphrase=not self.client.features.passphrase_protection)
-        except:
+        except Exception:
             if self.type == 'Keepkey':
                 print('Confirm the action by entering your PIN', file=sys.stderr)
                 print('Use \'sendpin\' to provide the number positions for the PIN as displayed on your device\'s screen', file=sys.stderr)

--- a/hwilib/devices/trezorlib/client.py
+++ b/hwilib/devices/trezorlib/client.py
@@ -149,7 +149,7 @@ class TrezorClient:
 
         try:
             passphrase = self.ui.get_passphrase()
-        except:
+        except Exception:
             self.call_raw(messages.Cancel())
             raise
 

--- a/hwilib/devices/trezorlib/transport/webusb.py
+++ b/hwilib/devices/trezorlib/transport/webusb.py
@@ -129,7 +129,7 @@ class WebUsbTransport(ProtocolBasedTransport):
                 # non-functional.
                 dev.getProduct()
                 devices.append(WebUsbTransport(dev))
-            except:
+            except Exception:
                 pass
         return devices
 

--- a/test/test_coldcard.py
+++ b/test/test_coldcard.py
@@ -31,7 +31,7 @@ def coldcard_test_suite(simulator, rpc, userpass, interface):
                     break
             if found:
                 break
-        except:
+        except Exception:
             pass
         time.sleep(0.5)
     # Cleanup

--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -28,7 +28,7 @@ def digitalbitbox_test_suite(simulator, rpc, userpass, interface):
             reply = send_plain(b'{"password":"0000"}', dev)
             if 'error' not in reply:
                 break
-        except:
+        except Exception:
             pass
         time.sleep(0.5)
     # Cleanup


### PR DESCRIPTION
Using a bare `except:` is not a good coding practice: it catches all exceptions inheriting from `BaseException`, including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` (which is not an error and should not normally be caught by user code).
```
BaseException
  - Exception
  - GeneratorExit
  - KeyboardInterrupt
  - SystemExit
```
This patch is sub-optimal because only specific exceptions should be catched... anyway, in situations where one wants to catch all “normal” exceptions, at least restrict to explicitly catch the `Exception` base class, instead of implicitly catching any `BaseException`.
