### PR TITLE
Update coldcard library

### DIFF
--- a/hwilib/devices/ckcc/README.md
+++ b/hwilib/devices/ckcc/README.md
@@ -2,7 +2,7 @@
 
 This is a stripped down and modified version of the official [ckcc-protocol](https://github.com/Coldcard/ckcc-protocol) library.
 
-This stripped down version was made at commit [49fa0265df4c9d0d0d915ccd4dc41b06104d6738](https://github.com/Coldcard/ckcc-protocol/tree/49fa0265df4c9d0d0d915ccd4dc41b06104d6738).
+This stripped down version was made at commit [ca8d2b7808784a9f4927f3250bf52d2623a4e15b](https://github.com/Coldcard/ckcc-protocol/tree/ca8d2b7808784a9f4927f3250bf52d2623a4e15b).
 
 ## Changes
 

--- a/hwilib/devices/ckcc/__init__.py
+++ b/hwilib/devices/ckcc/__init__.py
@@ -1,5 +1,5 @@
 
-__version__ = '0.7.2'
+__version__ = '1.0.2'
 
 __all__ = [ "client", "protocol", "constants" ]
 

--- a/hwilib/devices/ckcc/client.py
+++ b/hwilib/devices/ckcc/client.py
@@ -8,7 +8,7 @@
 #
 #   - ec_mult, ec_setup, aes_setup, mitm_verify
 #
-import hid, sys, os
+import hid, sys, os, platform
 from binascii import b2a_hex, a2b_hex
 from hashlib import sha256
 from .protocol import CCProtocolPacker, CCProtocolUnpacker, CCProtoError, MAX_MSG_LEN, MAX_BLK_LEN
@@ -27,6 +27,8 @@ class ColdcardDevice:
         self.is_simulator = False
 
         if not dev and sn and '/' in sn:
+            if platform.system() == 'Windows':
+                raise RuntimeError("Cannot connect to simulator. Is it running?")
             dev = UnixSimulatorPipe(sn)
             found = 'simulator'
             self.is_simulator = True

--- a/hwilib/devices/ckcc/constants.py
+++ b/hwilib/devices/ckcc/constants.py
@@ -24,6 +24,24 @@ MAX_UPLOAD_LEN = const(2*MAX_TXN_LEN)
 # Max length of text messages for signing
 MSG_SIGNING_MAX_LENGTH = const(240)
 
+# Types of user auth we support
+USER_AUTH_TOTP = const(1)       # RFC6238
+USER_AUTH_HOTP = const(2)       # RFC4226
+USER_AUTH_HMAC = const(3)       # PBKDF2('hmac-sha256', secret, sha256(psbt), PBKDF2_ITER_COUNT)
+USER_AUTH_SHOW_QR = const(0x80) # show secret on Coldcard screen (best for TOTP enroll)
+
+MAX_USERNAME_LEN = 16
+PBKDF2_ITER_COUNT = 2500
+
+# Max depth for derived keys, in PSBT files, and USB commands
+MAX_PATH_DEPTH = const(12)
+
+# Bitmask used in sign_transaction (stxn) command
+STXN_FINALIZE       = const(0x01)
+STXN_VISUALIZE      = const(0x02)
+STXN_SIGNED         = const(0x04)
+STXN_FLAGS_MASK     = const(0x07)
+
 # Bit values for address types
 AFC_PUBKEY      = const(0x01)       # pay to hash of pubkey
 AFC_SEGWIT      = const(0x02)       # requires a witness to spend
@@ -51,6 +69,7 @@ SUPPORTED_ADDR_FORMATS = frozenset([
 # BIP-174 aka PSBT defined values
 #
 PSBT_GLOBAL_UNSIGNED_TX     = const(0)
+PSBT_GLOBAL_XPUB            = const(1)
 
 PSBT_IN_NON_WITNESS_UTXO    = const(0)
 PSBT_IN_WITNESS_UTXO        = const(1)

--- a/hwilib/devices/ckcc/protocol.py
+++ b/hwilib/devices/ckcc/protocol.py
@@ -11,6 +11,12 @@ class CCProtoError(RuntimeError):
     def __str__(self):
         return self.args[0]
 
+class CCFramingError(CCProtoError):
+    # Typically framing errors are caused by multiple
+    # programs trying to talk to Coldcard at same time,
+    # and the encryption state gets confused.
+    pass
+
 class CCUserRefused(RuntimeError):
     def __str__(self):
         return 'You refused permission to do the operation'
@@ -43,6 +49,15 @@ class CCProtocolPacker:
         return b'ping' + bytes(msg)
 
     @staticmethod
+    def bip39_passphrase(pw):
+        return b'pass' + bytes(pw, 'utf8')
+
+    @staticmethod
+    def get_passphrase_done():
+        # poll completion of BIP39 encryption change (provides root xpub)
+        return b'pwok'
+
+    @staticmethod
     def check_mitm():
         return b'mitm'
 
@@ -72,10 +87,11 @@ class CCProtocolPacker:
         return b'sha2'
 
     @staticmethod
-    def sign_transaction(length, file_sha, finalize=False):
+    def sign_transaction(length, file_sha, finalize=False, flags=0x0):
         # must have already uploaded binary, and give expected sha256
         assert len(file_sha) == 32
-        return pack('<4sII32s', b'stxn', length, int(finalize), file_sha)
+        flags |= (STXN_FINALIZE if finalize else 0x00)
+        return pack('<4sII32s', b'stxn', length, int(flags), file_sha)
 
     @staticmethod
     def sign_message(raw_msg, subpath='m', addr_fmt=AF_CLASSIC):
@@ -99,14 +115,26 @@ class CCProtocolPacker:
         return b'stok'
 
     @staticmethod
+    def multisig_enroll(length, file_sha):
+        # multisig details must already be uploaded as a text file, this starts approval process.
+        assert len(file_sha) == 32
+        return pack('<4sI32s', b'enrl', length, file_sha)
+
+    @staticmethod
+    def multisig_check(M, N, xfp_xor):
+        # do we have a wallet already that matches M+N and xor(*xfps)?
+        return pack('<4s3I', b'msck', M, N, xfp_xor)
+
+    @staticmethod
     def get_xpub(subpath='m'):
         # takes a string, like: m/44'/0'/23/23
         return b'xpub' + subpath.encode('ascii')
 
     @staticmethod
     def show_address(subpath, addr_fmt=AF_CLASSIC):
-        # takes a string, like: m/44'/0'/23/23
-        # shows on screen, no feedback from user expected
+        # - takes a string, like: m/44'/0'/23/23
+        # - shows on screen, no feedback from user expected
+        assert not (addr_fmt & AFC_SCRIPT)
         return pack('<4sI', b'show', addr_fmt) + subpath.encode('ascii')
 
     @staticmethod
@@ -132,6 +160,11 @@ class CCProtocolPacker:
         return rv
 
     @staticmethod
+    def block_chain():
+        # ask what blockchain it's set for; expect "BTC" or "XTN"
+        return b'blkc'
+
+    @staticmethod
     def sim_keypress(key):
         # Simulator ONLY: pretend a key is pressed
         return b'XKEY' + key
@@ -140,6 +173,48 @@ class CCProtocolPacker:
     def bag_number(new_number=b''):
         # one time only: put into bag, or readback bag
         return b'bagi' + bytes(new_number)
+
+    @staticmethod
+    def hsm_start(length=0, file_sha=b''):
+        if length:
+            # New policy already be uploaded as a JSON file, get approval and start.
+            assert len(file_sha) == 32
+            return pack('<4sI32s', b'hsms', length, file_sha)
+        else:
+            # Use policy on device already. Confirmation still required by local user.
+            return b'hsms'
+
+    @staticmethod
+    def hsm_status():
+        # get current status of HSM mode and/or policy defined already. Returns JSON
+        return b'hsts'
+
+    @staticmethod
+    def create_user(username, auth_mode, secret=b''):
+        # create username, with pre-shared secret/password, or we generate.
+        # auth_model should be one of USER_AUTH_*
+        # for TOTP/HOTP, secret can be empty. Set bit 0x80 in auth_mode and QR will be used
+        assert 1 <= len(username) <= MAX_USERNAME_LEN
+        assert len(secret) in { 0, 10, 20, 32}
+        return pack('<4sBBB', b'nwur', auth_mode, len(username), len(secret)) + username + secret
+
+    @staticmethod
+    def delete_user(username):
+        # remove a username and forget secret; cannot be used in HSM mode (only before)
+        assert 0 < len(username) <= MAX_USERNAME_LEN
+        return pack('<4sB', b'rmur', len(username)) + username
+
+    @staticmethod
+    def user_auth(username, token, totp_time=0):
+        # HSM mode: try an authentication method for a username
+        assert 0 < len(username) <= 16
+        assert 6 <= len(token) <= 32
+        return pack('<4sIBB', b'user', totp_time, len(username), len(token)) + username + token
+
+    @staticmethod
+    def get_storage_locker():
+        # returns up to 414 bytes of user-defined sensitive data
+        return b'gslr'
 
 
 class CCProtocolUnpacker:
@@ -156,7 +231,7 @@ class CCProtocolUnpacker:
 
         d = getattr(cls, sign, cls)
         if d is cls:
-            raise CCProtoError('Unknown response signature: ' + repr(sign))
+            raise CCFramingError('Unknown response signature: ' + repr(sign))
 
         return d(msg)
         
@@ -170,9 +245,9 @@ class CCProtocolUnpacker:
 
     # low-level errors
     def fram(msg):
-        raise CCProtoError("Framing Error", str(msg[4:], 'utf8'))
+        raise CCFramingError("Framing Error", str(msg[4:], 'utf8'))
     def err_(msg):
-        raise CCProtoError("Remote Error: " + str(msg[4:], 'utf8', 'ignore'), msg[4:])
+        raise CCProtoError("Coldcard Error: " + str(msg[4:], 'utf8', 'ignore'), msg[4:])
 
     def refu(msg):
         # user didn't want to approve something

--- a/hwilib/devices/ckcc/utils.py
+++ b/hwilib/devices/ckcc/utils.py
@@ -85,24 +85,26 @@ def get_pubkey_string(b):
         y = p - y
     return x.to_bytes(32, byteorder="big") + y.to_bytes(32, byteorder="big")
 
-def str_to_int_path(xfp, path):
-    # convert text  m/34'/33/44 into BIP174 binary compat format
-    # - include hex for fingerprint (m) as first arg
 
-    rv = [struct.unpack('<I', binascii.a2b_hex(xfp))[0]]
-    for i in path.split('/'):
-        if i == 'm': continue
-        if not i: continue      # trailing or duplicated slashes
-        
-        if i[-1] in "'phHP":
-            assert len(i) >= 2, i
-            here = int(i[:-1]) | 0x80000000
-        else:
-            here = int(i)
-            assert 0 <= here < 0x80000000, here
-        
-        rv.append(here)
+def calc_local_pincode(psbt_sha, next_local_code):
+    # In HSM mode, you will need this function to generate
+    # the next 6-digit code for the local user.
+    #
+    # - next_local_code comes from the hsm_status response
+    # - psbt_sha is sha256() over the binary PSBT you will be submitting
+    #
+    from binascii import a2b_base64
+    from hashlib import sha256
+    import struct, hmac
 
-    return rv
+    key = a2b_base64(next_local_code)
+    assert len(key) >= 15
+    assert len(psbt_sha) == 32
+    digest = hmac.new(key, psbt_sha, sha256).digest()
+
+    num = struct.unpack('>I', digest[-4:])[0] & 0x7fffffff
+
+    return '%06d' % (num % 1000000)
+
 
 # EOF


### PR DESCRIPTION
#377 Broke coldcard support because hidapi updated and our version of the ckcc library was not ready to handle that. So update it.

This failure is not detected by our test suite as it requires actually accessing hardware.