### PR TITLE
tests: Descriptor wallets, multisig fixes, and general cleanups

### DIFF
--- a/test/data/coldcard-multisig-setup.patch
+++ b/test/data/coldcard-multisig-setup.patch
@@ -1,4 +1,4 @@
-From cadbd3d25306b43060fd06eed589947d537a5ced Mon Sep 17 00:00:00 2001
+From 8793fbaa9b32f3c67f289a05194e68acc5c61b7d Mon Sep 17 00:00:00 2001
 From: Andrew Chow <achow101-github@achow101.com>
 Date: Tue, 17 Dec 2019 17:56:05 -0500
 Subject: [PATCH 2/2] Change default simulator multisig
@@ -8,7 +8,7 @@ Subject: [PATCH 2/2] Change default simulator multisig
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/unix/frozen-modules/sim_settings.py b/unix/frozen-modules/sim_settings.py
-index 0313c3e..e2c3d71 100644
+index 0313c3e..6d301d4 100644
 --- a/unix/frozen-modules/sim_settings.py
 +++ b/unix/frozen-modules/sim_settings.py
 @@ -68,7 +68,11 @@ if '--ms' in sys.argv:
@@ -17,13 +17,13 @@ index 0313c3e..e2c3d71 100644
          # P2SH: 2of4 using BIP39 passwords: "Me", "Myself", "and I", and (empty string) on simulator
 -        sim_defaults['multisig'] = [['MeMyself', [2, 4], [[3503269483, 'tpubD9429UXFGCTKJ9NdiNK4rC5ygqSUkginycYHccqSg5gkmyQ7PZRHNjk99M6a6Y3NY8ctEUUJvCu6iCCui8Ju3xrHRu3Ez1CKB4ZFoRZDdP9'], [2389277556, 'tpubD97nVL37v5tWyMf9ofh5rznwhh1593WMRg6FT4o6MRJkKWANtwAMHYLrcJFsFmPfYbY1TE1LLQ4KBb84LBPt1ubvFwoosvMkcWJtMwvXgSc'], [3190206587, 'tpubD9ArfXowvGHnuECKdGXVKDMfZVGdephVWg8fWGWStH3VKHzT4ph3A4ZcgXWqFu1F5xGTfxncmrnf3sLC86dup2a8Kx7z3xQ3AgeNTQeFxPa'], [1130956047, 'tpubD8NXmKsmWp3a3DXhbihAYbYLGaRNVdTnr6JoSxxfXYQcmwVtW2hv8QoDwng6JtEonmJoL3cNEwfd2cLXMpGezwZ2vL2dQ7259bueNKj9C8n']], {'ch': 'XTN', 'pp': "45'"}]]
 +        sim_defaults['multisig'] = [
-+            ['mstest', [2, 3], [[1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj'], [1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj'], [1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj']], {'ft': 8, 'ch': 'XTN'}],
-+            ['mstest1', [2, 3], [[1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj'], [1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj'], [1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj']], {'ft': 14, 'ch': 'XTN'}],
-+            ['mstest2', [2, 3], [[1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj'], [1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj'], [1130956047, 'tpubDCDqt7XXvhAYY9HSwrCXB7BXqYM4RXB8WFtKgtTXGa6u3U6EV1NJJRFTcuTRyhSY5Vreg1LP8aPdyiAPQGrDJLikkHoc7VQg6DA9NtUxHtj']], {'ft': 26, 'ch': 'XTN'}],
++            ['mstest', [2, 3], [[1130956047, 'tpubDCp1a2CuSdeVLYbjKRF6H1oSU2hubMm6oV4tXYFkh5u7BwhJ1P5ZwntWGfNCx92BUWpbYPcbgApbYHNTEED49vFdscWgg6KpJepKdgBB92U'], [1130956047, 'tpubDCp1a2CuSdeVQxVNMuLWW4GDnSYqzaPwYRfb8uveDQmwYaPBXERNPWUR8GvyfSLDsbr9MwQxLsKeAAjSsigKpmgrkLdHJM77C3us7t5QFL2'], [1130956047, 'tpubDCp1a2CuSdeVS6h1LsXGqpALo6ZhvWEFDYDv8qTgcnBZYdAPsZ7QL25UKdUqKsMcc8eMQyZA9zjvUMaJjdSVcfDftzgmdvJfH5MnrZoxzFG']], {'ft': 8, 'ch': 'XTN'}],
++            ['mstest1', [2, 3], [[1130956047, 'tpubDCp1a2CuSdeVLYbjKRF6H1oSU2hubMm6oV4tXYFkh5u7BwhJ1P5ZwntWGfNCx92BUWpbYPcbgApbYHNTEED49vFdscWgg6KpJepKdgBB92U'], [1130956047, 'tpubDCp1a2CuSdeVQxVNMuLWW4GDnSYqzaPwYRfb8uveDQmwYaPBXERNPWUR8GvyfSLDsbr9MwQxLsKeAAjSsigKpmgrkLdHJM77C3us7t5QFL2'], [1130956047, 'tpubDCp1a2CuSdeVS6h1LsXGqpALo6ZhvWEFDYDv8qTgcnBZYdAPsZ7QL25UKdUqKsMcc8eMQyZA9zjvUMaJjdSVcfDftzgmdvJfH5MnrZoxzFG']], {'ft': 14, 'ch': 'XTN'}],
++            ['mstest2', [2, 3], [[1130956047, 'tpubDCp1a2CuSdeVLYbjKRF6H1oSU2hubMm6oV4tXYFkh5u7BwhJ1P5ZwntWGfNCx92BUWpbYPcbgApbYHNTEED49vFdscWgg6KpJepKdgBB92U'], [1130956047, 'tpubDCp1a2CuSdeVQxVNMuLWW4GDnSYqzaPwYRfb8uveDQmwYaPBXERNPWUR8GvyfSLDsbr9MwQxLsKeAAjSsigKpmgrkLdHJM77C3us7t5QFL2'], [1130956047, 'tpubDCp1a2CuSdeVS6h1LsXGqpALo6ZhvWEFDYDv8qTgcnBZYdAPsZ7QL25UKdUqKsMcc8eMQyZA9zjvUMaJjdSVcfDftzgmdvJfH5MnrZoxzFG']], {'ft': 26, 'ch': 'XTN'}],
 +            ]
      sim_defaults['fee_limit'] = -1
  
  if '--xfp' in sys.argv:
 -- 
-2.27.0
+2.28.0
 

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -167,12 +167,11 @@ class TestDeviceConnect(DeviceTestCase):
 
 class TestGetKeypool(DeviceTestCase):
     def setUp(self):
-        self.rpc = AuthServiceProxy('http://{}@127.0.0.1:18443'.format(self.rpc_userpass))
+        super().setUp()
         if '{}_test'.format(self.full_type) not in self.rpc.listwallets():
             self.rpc.createwallet('{}_test'.format(self.full_type), True)
         self.wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/{}_test'.format(self.rpc_userpass, self.full_type))
         self.wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(self.rpc_userpass))
-        self.emulator.start()
 
     def test_getkeypool(self):
         non_keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--nokeypool', '0', '20'])
@@ -245,10 +244,6 @@ class TestGetKeypool(DeviceTestCase):
         self.assertEqual(keypool_desc['code'], -7)
 
 class TestGetDescriptors(DeviceTestCase):
-    def setUp(self):
-        self.rpc = AuthServiceProxy('http://{}@127.0.0.1:18443'.format(self.rpc_userpass))
-        self.emulator.start()
-
     def tearDown(self):
         self.emulator.stop()
 
@@ -272,12 +267,11 @@ class TestGetDescriptors(DeviceTestCase):
 
 class TestSignTx(DeviceTestCase):
     def setUp(self):
-        self.rpc = AuthServiceProxy('http://{}@127.0.0.1:18443'.format(self.rpc_userpass))
+        super().setUp()
         if '{}_test'.format(self.full_type) not in self.rpc.listwallets():
             self.rpc.createwallet('{}_test'.format(self.full_type), True)
         self.wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/{}_test'.format(self.rpc_userpass, self.full_type))
         self.wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(self.rpc_userpass))
-        self.emulator.start()
 
     def _generate_and_finalize(self, unknown_inputs, psbt):
         if not unknown_inputs:
@@ -451,12 +445,11 @@ class TestSignTx(DeviceTestCase):
 
 class TestDisplayAddress(DeviceTestCase):
     def setUp(self):
-        self.rpc = AuthServiceProxy('http://{}@127.0.0.1:18443'.format(self.rpc_userpass))
+        super().setUp()
         if '{}_test'.format(self.full_type) not in self.rpc.listwallets():
             self.rpc.createwallet('{}_test'.format(self.full_type), True)
         self.wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/{}_test'.format(self.rpc_userpass, self.full_type))
         self.wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(self.rpc_userpass))
-        self.emulator.start()
 
     def test_display_address_bad_args(self):
         result = self.do_command(self.dev_args + ['displayaddress', '--sh_wpkh', '--wpkh', '--path', 'm/49h/1h/0h/0/0'])

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -115,9 +115,9 @@ class DeviceTestCase(unittest.TestCase):
         return '{}: {}'.format(self.full_type, super().__repr__())
 
     def setup_wallets(self):
-        if '{}_test'.format(self.full_type) not in self.rpc.listwallets():
-            self.rpc.createwallet('{}_test'.format(self.full_type), True)
-        self.wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/{}_test'.format(self.rpc_userpass, self.full_type))
+        wallet_name = '{}_{}_test'.format(self.full_type, self.id())
+        self.rpc.createwallet(wallet_name=wallet_name, disable_private_keys=True)
+        self.wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/{}'.format(self.rpc_userpass, wallet_name))
         self.wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(self.rpc_userpass))
 
     def setUp(self):

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -549,44 +549,33 @@ class TestDisplayAddress(DeviceTestCase):
 
         return ms_info["address"], desc, ms_info["redeemScript"], path
 
-    def test_display_address_multisig_path(self):
+    def test_display_address_multisig(self):
         if self.full_type not in SUPPORTS_MS_DISPLAY:
             raise unittest.SkipTest("{} does not support multisig display".format(self.full_type))
 
         for addrtype in ["pkh", "sh_wpkh", "wpkh"]:
-            addr, desc, rs, path = self._make_single_multisig(addrtype)
-            args = ['displayaddress', '--path', path, '--redeem_script', rs]
-            if addrtype != "pkh":
-                args.append("--{}".format(addrtype))
-            result = self.do_command(self.dev_args + args)
-            self.assertNotIn('error', result)
-            self.assertNotIn('code', result)
-            self.assertIn('address', result)
+            for use_desc in [True, False]:
+                with self.subTest(addrtype=addrtype, use_desc=use_desc):
+                    addr, desc, rs, path = self._make_single_multisig(addrtype)
 
-            if addrtype == "wpkh":
-                # removes prefix and checksum since regtest gives
-                # prefix `bcrt` on Bitcoin Core while wallets return testnet `tb` prefix
-                self.assertEqual(addr[4:58], result['address'][2:56])
-            else:
-                self.assertEqual(addr, result['address'])
+                    if use_desc:
+                        args = ['displayaddress', '--desc', desc]
+                    else:
+                        args = ['displayaddress', '--path', path, '--redeem_script', rs]
+                        if addrtype != "pkh":
+                            args.append("--{}".format(addrtype))
 
-    def test_display_address_multisig_descriptor(self):
-        if self.full_type not in SUPPORTS_MS_DISPLAY:
-            raise unittest.SkipTest("{} does not support multisig display".format(self.full_type))
+                    result = self.do_command(self.dev_args + args)
+                    self.assertNotIn('error', result)
+                    self.assertNotIn('code', result)
+                    self.assertIn('address', result)
 
-        for addrtype in ["pkh", "sh_wpkh", "wpkh"]:
-            addr, desc, rs, path = self._make_single_multisig(addrtype)
-            result = self.do_command(self.dev_args + ['displayaddress', '--desc', desc])
-            self.assertNotIn('error', result)
-            self.assertNotIn('code', result)
-            self.assertIn('address', result)
-
-            if addrtype == "wpkh":
-                # removes prefix and checksum since regtest gives
-                # prefix `bcrt` on Bitcoin Core while wallets return testnet `tb` prefix
-                self.assertEqual(addr[4:58], result['address'][2:56])
-            else:
-                self.assertEqual(addr, result['address'])
+                    if addrtype == "wpkh":
+                        # removes prefix and checksum since regtest gives
+                        # prefix `bcrt` on Bitcoin Core while wallets return testnet `tb` prefix
+                        self.assertEqual(addr[4:58], result['address'][2:56])
+                    else:
+                        self.assertEqual(addr, result['address'])
 
     def test_display_address_xpub_multisig(self):
         if self.full_type not in SUPPORTS_XPUB_MS_DISPLAY:

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -16,6 +16,8 @@ from hwilib.cli import process_commands
 from hwilib.descriptor import AddChecksum
 from hwilib.serializations import PSBT
 
+SUPPORTS_MS_DISPLAY = {'trezor_1', 'keepkey', 'coldcard', 'trezor_t'}
+
 # Class for emulator control
 class DeviceEmulator():
     def start(self):
@@ -547,9 +549,8 @@ class TestDisplayAddress(DeviceTestCase):
         return ms_info["address"], desc, ms_info["redeemScript"], path
 
     def test_display_address_multisig_path(self):
-        supports_multisig = {'trezor_1', 'keepkey', 'coldcard', 'trezor_t'}
-        if self.full_type not in supports_multisig:
-            return
+        if self.full_type not in SUPPORTS_MS_DISPLAY:
+            raise unittest.SkipTest("{} does not support multisig display".format(self.full_type))
 
         for addrtype in ["pkh", "sh_wpkh", "wpkh"]:
             addr, desc, rs, path = self._make_single_multisig(addrtype)
@@ -569,9 +570,8 @@ class TestDisplayAddress(DeviceTestCase):
                 self.assertEqual(addr, result['address'])
 
     def test_display_address_multisig_descriptor(self):
-        supports_multisig = {'trezor_1', 'keepkey', 'coldcard', 'trezor_t'}
-        if self.full_type not in supports_multisig:
-            return
+        if self.full_type not in SUPPORTS_MS_DISPLAY:
+            raise unittest.SkipTest("{} does not support multisig display".format(self.full_type))
 
         # descriptor with xpubs
         if self.full_type == 'trezor_t':

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -322,7 +322,7 @@ class TestSignTx(DeviceTestCase):
         desc_pubkeys = []
         sorted_pubkeys = []
         for i in range(0, 3):
-            path = "/49h/1h/0h/0/{}".format(i)
+            path = "/48h/1h/{}h/0/0".format(i)
             origin = '{}{}'.format(self.fingerprint, path)
             xpub = self.do_command(self.dev_args + ["--expert", "getxpub", "m{}".format(path)])
             desc_pubkeys.append("[{}]{}".format(origin, xpub["pubkey"]))
@@ -518,7 +518,7 @@ class TestDisplayAddress(DeviceTestCase):
         desc_pubkeys = []
         sorted_pubkeys = []
         for i in range(0, 3):
-            path = "/49h/1h/0h/0/{}".format(i)
+            path = "/48h/1h/{}h/0/0".format(i)
             origin = '{}{}'.format(self.fingerprint, path)
             xpub = self.do_command(self.dev_args + ["--expert", "getxpub", "m{}".format(path)])
             desc_pubkeys.append("[{}]{}".format(origin, xpub["pubkey"]))
@@ -575,8 +575,8 @@ class TestDisplayAddress(DeviceTestCase):
         if self.full_type not in SUPPORTS_XPUB_MS_DISPLAY:
             raise unittest.SkipTest("{} does not support multsig display with xpubs".format(self.full_type))
 
-        account_xpub = self.do_command(self.dev_args + ['getxpub', 'm/45h/0h/0h/2h'])['xpub']
-        desc = 'wsh(multi(2,[' + self.fingerprint + '/45h/0h/0h/2h]' + account_xpub + '/0/0,[' + self.fingerprint + '/45h/0h/0h/2h]' + account_xpub + '/1/0))'
+        account_xpub = self.do_command(self.dev_args + ['getxpub', 'm/48h/1h/0h'])['xpub']
+        desc = 'wsh(multi(2,[' + self.fingerprint + '/48h/1h/0h]' + account_xpub + '/0/0,[' + self.fingerprint + '/48h/1h/0h]' + account_xpub + '/1/0))'
         result = self.do_command(self.dev_args + ['displayaddress', '--desc', desc])
         self.assertNotIn('error', result)
         self.assertNotIn('code', result)

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -114,6 +114,12 @@ class DeviceTestCase(unittest.TestCase):
     def __repr__(self):
         return '{}: {}'.format(self.full_type, super().__repr__())
 
+    def setup_wallets(self):
+        if '{}_test'.format(self.full_type) not in self.rpc.listwallets():
+            self.rpc.createwallet('{}_test'.format(self.full_type), True)
+        self.wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/{}_test'.format(self.rpc_userpass, self.full_type))
+        self.wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(self.rpc_userpass))
+
     def setUp(self):
         self.emulator.start()
 
@@ -168,10 +174,7 @@ class TestDeviceConnect(DeviceTestCase):
 class TestGetKeypool(DeviceTestCase):
     def setUp(self):
         super().setUp()
-        if '{}_test'.format(self.full_type) not in self.rpc.listwallets():
-            self.rpc.createwallet('{}_test'.format(self.full_type), True)
-        self.wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/{}_test'.format(self.rpc_userpass, self.full_type))
-        self.wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(self.rpc_userpass))
+        self.setup_wallets()
 
     def test_getkeypool(self):
         non_keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--nokeypool', '0', '20'])
