### PR TITLE
bitbox02: fix enumerate regression

### DIFF
--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -214,7 +214,7 @@ class Bitbox02Client(HardwareWalletClient):
         Initializes a new BitBox02 client instance.
         """
         super().__init__(path, password=password, expert=expert)
-        if not password:
+        if password:
             raise BadArgumentError(
                 "The BitBox02 does not accept a passphrase from the host. Please enable the passphrase option and enter the passphrase on the device during unlock."
             )


### PR DESCRIPTION
6a6c46f6834b4dac5e67d0c92a9ef791619e9dce checks that a password must
exist instead of that a password must not exist.

That commit does not describe the reason for the change. Password
cannot be None anyway, as the type of password is `str`, not `Optional[str]`.