### PR TITLE
Derive child keys from an ExtendedKey

### DIFF
--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -117,8 +117,7 @@ class ColdcardClient(HardwareWalletClient):
         else:
             result = {'xpub': xpub}
         if self.expert:
-            xpub_obj = ExtendedKey()
-            xpub_obj.deserialize(xpub)
+            xpub_obj = ExtendedKey.deserialize(xpub)
             result.update(xpub_obj.get_printable_dict())
         return result
 

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -355,8 +355,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         else:
             result = {'xpub': reply['xpub']}
         if self.expert:
-            xpub_obj = ExtendedKey()
-            xpub_obj.deserialize(reply['xpub'])
+            xpub_obj = ExtendedKey.deserialize(reply['xpub'])
             result.update(xpub_obj.get_printable_dict())
         return result
 

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -167,8 +167,7 @@ class LedgerClient(HardwareWalletClient):
         result = {"xpub": xpub}
 
         if self.expert:
-            xpub_obj = ExtendedKey()
-            xpub_obj.deserialize(xpub)
+            xpub_obj = ExtendedKey.deserialize(xpub)
             result.update(xpub_obj.get_printable_dict())
         return result
 

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -176,8 +176,7 @@ class TrezorClient(HardwareWalletClient):
         else:
             result = {'xpub': output.xpub}
         if self.expert:
-            xpub_obj = ExtendedKey()
-            xpub_obj.deserialize(output.xpub)
+            xpub_obj = ExtendedKey.deserialize(output.xpub)
             result.update(xpub_obj.get_printable_dict())
         return result
 
@@ -419,9 +418,8 @@ class TrezorClient(HardwareWalletClient):
         # descriptor means multisig with xpubs
         if descriptor:
             pubkeys = []
-            xpub = ExtendedKey()
             for i in range(0, descriptor.multisig_N):
-                xpub.deserialize(descriptor.base_key[i])
+                xpub = ExtendedKey.deserialize(descriptor.base_key[i])
                 hd_node = proto.HDNodeType(depth=xpub.depth, fingerprint=int.from_bytes(xpub.parent_fingerprint, 'big'), child_num=xpub.child_num, chain_code=xpub.chaincode, public_key=xpub.pubkey)
                 pubkeys.append(proto.HDNodePathType(node=hd_node, address_n=parse_path('m' + descriptor.path_suffix[i])))
             multisig = proto.MultisigRedeemScriptType(m=int(descriptor.multisig_M), signatures=[b''] * int(descriptor.multisig_N), pubkeys=pubkeys)

