### PR TITLE
Add KeyOriginInfo class to handle derivation paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ jobs:
                 - pip install mypy
                 - pip install poetry
                 - poetry install
-            script: mypy --implicit-reexport --strict hwilib/base58.py hwilib/errors.py hwilib/serializations.py hwilib/hwwclient.py hwilib/devices/bitbox02.py
+            script: mypy --implicit-reexport --strict hwilib/base58.py hwilib/errors.py hwilib/serializations.py hwilib/hwwclient.py hwilib/devices/bitbox02.py hwilib/key.py
         -   name: Run non-device tests only
             stage: test
             install:

--- a/hwilib/base58.py
+++ b/hwilib/base58.py
@@ -9,7 +9,6 @@
 #
 
 import hashlib
-import struct
 from binascii import hexlify, unhexlify
 from typing import List
 b58_digits: str = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
@@ -72,11 +71,10 @@ def decode(s: str) -> bytes:
             break
     return b'\x00' * pad + res
 
-def get_xpub_fingerprint(s: str) -> int:
+def get_xpub_fingerprint(s: str) -> bytes:
     data = decode(s)
     fingerprint = data[5:9]
-    result: int = struct.unpack("<I", fingerprint)[0]
-    return result
+    return fingerprint
 
 def get_xpub_fingerprint_hex(xpub: str) -> str:
     data = decode(xpub)

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -39,8 +39,10 @@ from ..base58 import (
     get_xpub_fingerprint,
     xpub_main_2_test,
 )