@@ -268,10 +271,7 @@ class TestGetDescriptors(DeviceTestCase):
 class TestSignTx(DeviceTestCase):
     def setUp(self):
         super().setUp()
-        if '{}_test'.format(self.full_type) not in self.rpc.listwallets():
-            self.rpc.createwallet('{}_test'.format(self.full_type), True)
-        self.wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/{}_test'.format(self.rpc_userpass, self.full_type))
-        self.wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(self.rpc_userpass))
+        self.setup_wallets()
 
     def _generate_and_finalize(self, unknown_inputs, psbt):
         if not unknown_inputs:
@@ -446,10 +446,7 @@ class TestSignTx(DeviceTestCase):
 class TestDisplayAddress(DeviceTestCase):
     def setUp(self):
         super().setUp()
-        if '{}_test'.format(self.full_type) not in self.rpc.listwallets():
-            self.rpc.createwallet('{}_test'.format(self.full_type), True)
-        self.wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/{}_test'.format(self.rpc_userpass, self.full_type))
-        self.wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(self.rpc_userpass))
+        self.setup_wallets()
 
     def test_display_address_bad_args(self):
         result = self.do_command(self.dev_args + ['displayaddress', '--sh_wpkh', '--wpkh', '--path', 'm/49h/1h/0h/0/0'])

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -444,10 +444,6 @@ class TestSignTx(DeviceTestCase):
                 pass
 
 class TestDisplayAddress(DeviceTestCase):