--- a/hwilib/key.py
+++ b/hwilib/key.py
@@ -21,6 +21,12 @@ def H_(x: int) -> int:
     """
     return x | HARDENED_FLAG
 
+def is_hardened(i: int) -> bool:
+    """
+    Returns whether an index is hardened
+    """
+    return i & HARDENED_FLAG != 0
+
 
 # An extended public key (xpub) or private key (xprv). Just a data container for now.
 # Only handles deserialization of extended keys into component data to be handled by something else
@@ -102,7 +108,7 @@ class KeyOriginInfo(object):
     def _path_string(self) -> str:
         s = ""
         for i in self.path:
-            hardened = i & HARDENED_FLAG != 0
+            hardened = is_hardened(i)
             i &= ~HARDENED_FLAG
             s += "/" + str(i)
             if hardened:

--- a/hwilib/key.py
+++ b/hwilib/key.py
@@ -123,6 +123,21 @@ class ExtendedKey(object):
             pubkey = data[45:78]
             return cls(version, depth, parent_fingerprint, child_num, chaincode, None, pubkey)
 
+    def serialize(self) -> bytes:
+        r = self.version + struct.pack('B', self.depth) + self.parent_fingerprint + struct.pack('>I', self.child_num) + self.chaincode
+        if self.is_private:
+            if self.privkey is None:
+                raise ValueError("Somehow we are private but don't have a privkey")
+            r += b"\x00" + self.privkey
+        else:
+            r += self.pubkey
+        return r
+
+    def to_string(self) -> str:
+        data = self.serialize()
+        checksum = hashlib.sha256(hashlib.sha256(data).digest()).digest()[0:4]
+        return base58.encode(data + checksum)
+
     def get_printable_dict(self) -> Dict[str, object]:
         d: Dict[str, object] = {}
         d['testnet'] = self.is_testnet

--- a/hwilib/key.py
+++ b/hwilib/key.py
@@ -133,8 +133,7 @@ class ExtendedKey(object):
         d['chaincode'] = binascii.hexlify(self.chaincode).decode()
         if self.is_private and isinstance(self.privkey, bytes):
             d['privkey'] = binascii.hexlify(self.privkey).decode()
-        else:
-            d['pubkey'] = binascii.hexlify(self.pubkey).decode()
+        d['pubkey'] = binascii.hexlify(self.pubkey).decode()
         return d
 
     def derive_pub(self, i: int) -> 'ExtendedKey':

--- a/hwilib/key.py
+++ b/hwilib/key.py
@@ -90,7 +90,7 @@ class ExtendedKey(object):
     TESTNET_PUBLIC = b'\x04\x35\x87\xCF'
     TESTNET_PRIVATE = b'\x04\x35\x83\x94'
 
-    def __init__(self, version: bytes, depth: int, parent_fingerprint: bytes, child_num: int, chaincode: bytes, privkey: Optional[bytes], pubkey: Optional[bytes]) -> None:
+    def __init__(self, version: bytes, depth: int, parent_fingerprint: bytes, child_num: int, chaincode: bytes, privkey: Optional[bytes], pubkey: bytes) -> None:
         self.version: bytes = version
         self.is_testnet: bool = version == ExtendedKey.TESTNET_PUBLIC or version == ExtendedKey.TESTNET_PRIVATE
         self.is_private: bool = version == ExtendedKey.MAINNET_PRIVATE or version == ExtendedKey.TESTNET_PRIVATE
@@ -98,7 +98,7 @@ class ExtendedKey(object):
         self.parent_fingerprint: bytes = parent_fingerprint
         self.child_num: int = child_num
         self.chaincode: bytes = chaincode
-        self.pubkey: Optional[bytes] = pubkey
+        self.pubkey: bytes = pubkey
         self.privkey: Optional[bytes] = privkey
 
     @classmethod
@@ -114,7 +114,8 @@ class ExtendedKey(object):
 
         if is_private:
             privkey = data[46:]
-            return cls(version, depth, parent_fingerprint, child_num, chaincode, privkey, None)
+            pubkey = point_to_bytes(point_mul(G, int.from_bytes(privkey, byteorder="big")))
+            return cls(version, depth, parent_fingerprint, child_num, chaincode, privkey, pubkey)
         else:
             pubkey = data[45:78]
             return cls(version, depth, parent_fingerprint, child_num, chaincode, None, pubkey)
@@ -129,7 +130,7 @@ class ExtendedKey(object):
         d['chaincode'] = binascii.hexlify(self.chaincode).decode()
         if self.is_private and isinstance(self.privkey, bytes):
             d['privkey'] = binascii.hexlify(self.privkey).decode()
-        elif isinstance(self.pubkey, bytes):
+        else:
             d['pubkey'] = binascii.hexlify(self.pubkey).decode()
         return d
 

--- a/test/data/test_bip32.json
+++ b/test/data/test_bip32.json
@@ -1,0 +1,260 @@
+{
+    "serialization": [
+        {
+            "xpub": "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8",
+            "xprv": "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi",
+            "deser": {
+                "pub_version": "0488B21E",
+                "priv_version": "0488ADE4",
+                "is_testnet": false,
+                "depth": 0,
+                "parent_fingerprint": "00000000",
+                "child_num": 0,
+                "chaincode": "873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508",
+                "pubkey": "0339a36013301597daef41fbe593a02cc513d0b55527ec2df1050e2e8ff49c85c2",
+                "privkey": "e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35"
+            }
+        },
+        {
+            "xpub": "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw",
+            "xprv": "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
+            "deser": {
+                "pub_version": "0488B21E",
+                "priv_version": "0488ADE4",
+                "is_testnet": false,
+                "depth": 1,
+                "parent_fingerprint": "3442193e",
+                "child_num": 2147483648,
+                "chaincode": "47fdacbd0f1097043b78c63c20c34ef4ed9a111d980047ad16282c7ae6236141",
+                "pubkey": "035a784662a4a20a65bf6aab9ae98a6c068a81c52e4b032c0fb5400c706cfccc56",
+                "privkey": "edb2e14f9ee77d26dd93b4ecede8d16ed408ce149b6cd80b0715a2d911a0afea"
+            }
+        },
+        {
+            "xpub": "xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ",
+            "xprv": "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs",
+            "deser": {
+                "pub_version": "0488B21E",
+                "priv_version": "0488ADE4",
+                "is_testnet": false,
+                "depth": 2,
+                "parent_fingerprint": "5c1bd648",
+                "child_num": 1,
+                "chaincode": "2a7857631386ba23dacac34180dd1983734e444fdbf774041578e9b6adb37c19",
+                "pubkey": "03501e454bf00751f24b1b489aa925215d66af2234e3891c3b21a52bedb3cd711c",
+                "privkey": "3c6cb8d0f6a264c91ea8b5030fadaa8e538b020f0a387421a12de9319dc93368"
+            }
+        },
+        {
+            "xpub": "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5",
+            "xprv": "xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM",
+            "deser": {
+                "pub_version": "0488B21E",
+                "priv_version": "0488ADE4",
+                "is_testnet": false,
+                "depth": 3,
+                "parent_fingerprint": "bef5a2f9",
+                "child_num": 2147483650,
+                "chaincode": "04466b9cc8e161e966409ca52986c584f07e9dc81f735db683c3ff6ec7b1503f",
+                "pubkey": "0357bfe1e341d01c69fe5654309956cbea516822fba8a601743a012a7896ee8dc2",
+                "privkey": "cbce0d719ecf7431d88e6a89fa1483e02e35092af60c042b1df2ff59fa424dca"
+            }
+        },
+        {
+            "xpub": "xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV",
+            "xprv": "xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334",
+            "deser": {
+                "pub_version": "0488B21E",
+                "priv_version": "0488ADE4",
+                "is_testnet": false,
+                "depth": 4,
+                "parent_fingerprint": "ee7ab90c",
+                "child_num": 2,
+                "chaincode": "cfb71883f01676f587d023cc53a35bc7f88f724b1f8c2892ac1275ac822a3edd",
+                "pubkey": "02e8445082a72f29b75ca48748a914df60622a609cacfce8ed0e35804560741d29",
+                "privkey": "0f479245fb19a38a1954c5c7c0ebab2f9bdfd96a17563ef28a6a4b1a2a764ef4"
+            }
+        },
+        {
+            "xpub": "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy",
+            "xprv": "xprvA41z7zogVVwxVSgdKUHDy1SKmdb533PjDz7J6N6mV6uS3ze1ai8FHa8kmHScGpWmj4WggLyQjgPie1rFSruoUihUZREPSL39UNdE3BBDu76",
+            "deser": {
+                "pub_version": "0488B21E",
+                "priv_version": "0488ADE4",
+                "is_testnet": false,
+                "depth": 5,
+                "parent_fingerprint": "d880d7d8",
+                "child_num": 1000000000,
+                "chaincode": "c783e67b921d2beb8f6b389cc646d7263b4145701dadd2161548a8b078e65e9e",
+                "pubkey": "022a471424da5e657499d1ff51cb43c47481a03b1e77f951fe64cec9f5a48f7011",
+                "privkey": "471b76e389e528d6de6d816857e012c5455051cad6660850e58372a6c3e6e7c8"
+            }
+        },
+        {
+            "xpub": "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB",
+            "xprv": "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U",
+            "deser": {
+                "pub_version": "0488B21E",
+                "priv_version": "0488ADE4",
+                "is_testnet": false,
+                "depth": 0,
+                "parent_fingerprint": "00000000",
+                "child_num": 0,
+                "chaincode": "60499f801b896d83179a4374aeb7822aaeaceaa0db1f85ee3e904c4defbd9689",
+                "pubkey": "03cbcaa9c98c877a26977d00825c956a238e8dddfbd322cce4f74b0b5bd6ace4a7",
+                "privkey": "4b03d6fc340455b363f51020ad3ecca4f0850280cf436c70c727923f6db46c3e"
+            }
+        },
+        {
+            "xpub": "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH",
+            "xprv": "xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt",
+            "deser": {
+                "pub_version": "0488B21E",
+                "priv_version": "0488ADE4",
+                "is_testnet": false,
+                "depth": 1,
+                "parent_fingerprint": "bd16bee5",
+                "child_num": 0,
+                "chaincode": "f0909affaa7ee7abe5dd4e100598d4dc53cd709d5a5c2cac40e7412f232f7c9c",
+                "pubkey": "02fc9e5af0ac8d9b3cecfe2a888e2117ba3d089d8585886c9c826b6b22a98d12ea",
+                "privkey": "abe74a98f6c7eabee0428f53798f0ab8aa1bd37873999041703c742f15ac7e1e"
+            }
+        },
+        {
+            "xpub": "xpub6ASAVgeehLbnwdqV6UKMHVzgqAG8Gr6riv3Fxxpj8ksbH9ebxaEyBLZ85ySDhKiLDBrQSARLq1uNRts8RuJiHjaDMBU4Zn9h8LZNnBC5y4a",
+            "xprv": "xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9",
+            "deser": {
+                "pub_version": "0488B21E",
+                "priv_version": "0488ADE4",
+                "is_testnet": false,
+                "depth": 2,
+                "parent_fingerprint": "5a61ff8e",
+                "child_num": 4294967295,
+                "chaincode": "be17a268474a6bb9c61e1d720cf6215e2a88c5406c4aee7b38547f585c9a37d9",
+                "pubkey": "03c01e7425647bdefa82b12d9bad5e3e6865bee0502694b94ca58b666abc0a5c3b",
+                "privkey": "877c779ad9687164e9c2f4f0f4ff0340814392330693ce95a58fe18fd52e6e93"
+            }
+        },
+        {
+            "xpub": "xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon",
+            "xprv": "xprv9zFnWC6h2cLgpmSA46vutJzBcfJ8yaJGg8cX1e5StJh45BBciYTRXSd25UEPVuesF9yog62tGAQtHjXajPPdbRCHuWS6T8XA2ECKADdw4Ef",
+            "deser": {
+                "pub_version": "0488B21E",
+                "priv_version": "0488ADE4",
+                "is_testnet": false,
+                "depth": 3,
+                "parent_fingerprint": "d8ab4937",
+                "child_num": 1,
+                "chaincode": "f366f48f1ea9f2d1d3fe958c95ca84ea18e4c4ddb9366c336c927eb246fb38cb",
+                "pubkey": "03a7d1d856deb74c508e05031f9895dab54626251b3806e16b4bd12e781a7df5b9",
+                "privkey": "704addf544a06e5ee4bea37098463c23613da32020d604506da8c0518e1da4b7"
+            }
+        },
+        {
+            "xpub": "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL",
+            "xprv": "xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc",
+            "deser": {
+                "pub_version": "0488B21E",
+                "priv_version": "0488ADE4",
+                "is_testnet": false,
+                "depth": 4,
+                "parent_fingerprint": "78412e3a",
+                "child_num": 4294967294,
+                "chaincode": "637807030d55d01f9a0cb3a7839515d796bd07706386a6eddf06cc29a65a0e29",
+                "pubkey": "02d2b36900396c9282fa14628566582f206a5dd0bcc8d5e892611806cafb0301f0",
+                "privkey": "f1c7c871a54a804afe328b4c83a1c33b8e5ff48f5087273f04efa83b247d6a2d"
+            }
+        },
+        {
+            "xpub": "xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt",
+            "xprv": "xprvA2nrNbFZABcdryreWet9Ea4LvTJcGsqrMzxHx98MMrotbir7yrKCEXw7nadnHM8Dq38EGfSh6dqA9QWTyefMLEcBYJUuekgW4BYPJcr9E7j",
+            "deser": {
+                "pub_version": "0488B21E",
+                "priv_version": "0488ADE4",
+                "is_testnet": false,
+                "depth": 5,
+                "parent_fingerprint": "31a507b8",
+                "child_num": 2,
+                "chaincode": "9452b549be8cea3ecb7a84bec10dcfd94afe4d129ebfd3b3cb58eedf394ed271",
+                "pubkey": "024d902e1a2fc7a8755ab5b694c575fce742c48d9ff192e63df5193e4c7afe1f9c",
+                "privkey": "bb7d39bdb83ecf58f2fd82b6d918341cbef428661ef01ab97c28a4842125ac23"
+            }
+        },
+        {
+            "xpub": "xpub661MyMwAqRbcEZVB4dScxMAdx6d4nFc9nvyvH3v4gJL378CSRZiYmhRoP7mBy6gSPSCYk6SzXPTf3ND1cZAceL7SfJ1Z3GC8vBgp2epUt13",
+            "xprv": "xprv9s21ZrQH143K25QhxbucbDDuQ4naNntJRi4KUfWT7xo4EKsHt2QJDu7KXp1A3u7Bi1j8ph3EGsZ9Xvz9dGuVrtHHs7pXeTzjuxBrCmmhgC6",
+            "deser": {
+                "pub_version": "0488B21E",
+                "priv_version": "0488ADE4",
+                "is_testnet": false,
+                "depth": 0,
+                "parent_fingerprint": "00000000",
+                "child_num": 0,
+                "chaincode": "01d28a3e53cffa419ec122c968b3259e16b65076495494d97cae10bbfec3c36f",
+                "pubkey": "03683af1ba5743bdfc798cf814efeeab2735ec52d95eced528e692b8e34c4e5669",
+                "privkey": "00ddb80b067e0d4993197fe10f2657a844a384589847602d56f0c629c81aae32"
+            }
+        },
+        {
+            "xpub": "xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y",
+            "xprv": "xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L",
+            "deser": {
+                "pub_version": "0488B21E",
+                "priv_version": "0488ADE4",
+                "is_testnet": false,
+                "depth": 1,
+                "parent_fingerprint": "41d63b50",
+                "child_num": 2147483648,
+                "chaincode": "e5fea12a97b927fc9dc3d2cb0d1ea1cf50aa5a1fdc1f933e8906bb38df3377bd",
+                "pubkey": "026557fdda1d5d43d79611f784780471f086d58e8126b8c40acb82272a7712e7f2",
+                "privkey": "491f7a2eebc7b57028e0d3faa0acda02e75c33b03c48fb288c41e2ea44e1daef"
+            }
+        }
+    ],
+    "deriv" : [
+        {
+            "parent_xpub": "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw",
+            "parent_xprv": "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
+            "child_xpub": "xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ",
+            "index": 1
+        },
+        {
+            "parent_xpub": "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5",
+            "parent_xprv": "xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM",
+            "child_xpub": "xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV",
+            "index": 2
+        },
+        {
+            "parent_xpub": "xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV",
+            "parent_xprv": "xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334",
+            "child_xpub": "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy",
+            "index": 1000000000
+        },
+        {
+            "parent_xpub": "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB",
+            "parent_xprv": "xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U",
+            "child_xpub": "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH",
+            "index": 0
+        },
+        {
+            "parent_xpub": "xpub6ASAVgeehLbnwdqV6UKMHVzgqAG8Gr6riv3Fxxpj8ksbH9ebxaEyBLZ85ySDhKiLDBrQSARLq1uNRts8RuJiHjaDMBU4Zn9h8LZNnBC5y4a",
+            "parent_xprv": "xprv9wSp6B7kry3Vj9m1zSnLvN3xH8RdsPP1Mh7fAaR7aRLcQMKTR2vidYEeEg2mUCTAwCd6vnxVrcjfy2kRgVsFawNzmjuHc2YmYRmagcEPdU9",
+            "child_xpub": "xpub6DF8uhdarytz3FWdA8TvFSvvAh8dP3283MY7p2V4SeE2wyWmG5mg5EwVvmdMVCQcoNJxGoWaU9DCWh89LojfZ537wTfunKau47EL2dhHKon",
+            "index": 1
+        },
+        {
+            "parent_xpub": "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL",
+            "parent_xprv": "xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc",
+            "child_xpub": "xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt",
+            "index": 2
+        }
+    ],
+    "deriv_path": [
+        {
+            "parent_xpub": "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5",
+            "parent_xprv": "xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM",
+            "child_xpub": "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy",
+            "path": "m/2/1000000000"
+        }
+    ]
+}

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -6,6 +6,7 @@ import unittest
 
 from test_base58 import TestBase58
 from test_bech32 import TestSegwitAddress
+from test_bip32 import TestBIP32
 from test_coldcard import coldcard_test_suite
 from test_descriptor import TestDescriptor
 from test_device import start_bitcoind
@@ -62,6 +63,7 @@ suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestDescriptor))
 suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestSegwitAddress))
 suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestPSBT))
 suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestBase58))
+suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestBIP32))
 if sys.platform.startswith("linux"):
     suite.addTests(unittest.defaultTestLoader.loadTestsFromTestCase(TestUdevRulesInstaller))
 success = unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite).wasSuccessful()

--- a/test/test_bip32.py
+++ b/test/test_bip32.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The HWI developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from hwilib.key import (
+    ExtendedKey,
+    parse_path,
+)
+
+import binascii
+import json
+import os
+import unittest
+
+class TestBIP32(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), "data/test_bip32.json"), encoding="utf-8") as f:
+            cls.data = json.load(f)
+            for key in cls.data["serialization"]:
+                deser = key["deser"]
+                deser["pub_version"] = binascii.unhexlify(deser["pub_version"])
+                deser["priv_version"] = binascii.unhexlify(deser["priv_version"])
+                deser["hex_parent_fingerprint"] = deser["parent_fingerprint"]
+                deser["parent_fingerprint"] = binascii.unhexlify(deser["parent_fingerprint"])
+                deser["hex_chaincode"] = deser["chaincode"]
+                deser["chaincode"] = binascii.unhexlify(deser["chaincode"])
+                deser["hex_pubkey"] = deser["pubkey"]
+                deser["pubkey"] = binascii.unhexlify(deser["pubkey"])
+                deser["hex_privkey"] = deser["privkey"]
+                deser["privkey"] = binascii.unhexlify(deser["privkey"])
+
+    def test_serialization(self):
+        for key in self.data["serialization"]:
+            xpub = key["xpub"]
+            xprv = key["xprv"]
+            deser = key["deser"]
+            with self.subTest(key=key):
+                key_pub = ExtendedKey.deserialize(xpub)
+                key_prv = ExtendedKey.deserialize(xprv)
+
+                # Make sure they roundtrip
+                self.assertEqual(key_pub.to_string(), xpub)
+                self.assertEqual(key_prv.to_string(), xprv)
+
+                # Make sure they agree
+                self.assertEqual(key_pub.is_testnet, key_prv.is_testnet)
+                self.assertEqual(key_pub.depth, key_prv.depth)
+                self.assertEqual(key_pub.parent_fingerprint, key_prv.parent_fingerprint)
+                self.assertEqual(key_pub.child_num, key_prv.child_num)
+                self.assertEqual(key_pub.chaincode, key_prv.chaincode)
+                self.assertEqual(key_pub.pubkey, key_prv.pubkey)
+
+                # Make sure they are correct
+                self.assertEqual(key_pub.version, deser["pub_version"])
+                self.assertEqual(key_pub.is_testnet, deser["is_testnet"])
+                self.assertEqual(key_pub.is_private, False)
+                self.assertEqual(key_pub.depth, deser["depth"])
+                self.assertEqual(key_pub.parent_fingerprint, deser["parent_fingerprint"])
+                self.assertEqual(key_pub.child_num, deser["child_num"])
+                self.assertEqual(key_pub.chaincode, deser["chaincode"])
+                self.assertEqual(key_pub.pubkey, deser["pubkey"])
+                self.assertEqual(key_prv.version, deser["priv_version"])
+                self.assertEqual(key_prv.is_testnet, deser["is_testnet"])
+                self.assertEqual(key_prv.is_private, True)
+                self.assertEqual(key_prv.depth, deser["depth"])
+                self.assertEqual(key_prv.parent_fingerprint, deser["parent_fingerprint"])
+                self.assertEqual(key_prv.child_num, deser["child_num"])
+                self.assertEqual(key_prv.chaincode, deser["chaincode"])
+                self.assertEqual(key_prv.pubkey, deser["pubkey"])
+                self.assertEqual(key_prv.privkey, deser["privkey"])
+
+                # Make sure the printable dict is right
+                key_dict = key_pub.get_printable_dict()
+                self.assertEqual(key_dict["testnet"], deser["is_testnet"])
+                self.assertEqual(key_dict["private"], False)
+                self.assertEqual(key_dict["depth"], deser["depth"])
+                self.assertEqual(key_dict["parent_fingerprint"], deser["hex_parent_fingerprint"])
+                self.assertEqual(key_dict["child_num"], deser["child_num"])
+                self.assertEqual(key_dict["chaincode"], deser["hex_chaincode"])
+                self.assertEqual(key_dict["pubkey"], deser["hex_pubkey"])
+                key_dict = key_prv.get_printable_dict()
+                self.assertEqual(key_dict["testnet"], deser["is_testnet"])
+                self.assertEqual(key_dict["private"], True)
+                self.assertEqual(key_dict["depth"], deser["depth"])
+                self.assertEqual(key_dict["parent_fingerprint"], deser["hex_parent_fingerprint"])
+                self.assertEqual(key_dict["child_num"], deser["child_num"])
+                self.assertEqual(key_dict["chaincode"], deser["hex_chaincode"])
+                self.assertEqual(key_dict["pubkey"], deser["hex_pubkey"])
+                self.assertEqual(key_dict["privkey"], deser["hex_privkey"])
+
+    def test_deriv(self):
+        for test in self.data["deriv"]:
+            with self.subTest(test=test):
+                # Deser
+                par_xpub = ExtendedKey.deserialize(test["parent_xpub"])
+                par_xprv = ExtendedKey.deserialize(test["parent_xprv"])
+
+                # Derive
+                i = test["index"]
+                child_xpub = test["child_xpub"]
+                xpub_der = par_xpub.derive_pub(i)
+                self.assertEqual(xpub_der.to_string(), child_xpub)
+                xprv_der = par_xprv.derive_pub(i)
+                self.assertEqual(xprv_der.to_string(), child_xpub)
+
+    def test_deriv_path(self):
+        for test in self.data["deriv_path"]:
+            with self.subTest(test=test):
+                # Deser
+                par_xpub = ExtendedKey.deserialize(test["parent_xpub"])
+                par_xprv = ExtendedKey.deserialize(test["parent_xprv"])
+
+                # Parse the path
+                path = parse_path(test["path"])
+
+                # Derive
+                child_xpub = test["child_xpub"]
+                xpub_der = par_xpub.derive_pub_path(path)
+                self.assertEqual(xpub_der.to_string(), child_xpub)
+                xprv_der = par_xprv.derive_pub_path(path)
+                self.assertEqual(xprv_der.to_string(), child_xpub)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
It might be useful to us to be able to derive further child keys from an xpub. This PR re-introduces the BIP 32 code that was removed in a3cdd53ddaab86cf9b7cb12f73bc99a081b450a6.

Based on #374 for organizational reasons.