### PR TITLE
Update docs regarding Trezor T mixed input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Please also see [docs](docs/) for additional information about each device.
 | Arbitrary redeemScript Inputs | Yes | Yes | N/A | N/A | Yes | N/A | N/A |
 | Arbitrary witnessScript Inputs | Yes | Yes | N/A | N/A | Yes | N/A | N/A |
 | Non-wallet inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Mixed Segwit and Non-Segwit Inputs | N/A | N/A | Yes | N/A | Yes | Yes | Yes |
+| Mixed Segwit and Non-Segwit Inputs | N/A | N/A | Yes | Yes | Yes | Yes | Yes |
 | Display on device screen | Yes | Yes | Yes | Yes | N/A | Yes | Yes |
 
 ## Using with Bitcoin Core

--- a/docs/trezor.md
+++ b/docs/trezor.md
@@ -21,7 +21,6 @@ Due to the limitations of the Trezor, some transactions cannot be signed by a Tr
 - Multisig inputs are limited to at most n-of-15 multisigs. This is a firmware limitation.
 * Transactions with arbitrary input scripts (scriptPubKey, redeemScript, or witnessScript) and arbitrary output scripts cannot be signed. This is a firmware limitation.
 * Send-to-self transactions will result in no prompt for outputs as all outputs will be detected as change.
-- For **Trezor T**, a transaction cannot contain both segwit and non-segwit inputs
 
 ## Note on `backup`
 


### PR DESCRIPTION
AFAICT Trezor T does support mixed segwit and non-segwit inputs, there's couple of tests for that: https://github.com/trezor/trezor-firmware/blob/core/v2.3.2/tests/device_tests/test_msg_signtx_mixed_inputs.py