-    def setUp(self):
-        super().setUp()
-        self.setup_wallets()
-
     def test_display_address_bad_args(self):
         result = self.do_command(self.dev_args + ['displayaddress', '--sh_wpkh', '--wpkh', '--path', 'm/49h/1h/0h/0/0'])
         self.assertIn('error', result)

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -65,7 +65,7 @@ class DeviceTestCase(unittest.TestCase):
         self.fingerprint = fingerprint
         self.master_xpub = master_xpub
         self.password = password
-        self.dev_args = ['-t', self.type, '-d', self.path]
+        self.dev_args = ['-t', self.type, '-d', self.path, '--testnet']
         if emulator:
             self.emulator = emulator
         else:
@@ -172,8 +172,6 @@ class TestGetKeypool(DeviceTestCase):
             self.rpc.createwallet('{}_test'.format(self.full_type), True)
         self.wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/{}_test'.format(self.rpc_userpass, self.full_type))
         self.wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(self.rpc_userpass))
-        if '--testnet' not in self.dev_args:
-            self.dev_args.append('--testnet')
         self.emulator.start()
 
     def test_getkeypool(self):
@@ -249,8 +247,6 @@ class TestGetKeypool(DeviceTestCase):
 class TestGetDescriptors(DeviceTestCase):
     def setUp(self):
         self.rpc = AuthServiceProxy('http://{}@127.0.0.1:18443'.format(self.rpc_userpass))
