### PR TITLE
Bitbox02 multisig

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Please also see [docs](docs/) for additional information about each device.
 | P2SH-P2WPKH Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | P2WPKH Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | P2SH Multisig Inputs | Yes | Yes | Yes | Yes | Yes | N/A | Yes | Yes |
-| P2SH-P2WSH Multisig Inputs | Yes | Yes | Yes | Yes | Yes | N/A | Yes | Yes |
+| P2SH-P2WSH Multisig Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | P2WSH Multisig Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | Bare Multisig Inputs | Yes | Yes | N/A | N/A | Yes | N/A | N/A | N/A |
 | Arbitrary scriptPubKey Inputs | Yes | Yes | N/A | N/A | Yes | N/A | N/A | N/A |

--- a/docs/bitbox02.md
+++ b/docs/bitbox02.md
@@ -13,20 +13,19 @@ Current implemented commands are:
 * `backup`
 * `togglepassphrase`
 
-Multisig (P2WSH only) is supported by the BitBox02, but is not ingerated into HWI yet. Coming
-soon^{tm}.
-
 # Usage Notes
 
 ## Strict keypaths
 
 The BitBox02 has strict keypath validation.
 
-The only accepted keypaths for xpubs are:
+The only accepted keypaths for xpubs are (as of firmware v9.3.0):
 
 - `m/49'/0'/<account'>` for `p2wpkh-p2sh` (segwit wrapped in P2SH)
 - `m/84'/0'/<account'>` for `p2wpkh` (native segwit v0)
-- `m/48'/0'/<account'>/2` for p2wsh multisig (native segwit v0 multisig).
+- `m/48'/0'/<account'>/2'` for p2wsh multisig (native segwit v0 multisig).
+- `m/48'/0'/<account'>/1'` for p2wsh-p2sh multisig (p2sh-wrapped segwit v0 multisig).
+- `m/48'/0'/<account'>` for p2wsh and p2wsh-p2sh multisig.
 
 `account'` can be between `0'` and `99'`.
 

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -612,7 +612,8 @@ class Bitbox02Client(HardwareWalletClient):
                 "Label/passphrase not needed when exporting mnemonic from the BitBox02."
             )
 
-        return {"success": self.init().show_mnemonic()}
+        self.init().show_mnemonic()
+        return {"success": True}
 
     @bitbox02_exception
     def restore_device(

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -713,7 +713,6 @@ class Bitbox02Client(HardwareWalletClient):
                 script_configs[0].script_config, script_configs[0].keypath
             )
 