-from ..serializations import (
+from ..key import (
     ExtendedKey,
+)
+from ..serializations import (
     PSBT,
 )
 from hashlib import sha256

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -121,7 +121,7 @@ class ColdcardClient(HardwareWalletClient):
             our_keys = 0
             for key in psbt_in.hd_keypaths.keys():
                 keypath = psbt_in.hd_keypaths[key]
-                if keypath[0] == master_fp and key not in psbt_in.partial_sigs:
+                if keypath.fingerprint == master_fp and key not in psbt_in.partial_sigs:
                     our_keys += 1
             if our_keys > passes:
                 passes = our_keys

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -28,9 +28,11 @@ from ..errors import (
     common_err_msgs,
     handle_errors,
 )
+from ..key import (
+    ExtendedKey,
+)
 from ..serializations import (
     CTransaction,
-    ExtendedKey,
     hash256,
     is_p2pk,
     is_p2pkh,

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -458,15 +458,9 @@ class DigitalbitboxClient(HardwareWalletClient):
 
             # Figure out which keypath thing is for this input
             for pubkey, keypath in psbt_in.hd_keypaths.items():
-                if master_fp == keypath[0]:
+                if master_fp == keypath.fingerprint:
                     # Add the keypath strings
-                    keypath_str = 'm'
-                    for index in keypath[1:]:
-                        keypath_str += '/'
-                        if index >= 0x80000000:
-                            keypath_str += str(index - 0x80000000) + 'h'
-                        else:
-                            keypath_str += str(index)
+                    keypath_str = keypath.get_derivation_path()
 
                     # Create tuples and add to List
                     tup = (binascii.hexlify(sighash).decode(), keypath_str, i_num, pubkey)

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -204,7 +204,7 @@ class LedgerClient(HardwareWalletClient):
             # Wallets shouldn't be sending to change address as user action
             # otherwise this will get confused
             for pubkey, path in tx.outputs[i_num].hd_keypaths.items():
-                if struct.pack("<I", path[0]) == master_fpr and len(path) > 2 and path[-2] == 1:
+                if path.fingerprint == master_fpr and len(path.path) > 1 and path[-1] == 1:
                     # For possible matches, check if pubkey matches possible template
                     if hash160(pubkey) in txout.scriptPubKey or hash160(bytearray.fromhex("0014") + hash160(pubkey)) in txout.scriptPubKey:
                         change_path = ''
@@ -277,12 +277,9 @@ class LedgerClient(HardwareWalletClient):
             # Figure out which keys in inputs are from our wallet
             for pubkey in pubkeys:
                 keypath = psbt_in.hd_keypaths[pubkey]
-                if master_fpr == struct.pack("<I", keypath[0]):
+                if master_fpr == keypath.fingerprint:
                     # Add the keypath strings
-                    keypath_str = ''
-                    for index in keypath[1:]:
-                        keypath_str += str(index) + "/"
-                    keypath_str = keypath_str[:-1]
+                    keypath_str = keypath.get_derivation_path()[2:] # Drop the leading m/
                     signature_attempts.append([keypath_str, pubkey])
 
             all_signature_attempts[i_num] = signature_attempts

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -24,8 +24,11 @@ import base64
 import hid
 import struct
 from .. import base58
-from ..serializations import (
+
+from ..key import (
     ExtendedKey,
+)
+from ..serializations import (
     hash256,
     hash160,
     is_p2sh,

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -44,9 +44,12 @@ from ..base58 import (
     to_address,
     xpub_main_2_test,
 )
+
+from ..key import (
+    ExtendedKey,
+)
 from ..serializations import (
     CTxOut,
-    ExtendedKey,
     is_p2pkh,
     is_p2sh,
     is_p2wsh,

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -284,12 +284,12 @@ class TrezorClient(HardwareWalletClient):
                 our_keys = 0
                 for key in psbt_in.hd_keypaths.keys():
                     keypath = psbt_in.hd_keypaths[key]
-                    if keypath[0] == master_fp:
+                    if keypath.fingerprint == master_fp:
                         if key in psbt_in.partial_sigs: # This key already has a signature
                             found_in_sigs = True
                             continue
                         if not found: # This key does not have a signature and we don't have a key to sign with yet
-                            txinputtype.address_n = keypath[1:]
+                            txinputtype.address_n = keypath.path
                             found = True
                         our_keys += 1
 
@@ -339,20 +339,20 @@ class TrezorClient(HardwareWalletClient):
                 psbt_out = tx.outputs[i]
                 if len(psbt_out.hd_keypaths) == 1:
                     _, keypath = next(iter(psbt_out.hd_keypaths.items()))
-                    if keypath[0] == master_fp:
+                    if keypath.fingerprint == master_fp:
                         wit, ver, prog = out.is_witness()
                         if out.is_p2pkh():
-                            txoutput.address_n = keypath[1:]
+                            txoutput.address_n = keypath.path
                             txoutput.address = None
                         elif wit:
                             txoutput.script_type = proto.OutputScriptType.PAYTOWITNESS
-                            txoutput.address_n = keypath[1:]
+                            txoutput.address_n = keypath.path
                             txoutput.address = None
                         elif out.is_p2sh() and psbt_out.redeem_script:
                             wit, ver, prog = CTxOut(0, psbt_out.redeem_script).is_witness()
                             if wit and len(prog) == 20:
                                 txoutput.script_type = proto.OutputScriptType.PAYTOP2SHWITNESS
-                                txoutput.address_n = keypath[1:]
+                                txoutput.address_n = keypath.path
                                 txoutput.address = None
 
                 # append to outputs
@@ -395,7 +395,7 @@ class TrezorClient(HardwareWalletClient):
                 if input_num in to_ignore:
                     continue
                 for pubkey in psbt_in.hd_keypaths.keys():
-                    fp = psbt_in.hd_keypaths[pubkey][0]
+                    fp = psbt_in.hd_keypaths[pubkey].fingerprint
                     if fp == master_fp and pubkey not in psbt_in.partial_sigs:
                         psbt_in.partial_sigs[pubkey] = sig + b'\x01'
                         break

--- a/hwilib/key.py
+++ b/hwilib/key.py
@@ -21,14 +21,14 @@ class ExtendedKey(object):
     TESTNET_PRIVATE = b'\x04\x35\x83\x94'
 
     def __init__(self) -> None:
-        self.is_testnet = False
-        self.is_private = False
-        self.depth = 0
-        self.parent_fingerprint = b''
-        self.child_num = 0
-        self.chaincode = b''
-        self.pubkey = b''
-        self.privkey = b''
+        self.is_testnet: bool = False
+        self.is_private: bool = False
+        self.depth: int = 0
+        self.parent_fingerprint: bytes = b''
+        self.child_num: int = 0
+        self.chaincode: bytes = b''
+        self.pubkey: bytes = b''
+        self.privkey: bytes = b''
 
     def deserialize(self, xpub: str) -> None:
         data = base58.decode(xpub)[:-4] # Decoded xpub without checksum

--- a/hwilib/key.py
+++ b/hwilib/key.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The HWI developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from . import base58
+
+import binascii
+import struct
+from typing import (
+    Dict,
+)
+
+# An extended public key (xpub) or private key (xprv). Just a data container for now.
+# Only handles deserialization of extended keys into component data to be handled by something else
+class ExtendedKey(object):
+
+    MAINNET_PUBLIC = b'\x04\x88\xB2\x1E'
+    MAINNET_PRIVATE = b'\x04\x88\xAD\xE4'
+    TESTNET_PUBLIC = b'\x04\x35\x87\xCF'
+    TESTNET_PRIVATE = b'\x04\x35\x83\x94'
+
+    def __init__(self) -> None:
+        self.is_testnet = False
+        self.is_private = False
+        self.depth = 0
+        self.parent_fingerprint = b''
+        self.child_num = 0
+        self.chaincode = b''
+        self.pubkey = b''
+        self.privkey = b''
+
+    def deserialize(self, xpub: str) -> None:
+        data = base58.decode(xpub)[:-4] # Decoded xpub without checksum
+
+        version = data[0:4]
+        if version == ExtendedKey.TESTNET_PUBLIC or version == ExtendedKey.TESTNET_PRIVATE:
+            self.is_testnet = True
+        if version == ExtendedKey.MAINNET_PRIVATE or version == ExtendedKey.TESTNET_PRIVATE:
+            self.is_private = True
+
+        self.depth = data[4]
+        self.parent_fingerprint = data[5:9]
+        self.child_num = struct.unpack('>I', data[9:13])[0]
+        self.chaincode = data[13:45]
+
+        if self.is_private:
+            self.privkey = data[46:]
+        else:
+            self.pubkey = data[45:78]
+
+    def get_printable_dict(self) -> Dict[str, object]:
+        d: Dict[str, object] = {}
+        d['testnet'] = self.is_testnet
+        d['private'] = self.is_private
+        d['depth'] = self.depth
+        d['parent_fingerprint'] = binascii.hexlify(self.parent_fingerprint).decode()
+        d['child_num'] = self.child_num
+        d['chaincode'] = binascii.hexlify(self.chaincode).decode()
+        if self.is_private:
+            d['privkey'] = binascii.hexlify(self.privkey).decode()
+        else:
+            d['pubkey'] = binascii.hexlify(self.pubkey).decode()
+        return d

--- a/hwilib/key.py
+++ b/hwilib/key.py
@@ -81,7 +81,7 @@ class KeyOriginInfo(object):
         self.path: Sequence[int] = path
 
     @classmethod
-    def deserialize(cls, s: bytes) -> object:
+    def deserialize(cls, s: bytes) -> 'KeyOriginInfo':
         """
         Deserialize a serialized KeyOriginInfo.
         They will be serialized in the same way that PSBTs serialize derivation paths

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -17,7 +17,6 @@ ser_*, deser_*: functions that handle serialization/deserialization
 
 from io import BytesIO, BufferedReader
 from .errors import PSBTSerializationError
-from . import base58
 
 import struct
 import binascii
@@ -870,55 +869,3 @@ class PSBT(object):
 
         # return hex string
         return HexToBase64(r.hex()).decode()
-
-# An extended public key (xpub) or private key (xprv). Just a data container for now.
-# Only handles deserialization of extended keys into component data to be handled by something else
-class ExtendedKey(object):
-
-    MAINNET_PUBLIC = b'\x04\x88\xB2\x1E'
-    MAINNET_PRIVATE = b'\x04\x88\xAD\xE4'
-    TESTNET_PUBLIC = b'\x04\x35\x87\xCF'
-    TESTNET_PRIVATE = b'\x04\x35\x83\x94'
-
-    def __init__(self) -> None:
-        self.is_testnet = False
-        self.is_private = False
-        self.depth = 0
-        self.parent_fingerprint = b''
-        self.child_num = 0
-        self.chaincode = b''
-        self.pubkey = b''
-        self.privkey = b''
-
-    def deserialize(self, xpub: str) -> None:
-        data = base58.decode(xpub)[:-4] # Decoded xpub without checksum
-
-        version = data[0:4]
-        if version == ExtendedKey.TESTNET_PUBLIC or version == ExtendedKey.TESTNET_PRIVATE:
-            self.is_testnet = True
-        if version == ExtendedKey.MAINNET_PRIVATE or version == ExtendedKey.TESTNET_PRIVATE:
-            self.is_private = True
-
-        self.depth = data[4]
-        self.parent_fingerprint = data[5:9]
-        self.child_num = struct.unpack('>I', data[9:13])[0]
-        self.chaincode = data[13:45]
-
-        if self.is_private:
-            self.privkey = data[46:]
-        else:
-            self.pubkey = data[45:78]
-
-    def get_printable_dict(self) -> Dict[str, object]:
-        d: Dict[str, object] = {}
-        d['testnet'] = self.is_testnet
-        d['private'] = self.is_private
-        d['depth'] = self.depth
-        d['parent_fingerprint'] = binascii.hexlify(self.parent_fingerprint).decode()
-        d['child_num'] = self.child_num
-        d['chaincode'] = binascii.hexlify(self.chaincode).decode()
-        if self.is_private:
-            d['privkey'] = binascii.hexlify(self.privkey).decode()
-        else:
-            d['pubkey'] = binascii.hexlify(self.pubkey).decode()
-        return d

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -14,6 +14,7 @@ from authproxy import AuthServiceProxy, JSONRPCException
 from hwilib.base58 import xpub_to_pub_hex
 from hwilib.cli import process_commands
 from hwilib.descriptor import AddChecksum
+from hwilib.key import KeyOriginInfo
 from hwilib.serializations import PSBT
 
 SUPPORTS_MS_DISPLAY = {'trezor_1', 'keepkey', 'coldcard', 'trezor_t'}
@@ -289,9 +290,9 @@ class TestSignTx(DeviceTestCase):
             # Single input PSBTs will be fully signed by first signer
             for psbt_input in first_psbt.inputs[1:]:
                 for pubkey, path in psbt_input.hd_keypaths.items():
-                    psbt_input.hd_keypaths[pubkey] = [0] + path[1:]
+                    psbt_input.hd_keypaths[pubkey] = KeyOriginInfo(b"\x00\x00\x00\x00", path.path)
             for pubkey, path in second_psbt.inputs[0].hd_keypaths.items():
-                second_psbt.inputs[0].hd_keypaths[pubkey] = [0] + path[1:]
+                second_psbt.inputs[0].hd_keypaths[pubkey] = KeyOriginInfo(b"\x00\x00\x00\x00", path.path)
 
             single_input = len(first_psbt.inputs) == 1
 


### PR DESCRIPTION
Instead of passing around key origins (fingerprint and derivation path combos) as lists of ints, put these into a new class `KeyOriginInfo`. This is basically what we do in Bitcoin Core. All of the PSBT derivation path stuff should be operating on `KeyOriginInfo`. This is placed in a new `hwilib/key.py` file along with the `ExtendedKey` class.

Additionally, the `parse_path` function in `trezorlib.tools` has been copied to `key.py` so that we can use it in other devices without requiring `trezorlib`.