-        if '--testnet' not in self.dev_args:
-            self.dev_args.append('--testnet')
         self.emulator.start()
 
     def tearDown(self):
@@ -281,8 +277,6 @@ class TestSignTx(DeviceTestCase):
             self.rpc.createwallet('{}_test'.format(self.full_type), True)
         self.wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/{}_test'.format(self.rpc_userpass, self.full_type))
         self.wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(self.rpc_userpass))
-        if '--testnet' not in self.dev_args:
-            self.dev_args.append('--testnet')
         self.emulator.start()
 
     def _generate_and_finalize(self, unknown_inputs, psbt):
@@ -462,8 +456,6 @@ class TestDisplayAddress(DeviceTestCase):
             self.rpc.createwallet('{}_test'.format(self.full_type), True)
         self.wrpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/{}_test'.format(self.rpc_userpass, self.full_type))
         self.wpk_rpc = AuthServiceProxy('http://{}@127.0.0.1:18443/wallet/'.format(self.rpc_userpass))
-        if '--testnet' not in self.dev_args:
-            self.dev_args.append('--testnet')
         self.emulator.start()
 
     def test_display_address_bad_args(self):

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -521,129 +521,61 @@ class TestDisplayAddress(DeviceTestCase):
         self.assertIn('code', result)
         self.assertEqual(result['code'], -7)
 
