### PR TITLE
Pastable udev Shell script

### DIFF
--- a/hwilib/udev/README.md
+++ b/hwilib/udev/README.md
@@ -14,11 +14,12 @@ These are necessary for the devices to be reachable on linux environments.
 Apply these rules by copying them to `/etc/udev/rules.d/` and notifying `udevadm`.
 Your user will need to be added to the `plugdev` group, which needs to be created if it does not already exist.
 
+```Shell
+cd hwilib/; \
+  sudo cp udev/*.rules /etc/udev/rules.d/ && \
+  sudo udevadm trigger && \
+  sudo udevadm control --reload-rules  && \
+  sudo groupadd plugdev && \
+  sudo usermod -aG plugdev `whoami`
 ```
-$ cd hwilib/
-$ sudo cp udev/*.rules /etc/udev/rules.d/
-$ sudo udevadm trigger
-$ sudo udevadm control --reload-rules
-$ sudo groupadd plugdev
-$ sudo usermod -aG plugdev `whoami`
-```
+


### PR DESCRIPTION
Modified the UDEV rule install script in a way that the user can easily copy/paste as a whole, enter his password, and press enter. 