-        bip44_network = 1 + HARDENED if self.is_testnet else 0 + HARDENED
         sigs = self.init().btc_sign(
             self._get_coin(),
             script_configs,

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -73,6 +73,8 @@ class BitBox02Error(UnavailableActionError):
         msg += "m/49'/0'/<account'> for p2wpkh-p2sh; "
         msg += "m/84'/0'/<account'> for p2wpkh; "
         msg += "m/48'/0'/<account'>/2' for p2wsh multisig; "
+        msg += "m/48'/0'/<account'>/1' for p2wsh-p2sh multisig; "
+        msg += "m/48'/0'/<account'>' for any supported multisig; "
         msg += "account can be between 0' and 99'; "
         msg += "For address keypaths, append /0/<address index> for a receive and /1/<change index> for a change address."
         super().__init__(msg)

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -34,10 +34,7 @@ from ..errors import (
     handle_errors,
     common_err_msgs,
 )
-from ..key import (
-    KeyOriginInfo,
-    parse_path,
-)
+from ..key import KeyOriginInfo, parse_path
 
 import hid  # type: ignore
 

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -495,9 +495,10 @@ def DeserializeHDKeypath(
     f: Readable,
     key: bytes,
     hd_keypaths: MutableMapping[bytes, KeyOriginInfo],
+    expected_sizes: Sequence[int],
 ) -> None:
-    if len(key) != 34 and len(key) != 66:
-        raise PSBTSerializationError("Size of key was not the expected size for the type partial signature pubkey")
+    if len(key) not in expected_sizes:
+        raise PSBTSerializationError("Size of key was not the expected size for the type partial signature pubkey. Length: {}".format(len(key)))
     pubkey = key[1:]
     if pubkey in hd_keypaths:
         raise PSBTSerializationError("Duplicate key, input partial signature for pubkey already provided")
@@ -604,7 +605,7 @@ class PartiallySignedInput:
                 self.witness_script = deser_string(f)
 
             elif key_type == 6:
-                DeserializeHDKeypath(f, key, self.hd_keypaths)
+                DeserializeHDKeypath(f, key, self.hd_keypaths, [34, 66])
 
             elif key_type == 7:
                 if len(self.final_script_sig) != 0:
@@ -719,7 +720,7 @@ class PartiallySignedOutput:
                 self.witness_script = deser_string(f)
 
             elif key_type == 2:
-                DeserializeHDKeypath(f, key, self.hd_keypaths)
+                DeserializeHDKeypath(f, key, self.hd_keypaths, [34, 66])
 
             else:
                 if key in self.unknown:
@@ -757,6 +758,7 @@ class PSBT(object):
         self.inputs: List[PartiallySignedInput] = []
         self.outputs: List[PartiallySignedOutput] = []
         self.unknown: Dict[bytes, bytes] = {}
+        self.xpub: Dict[bytes, KeyOriginInfo] = {}
 
     def deserialize(self, psbt: str) -> None:
         psbt_bytes = base64.b64decode(psbt.strip())
@@ -799,7 +801,8 @@ class PSBT(object):
                 for txin in self.tx.vin:
                     if len(txin.scriptSig) != 0 or not self.tx.wit.is_null():
                         raise PSBTSerializationError("Unsigned tx does not have empty scriptSigs and scriptWitnesses")
-
+            elif key_type == 0x01:
+                DeserializeHDKeypath(f, key, self.xpub, [79])
             else:
                 if key in self.unknown:
                     raise PSBTSerializationError("Duplicate key, key for unknown value already provided")
@@ -850,6 +853,9 @@ class PSBT(object):
         tx = self.tx.serialize_with_witness()
         r += ser_compact_size(len(tx))
         r += tx
+
+        # write xpubs
+        r += SerializeHDKeypath(self.xpub, b"\x01")
 
         # unknowns
         for key, value in sorted(self.unknown.items()):

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -348,6 +348,9 @@ class CTxOut(object):
     def is_p2sh(self) -> bool:
         return is_p2sh(self.scriptPubKey)
 
+    def is_p2wsh(self) -> bool:
+        return is_p2wsh(self.scriptPubKey)
+
     def is_p2pkh(self) -> bool:
         return is_p2pkh(self.scriptPubKey)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -32,7 +32,7 @@ description = "Python library for bitbox02 communication"
 name = "bitbox02"
 optional = false
 python-versions = ">=3.6"
-version = "4.1.0"
+version = "5.1.0"
 
 [package.dependencies]
 base58 = ">=2.0.0"
@@ -349,7 +349,8 @@ testing = ["jaraco.itertools", "func-timeout"]
 qt = ["pyside2"]
 
 [metadata]
-content-hash = "6bee57172b9beaa2587a228e24a3c7588d2472f228b4bd845ff0cc8c99f4374f"
+content-hash = "2cf812887d174f29ea88b17382662d98471ab2f753d5ef597a9c90413e58fab7"
+lock-version = "1.0"
 python-versions = "^3.6,<3.9"
 
 [metadata.files]
@@ -365,8 +366,8 @@ base58 = [
     {file = "base58-2.0.1.tar.gz", hash = "sha256:365c9561d9babac1b5f18ee797508cd54937a724b6e419a130abad69cec5ca79"},
 ]
 bitbox02 = [
-    {file = "bitbox02-4.1.0-py3-none-any.whl", hash = "sha256:1af95952d67b74c80ccc0588e0aee983c764960da637bd24bc41a1cb89d5e127"},
-    {file = "bitbox02-4.1.0.tar.gz", hash = "sha256:73a35594162f32897dd2b1880f0cfaa42922acd1c2d7f4cf3d94b8333329c931"},
+    {file = "bitbox02-5.1.0-py3-none-any.whl", hash = "sha256:7d0efad2516604c0275452506f415730ac9e790569dedc79668b67db2ed13cdf"},
+    {file = "bitbox02-5.1.0.tar.gz", hash = "sha256:0562bc93d87afd89879e130c60c8dbfaffa8a1c3deff01201702939c9594d242"},
 ]
 cffi = [
     {file = "cffi-1.14.2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:da9d3c506f43e220336433dffe643fbfa40096d408cb9b7f2477892f369d5f82"},
@@ -518,6 +519,8 @@ pyside2 = [
     {file = "PySide2-5.15.0-5.15.0-cp35.cp36.cp37.cp38-abi3-manylinux1_x86_64.whl", hash = "sha256:f9099e49fb2d3571f5a81eb9ff281ce832ce8c333052e8175e2356b9c3e4a882"},
     {file = "PySide2-5.15.0-5.15.0-cp35.cp36.cp37.cp38-none-win32.whl", hash = "sha256:7c91a5074f3c60bac7e9336943a1dc9d5c8be8ab88a232dc55018e555dae81b2"},
     {file = "PySide2-5.15.0-5.15.0-cp35.cp36.cp37.cp38-none-win_amd64.whl", hash = "sha256:2d72150f63025b9b55097c1a64d09da37ff9191f73f69237500dec7a4a130541"},
+    {file = "PySide2-5.15.0-5.15.0_1-cp35.cp36.cp37.cp38-none-win_amd64.whl", hash = "sha256:7ac86f31bc0a4fbf3f0bf00890e849441776be304c7b8bf259d777a7fe5fe913"},
+    {file = "PySide2-5.15.0-5.15.0_2-cp35.cp36.cp37.cp38-none-win_amd64.whl", hash = "sha256:fad5ce781d0774bfad39f54b6c3376909b8d27f2075cbde6f4499df7dbd855f9"},
 ]
 pywin32-ctypes = [
     {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ mnemonic = "~0"
 typing-extensions = "^3.7"
 libusb1 = "^1.7"
 pyside2 = { version = "^5.14.0", optional = true }
-bitbox02 = ">=4.1.0"
+bitbox02 = ">=5.1.0"
 
 [tool.poetry.extras]
 qt = ["pyside2"]

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ package_data = \
 modules = \
 ['hwi', 'hwi-qt']
 install_requires = \
-['bitbox02>=4.1.0',
+['bitbox02>=5.1.0',
  'ecdsa>=0,<1',
  'hidapi>=0,<1',
  'libusb1>=1.7,<2.0',


### PR DESCRIPTION
This adds support for multisig `display_address` and `sign_tx` for segwit multisig (p2wsh and p2wsh-p2sh).

This is in high demand by our users and enables multisig support in downstream wallets such as Nunchuk, Specter, Sparrow, etc.

Firmware v9.3.0 is required. 