+    def _make_single_multisig(self, addrtype):
+        desc_pubkeys = []
+        sorted_pubkeys = []
+        for i in range(0, 3):
+            path = "/49h/1h/0h/0/{}".format(i)
+            origin = '{}{}'.format(self.fingerprint, path)
+            xpub = self.do_command(self.dev_args + ["--expert", "getxpub", "m{}".format(path)])
+            desc_pubkeys.append("[{}]{}".format(origin, xpub["pubkey"]))
+            sorted_pubkeys.append((xpub["pubkey"], origin))
+        sorted_pubkeys.sort(key=lambda tup: tup[0])
+
+        if addrtype == "pkh":
+            desc = AddChecksum("sh(sortedmulti(2,{},{},{}))".format(desc_pubkeys[0], desc_pubkeys[1], desc_pubkeys[2]))
+            ms_info = self.rpc.createmultisig(2, [x[0] for x in sorted_pubkeys], "legacy")
+        elif addrtype == "sh_wpkh":
+            desc = AddChecksum("sh(wsh(sortedmulti(2,{},{},{})))".format(desc_pubkeys[1], desc_pubkeys[2], desc_pubkeys[0]))
+            ms_info = self.rpc.createmultisig(2, [x[0] for x in sorted_pubkeys], "p2sh-segwit")
+        elif addrtype == "wpkh":
+            desc = AddChecksum("wsh(sortedmulti(2,{},{},{}))".format(desc_pubkeys[2], desc_pubkeys[1], desc_pubkeys[0]))
+            ms_info = self.rpc.createmultisig(2, [x[0] for x in sorted_pubkeys], "bech32")
+        else:
+            self.fail("Oops the test is broken")
+
+        self.assertEqual(self.rpc.deriveaddresses(desc)[0], ms_info["address"])
+
+        path = "{},{},{}".format(sorted_pubkeys[0][1], sorted_pubkeys[1][1], sorted_pubkeys[2][1])
+
+        return ms_info["address"], desc, ms_info["redeemScript"], path
+
     def test_display_address_multisig_path(self):
         supports_multisig = {'trezor_1', 'keepkey', 'coldcard', 'trezor_t'}
         if self.full_type not in supports_multisig:
             return
