### PR TITLE
descriptor: fix wrong handling of missing origin in multisig

### DIFF
--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -242,7 +242,8 @@ def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False, rede
             redeem_script = format(80 + int(descriptor.multisig_M), 'x')
             xpubs_descriptor = False
             for i in range(0, descriptor.multisig_N):
-                path += descriptor.origin_fingerprint[i] + descriptor.origin_path[i]
+                if descriptor.origin_fingerprint[i] and descriptor.origin_path[i]:
+                    path += descriptor.origin_fingerprint[i] + descriptor.origin_path[i]
                 if not descriptor.path_suffix[i]:
                     redeem_script += '21' + descriptor.base_key[i]
                 else:

--- a/hwilib/descriptor.py
+++ b/hwilib/descriptor.py
@@ -86,9 +86,13 @@ class Descriptor:
         elif isinstance(origin_path, list):
             self.m_path_base = []
             self.m_path = []
-            for i in range(0, len(origin_path)):
-                self.m_path_base.append("m" + origin_path[i])
-                self.m_path.append("m" + origin_path[i] + (path_suffix[i] or ""))
+            for i, path in enumerate(origin_path):
+                if path is None:
+                    self.m_path_base.append(None)
+                    self.m_path.append(None)
+                else:
+                    self.m_path_base.append("m" + path)
+                    self.m_path.append("m" + path + (path_suffix[i] or ""))
 
     @classmethod
     def parse(cls, desc, testnet=False):
@@ -145,6 +149,8 @@ class Descriptor:
 
         descriptors = []
         for key in keys:
+            origin_fingerprint = None
+            origin_path = None
             origin_match = re.search(r"\[(.*)\]", key)
             if origin_match:
                 origin = origin_match.group(1)

--- a/test/test_descriptor.py
+++ b/test/test_descriptor.py
@@ -28,6 +28,18 @@ class TestDescriptor(unittest.TestCase):
         self.assertEqual(desc.m_path_base, ["m/48'/0'/0'/2'", "m/48'/0'/0'/2'"])
         self.assertEqual(desc.m_path, ["m/48'/0'/0'/2'/0/0", "m/48'/0'/0'/2'/0/0"])
 
+    def test_parse_multisig_descriptor_with_missing_origin(self):
+        desc = Descriptor.parse("wsh(multi(2,[00000001/48'/0'/0'/2']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0,tpubDFHiBJDeNvqPWNJbzzxqDVXmJZoNn2GEtoVcFhMjXipQiorGUmps3e5ieDGbRrBPTFTh9TXEKJCwbAGW9uZnfrVPbMxxbFohuFzfT6VThty/0/0))", True)
+        self.assertIsNotNone(desc)
+        self.assertEqual(desc.wsh, True)
+        self.assertEqual(desc.origin_fingerprint, ["00000001", None])
+        self.assertEqual(desc.origin_path, ["/48'/0'/0'/2'", None])
+        self.assertEqual(desc.base_key, ["tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B", "tpubDFHiBJDeNvqPWNJbzzxqDVXmJZoNn2GEtoVcFhMjXipQiorGUmps3e5ieDGbRrBPTFTh9TXEKJCwbAGW9uZnfrVPbMxxbFohuFzfT6VThty"])
+        self.assertEqual(desc.path_suffix, ["/0/0", "/0/0"])
+        self.assertEqual(desc.testnet, True)
+        self.assertEqual(desc.m_path_base, ["m/48'/0'/0'/2'", None])
+        self.assertEqual(desc.m_path, ["m/48'/0'/0'/2'/0/0", None])
+
     def test_parse_descriptor_without_origin(self):
         desc = Descriptor.parse("wpkh(tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0)", True)
         self.assertIsNotNone(desc)


### PR DESCRIPTION
Example (second key is missing an origin):

wsh(multi(2,[00000001/48'/0'/0'/2']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/0,tpubDFHiBJDeNvqPWNJbzzxqDVXmJZoNn2GEtoVcFhMjXipQiorGUmps3e5ieDGbRrBPTFTh9TXEKJCwbAGW9uZnfrVPbMxxbFohuFzfT6VThty/0/0))

Before, the fingerprint and origin keypath of the second key was the
same as the first one, as the loop parsing it did not reset it.

Now, the fingerprint and origin keypath of the second key is None.