### PR TITLE
Allow passing None to BitBox2 passphrase

### DIFF
--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -246,7 +246,7 @@ class Bitbox02Client(HardwareWalletClient):
         Initializes a new BitBox02 client instance.
         """
         super().__init__(path, password=password, expert=expert)
-        if password != "":
+        if not password:
             raise BadArgumentError(
                 "The BitBox02 does not accept a passphrase from the host. Please enable the passphrase option and enter the passphrase on the device during unlock."
             )


### PR DESCRIPTION
Check for emptiness instead of an empty string when initializing BitBox2.
A very small change but I think that'd be the expected behavior with regards to how others (like Ledger) treat the passphrase.


A separate question, are you planning to make a new release soon with the BitBox2 in it?