-        # Import some keys to the watch only wallet and get multisig address
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--sh_wpkh', '40', '50'])
-        import_result = self.wrpc.importmulti(keypool_desc)
-        self.assertTrue(import_result[0]['success'])
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--sh_wpkh', '--internal', '40', '50'])
-        import_result = self.wrpc.importmulti(keypool_desc)
-        self.assertTrue(import_result[0]['success'])
-        sh_wpkh_addr = self.wrpc.getnewaddress('', 'p2sh-segwit')
-        wpkh_addr = self.wrpc.getnewaddress('', 'bech32')
-        pkh_addr = self.wrpc.getnewaddress('', 'legacy')
-        self.wrpc.importaddress(wpkh_addr)
-        self.wrpc.importaddress(pkh_addr)
 
-        # pubkeys to construct 2-of-3 multisig descriptors for import
-        sh_wpkh_info = self.wrpc.getaddressinfo(sh_wpkh_addr)
-        wpkh_info = self.wrpc.getaddressinfo(wpkh_addr)
-        pkh_info = self.wrpc.getaddressinfo(pkh_addr)
+        for addrtype in ["pkh", "sh_wpkh", "wpkh"]:
+            addr, desc, rs, path = self._make_single_multisig(addrtype)
+            args = ['displayaddress', '--path', path, '--redeem_script', rs]
+            if addrtype != "pkh":
+                args.append("--{}".format(addrtype))
+            result = self.do_command(self.dev_args + args)
+            self.assertNotIn('error', result)
+            self.assertNotIn('code', result)
+            self.assertIn('address', result)
 
-        pubkeys = [sh_wpkh_info['desc'][8:-11],
-                   wpkh_info['desc'][5:-10],
-                   pkh_info['desc'][4:-10]]
-
-        # Get the descriptors with their checksums
-        sh_multi_desc = self.wrpc.getdescriptorinfo('sh(sortedmulti(2,' + pubkeys[0] + ',' + pubkeys[1] + ',' + pubkeys[2] + '))')['descriptor']
-        sh_wsh_multi_desc = self.wrpc.getdescriptorinfo('sh(wsh(sortedmulti(2,' + pubkeys[0] + ',' + pubkeys[1] + ',' + pubkeys[2] + ')))')['descriptor']
-        wsh_multi_desc = self.wrpc.getdescriptorinfo('wsh(sortedmulti(2,' + pubkeys[2] + ',' + pubkeys[1] + ',' + pubkeys[0] + '))')['descriptor']
-
-        sh_multi_import = {'desc': sh_multi_desc, "timestamp": "now", "label": "shmulti-display"}
-        sh_wsh_multi_import = {'desc': sh_wsh_multi_desc, "timestamp": "now", "label": "shwshmulti-display"}
-        # re-order pubkeys to allow import without "already have private keys" error
-        wsh_multi_import = {'desc': wsh_multi_desc, "timestamp": "now", "label": "wshmulti-display"}
-        multi_result = self.wrpc.importmulti([sh_multi_import, sh_wsh_multi_import, wsh_multi_import])
-        self.assertTrue(multi_result[0]['success'])
-        self.assertTrue(multi_result[1]['success'])
-        self.assertTrue(multi_result[2]['success'])
-
-        sh_multi_addr = self.wrpc.getaddressesbylabel("shmulti-display").popitem()[0]
-        sh_wsh_multi_addr = self.wrpc.getaddressesbylabel("shwshmulti-display").popitem()[0]
-        wsh_multi_addr = self.wrpc.getaddressesbylabel("wshmulti-display").popitem()[0]
-
-        sh_multi_addr_redeem_script = self.wrpc.getaddressinfo(sh_multi_addr)['hex']
-        sh_wsh_multi_addr_redeem_script = self.wrpc.getaddressinfo(sh_multi_addr)['hex']
-        wsh_multi_addr_redeem_script = self.wrpc.getaddressinfo(sh_multi_addr)['hex']
-
-        path = pubkeys[2][1:24] + ',' + pubkeys[1][1:24] + ',' + pubkeys[0][1:24]
-        # need to replace `'` with `h` for stdin option to work
-        path = path.replace("'", "h")
-
-        # legacy
-        result = self.do_command(self.dev_args + ['displayaddress', '--path', path, '--redeem_script', sh_multi_addr_redeem_script])
-        self.assertNotIn('error', result)
-        self.assertNotIn('code', result)
-        self.assertIn('address', result)
-        self.assertEqual(sh_multi_addr, result['address'])
-
-        # wrapped segwit
-        result = self.do_command(self.dev_args + ['displayaddress', '--sh_wpkh', '--path', path, '--redeem_script', sh_wsh_multi_addr_redeem_script])
-        self.assertNotIn('error', result)
-        self.assertNotIn('code', result)
-        self.assertIn('address', result)
-        self.assertEqual(sh_wsh_multi_addr, result['address'])
-
-        # native setwit
-        result = self.do_command(self.dev_args + ['displayaddress', '--wpkh', '--path', path, '--redeem_script', wsh_multi_addr_redeem_script])
-        self.assertNotIn('error', result)
-        self.assertNotIn('code', result)
-        self.assertIn('address', result)
-        # removes prefix and checksum since regtest gives
-        # prefix `bcrt` on Bitcoin Core while wallets return testnet `tb` prefix
-        self.assertEqual(wsh_multi_addr[4:58], result['address'][2:56])
+            if addrtype == "wpkh":
+                # removes prefix and checksum since regtest gives
+                # prefix `bcrt` on Bitcoin Core while wallets return testnet `tb` prefix
+                self.assertEqual(addr[4:58], result['address'][2:56])
+            else:
+                self.assertEqual(addr, result['address'])
 
     def test_display_address_multisig_descriptor(self):
         supports_multisig = {'trezor_1', 'keepkey', 'coldcard', 'trezor_t'}
         if self.full_type not in supports_multisig:
             return
