### PR TITLE
Upgrade USB enumeration logic for Ledger products

### DIFF
--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -47,6 +47,10 @@ LEDGER_MODEL_IDS = {
     0x10: "ledger_nano_s",
     0x40: "ledger_nano_x"
 }
+LEDGER_LEGACY_PRODUCT_IDS = {
+    0x0001: "ledger_nano_s",
+    0x0004: "ledger_nano_x"
+}
 
 # minimal checking of string keypath
 def check_keypath(key_path):
@@ -397,9 +401,12 @@ def enumerate(password=''):
             path = d['path'].decode()
             d_data['type'] = 'ledger'
             model = d['product_id'] >> 8
-            if model not in LEDGER_MODEL_IDS.keys():
+            if model in LEDGER_MODEL_IDS.keys():
+                d_data['model'] = LEDGER_MODEL_IDS[model]
+            elif d['product_id'] in LEDGER_LEGACY_PRODUCT_IDS.keys():
+                d_data['model'] = LEDGER_LEGACY_PRODUCT_IDS[d['product_id']]
+            else:
                 continue
-            d_data['model'] = LEDGER_MODEL_IDS[model]
             d_data['path'] = path
 
             if path == SIMULATOR_PATH:

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -43,10 +43,10 @@ import re
 SIMULATOR_PATH = 'tcp:127.0.0.1:9999'
 
 LEDGER_VENDOR_ID = 0x2c97
-LEDGER_DEVICE_IDS = [
-    0x0001, # Ledger Nano S
-    0x0004, # Ledger Nano X
-]
+LEDGER_MODEL_IDS = {
+    0x10: "ledger_nano_s",
+    0x40: "ledger_nano_x"
+}
 
 # minimal checking of string keypath
 def check_keypath(key_path):
@@ -386,9 +386,8 @@ class LedgerClient(HardwareWalletClient):
 def enumerate(password=''):
     results = []
     devices = []
-    for device_id in LEDGER_DEVICE_IDS:
-        devices.extend(hid.enumerate(LEDGER_VENDOR_ID, device_id))
-    devices.append({'path': SIMULATOR_PATH.encode(), 'interface_number': 0, 'product_id': 1})
+    devices.extend(hid.enumerate(LEDGER_VENDOR_ID, 0))
+    devices.append({'path': SIMULATOR_PATH.encode(), 'interface_number': 0, 'product_id': 0x1000})
 
     for d in devices:
         if ('interface_number' in d and d['interface_number'] == 0
@@ -397,7 +396,10 @@ def enumerate(password=''):
 
             path = d['path'].decode()
             d_data['type'] = 'ledger'
-            d_data['model'] = 'ledger_nano_x' if d['product_id'] == 0x0004 else 'ledger_nano_s'
+            model = d['product_id'] >> 8
+            if model not in LEDGER_MODEL_IDS.keys():
+                continue
+            d_data['model'] = LEDGER_MODEL_IDS[model]
             d_data['path'] = path
 
             if path == SIMULATOR_PATH:


### PR DESCRIPTION
Following this issue: https://github.com/bitcoin-core/HWI/issues/402
Linked to this update in the device PID numbering logic: https://www.ledger.com/windows-10-update-sunsetting-u2f-tunnel-transport-for-ledger-devices

https://github.com/bitcoin-core/HWI/pull/403/commits/1080756258477b15c4e61025635e5b7b2dc947d4 can be discarded if we don't care about apps <v1.5.1