### PR TITLE
Fix README features table rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,15 @@ The below table lists what devices and features are supported for each device.
 Please also see [docs](docs/) for additional information about each device.
 
 | Feature \ Device | Ledger Nano X | Ledger Nano S | Trezor One | Trezor Model T | BitBox01 | BitBox02 | KeepKey | Coldcard |
-|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | Support Planned | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | Implemented | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | xpub retrieval | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | Message Signing | Yes | Yes | Yes | Yes | Yes | N/A | Yes | Yes |
 | Device Setup | N/A | N/A | Yes | Yes | Yes | Yes | Yes | N/A |
 | Device Wipe | N/A | N/A | Yes | Yes | Yes | Yes | Yes | N/A |
-| Device Recovery | N/A | N/A | Yes | Yes | N/A |  Yes | Yes | N/A |
-| Device Backup | N/A | N/A | N/A | N/A | Yes |  Yes | N/A | Yes |
+| Device Recovery | N/A | N/A | Yes | Yes | N/A | Yes | Yes | N/A |
+| Device Backup | N/A | N/A | N/A | N/A | Yes | Yes | N/A | Yes |
 | P2PKH Inputs | Yes | Yes | Yes | Yes | Yes | N/A | Yes | Yes |
 | P2SH-P2WPKH Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | P2WPKH Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |


### PR DESCRIPTION
The HWW features table seems to have been broken with #363 due to a small issue (needed to add another `:---:|` at the table separator list), so just a small PR to fix that (and remove duplicated spaces).