-        # Import some keys to the watch only wallet and get multisig address
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--sh_wpkh', '50', '60'])
-        import_result = self.wrpc.importmulti(keypool_desc)
-        self.assertTrue(import_result[0]['success'])
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--sh_wpkh', '--internal', '50', '60'])
-        import_result = self.wrpc.importmulti(keypool_desc)
-        self.assertTrue(import_result[0]['success'])
-        sh_wpkh_addr = self.wrpc.getnewaddress('', 'p2sh-segwit')
-        wpkh_addr = self.wrpc.getnewaddress('', 'bech32')
-        pkh_addr = self.wrpc.getnewaddress('', 'legacy')
-        self.wrpc.importaddress(wpkh_addr)
-        self.wrpc.importaddress(pkh_addr)
-
-        # pubkeys to construct 2-of-3 multisig descriptors for import
-        sh_wpkh_info = self.wrpc.getaddressinfo(sh_wpkh_addr)
-        wpkh_info = self.wrpc.getaddressinfo(wpkh_addr)
-        pkh_info = self.wrpc.getaddressinfo(pkh_addr)
-
-        pubkeys = [sh_wpkh_info['desc'][8:-11],
-                   wpkh_info['desc'][5:-10],
-                   pkh_info['desc'][4:-10]]
-
-        # Get the descriptors with their checksums
-        sh_multi_desc = self.wrpc.getdescriptorinfo('sh(sortedmulti(2,' + pubkeys[0] + ',' + pubkeys[1] + ',' + pubkeys[2] + '))')['descriptor']
-        sh_wsh_multi_desc = self.wrpc.getdescriptorinfo('sh(wsh(sortedmulti(2,' + pubkeys[0] + ',' + pubkeys[1] + ',' + pubkeys[2] + ')))')['descriptor']
-        wsh_multi_desc = self.wrpc.getdescriptorinfo('wsh(sortedmulti(2,' + pubkeys[2] + ',' + pubkeys[1] + ',' + pubkeys[0] + '))')['descriptor']
-
-        sh_multi_import = {'desc': sh_multi_desc, "timestamp": "now", "label": "shmulti-display-desc"}
-        sh_wsh_multi_import = {'desc': sh_wsh_multi_desc, "timestamp": "now", "label": "shwshmulti-display-desc"}
-        # re-order pubkeys to allow import without "already have private keys" error
-        wsh_multi_import = {'desc': wsh_multi_desc, "timestamp": "now", "label": "wshmulti-display-desc"}
-        multi_result = self.wrpc.importmulti([sh_multi_import, sh_wsh_multi_import, wsh_multi_import])
-        self.assertTrue(multi_result[0]['success'])
-        self.assertTrue(multi_result[1]['success'])
-        self.assertTrue(multi_result[2]['success'])
-
-        sh_multi_addr = self.wrpc.getaddressesbylabel("shmulti-display-desc").popitem()[0]
-        sh_wsh_multi_addr = self.wrpc.getaddressesbylabel("shwshmulti-display-desc").popitem()[0]
-        wsh_multi_addr = self.wrpc.getaddressesbylabel("wshmulti-display-desc").popitem()[0]
-
-        # need to replace `'` with `h` and to remove checksum for the stdin option to work
-        sh_multi_desc = sh_multi_desc.replace("'", "h").split('#')[0]
-        sh_wsh_multi_desc = sh_wsh_multi_desc.replace("'", "h").split('#')[0]
-        wsh_multi_desc = wsh_multi_desc.replace("'", "h").split('#')[0]
 
         # descriptor with xpubs
         if self.full_type == 'trezor_t':
@@ -658,28 +590,19 @@ class TestDisplayAddress(DeviceTestCase):
             # prefix `bcrt` on Bitcoin Core while wallets return testnet `tb` prefix
             self.assertEqual(addr[4:58], result['address'][2:56])
 
-        # legacy
-        result = self.do_command(self.dev_args + ['displayaddress', '--desc', sh_multi_desc])
-        self.assertNotIn('error', result)
-        self.assertNotIn('code', result)
-        self.assertIn('address', result)
-        self.assertEqual(sh_multi_addr, result['address'])
+        for addrtype in ["pkh", "sh_wpkh", "wpkh"]:
+            addr, desc, rs, path = self._make_single_multisig(addrtype)
+            result = self.do_command(self.dev_args + ['displayaddress', '--desc', desc])
+            self.assertNotIn('error', result)
+            self.assertNotIn('code', result)
+            self.assertIn('address', result)
 
-        # wrapped segwit
-        result = self.do_command(self.dev_args + ['displayaddress', '--desc', sh_wsh_multi_desc])
-        self.assertNotIn('error', result)
-        self.assertNotIn('code', result)
-        self.assertIn('address', result)
-        self.assertEqual(sh_wsh_multi_addr, result['address'])
-
-        # native setwit
-        result = self.do_command(self.dev_args + ['displayaddress', '--desc', wsh_multi_desc])
-        self.assertNotIn('error', result)
-        self.assertNotIn('code', result)
-        self.assertIn('address', result)
-        # removes prefix and checksum since regtest gives
-        # prefix `bcrt` on Bitcoin Core while wallets return testnet `tb` prefix
-        self.assertEqual(wsh_multi_addr[4:58], result['address'][2:56])
+            if addrtype == "wpkh":
+                # removes prefix and checksum since regtest gives
+                # prefix `bcrt` on Bitcoin Core while wallets return testnet `tb` prefix
+                self.assertEqual(addr[4:58], result['address'][2:56])
+            else:
+                self.assertEqual(addr, result['address'])
 
 class TestSignMessage(DeviceTestCase):
     def test_sign_msg(self):

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -403,9 +403,9 @@ class TestSignTx(DeviceTestCase):
 
     # Test wrapper to avoid mixed-inputs signing for Ledger
     def test_signtx(self):
-        supports_mixed = {'coldcard', 'trezor_1', 'digitalbitbox', 'keepkey'}
+        supports_mixed = {'coldcard', 'trezor_1', 'digitalbitbox', 'keepkey', 'trezor_t'}
         supports_multisig = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t'}
-        supports_external = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard'}
+        supports_external = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t'}
         self._test_signtx("legacy", self.full_type in supports_multisig, self.full_type in supports_external)
         self._test_signtx("segwit", self.full_type in supports_multisig, self.full_type in supports_external)
         if self.full_type in supports_mixed:

--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -133,6 +133,9 @@ def digitalbitbox_test_suite(simulator, rpc, userpass, interface):
             self.assertTrue(result['success'])
 
     class TestBitboxGetXpub(DeviceTestCase):
+        def setUp(self):
+            self.dev_args.remove('--testnet')
+
         def test_getxpub(self):
             result = self.do_command(self.dev_args + ['--expert', 'getxpub', 'm/44h/0h/0h/3'])
             self.assertEqual(result['xpub'], 'xpub6Du9e5Cz1NZWz3dvsvM21tsj4xEdbAb7AcbysFL42Y3yr8PLMnsaxhetHxurTpX5Rp5RbnFFwP1wct8K3gErCUSwcxFhxThsMBSxdmkhTNf')

--- a/test/test_ledger.py
+++ b/test/test_ledger.py
@@ -99,6 +99,9 @@ def ledger_test_suite(emulator, rpc, userpass, interface):
             self.assertEqual(result['code'], -9)
 
     class TestLedgerGetXpub(DeviceTestCase):
+        def setUp(self):
+            self.dev_args.remove("--testnet")
+
         def test_getxpub(self):
             result = self.do_command(self.dev_args + ['--expert', 'getxpub', 'm/44h/0h/0h/3'])
             self.assertEqual(result['xpub'], 'xpub6DqTtMuqBiBsSPb5UxB1qgJ3ViXuhoyZYhw3zTK4MywLB6psioW4PN1SAbhxVVirKQojnTBsjG5gXiiueRBgWmUuN43dpbMSgMCQHVqx2bR')


### PR DESCRIPTION
* Refactor and cleanup wallet, RPC, and `--testnet` argument setup
  * A new wallet is made for each individual test case for now. Funds still provided by the default wallet.
* Multisig setups are refactored and updated to not use the wallet
  * Common functionality is refactored into a separate function to deduplicate a bunch of code.
  * The setup itself is simplified to not require the use of the wallet.
* The multisig descriptor with xpub test added in #353 is moved to its own function
* The multisig `displayaddress` tests for descriptor and paths have been combined as they are basically the same
* The wallet we import stuff into is now a descriptor wallet and we use `importdescriptors` now. This is necessary to fix the Trezor 1 test failure.
* Change multisigs to use the `m/48'` path that is supposedly a standard but not really documented anywhere. This is necessary to fix the Trezor 1 test failure.