### PR TITLE
Accept an encoded Base64 PSBT (as both str and bytes) or a PSBT object as input to sign_tx

### DIFF
--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -358,7 +358,12 @@ class Bitbox02Client(HardwareWalletClient):
         return {"address": address}
 
     @bitbox02_exception
-    def sign_tx(self, psbt: PSBT) -> Dict[str, str]:
+    def sign_tx(self, psbt: Union[PSBT, str, bytes]) -> Dict[str, str]:
+        if isinstance(psbt, (str, bytes)):
+            psbt2 = PSBT()
+            psbt2.deserialize(psbt)
+            psbt = psbt2
+
         def find_our_key(
             keypaths: Dict[bytes, KeyOriginInfo]
         ) -> Tuple[Optional[bytes], Optional[Sequence[int]]]:

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -129,7 +129,12 @@ class ColdcardClient(HardwareWalletClient):
     # Must return a hex string with the signed transaction
     # The tx must be in the combined unsigned transaction format
     @coldcard_exception
-    def sign_tx(self, tx):
+    def sign_tx(self, tx: Union[PSBT, str, bytes]) -> Dict[str, str]:
+        if isinstance(tx, (str, bytes)):
+            psbt2 = PSBT()
+            psbt2.deserialize(tx)
+            tx = psbt2
+
         self.device.check_mitm()
 
         # Get this devices master key fingerprint

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -33,6 +33,7 @@ from ..key import (
 )
 from ..serializations import (
     CTransaction,
+    PSBT,
     hash256,
     is_p2pk,
     is_p2pkh,
@@ -363,7 +364,11 @@ class DigitalbitboxClient(HardwareWalletClient):
     # Must return a hex string with the signed transaction
     # The tx must be in the PSBT format
     @digitalbitbox_exception
-    def sign_tx(self, tx):
+    def sign_tx(self, tx: Union[PSBT, str, bytes]) -> Dict[str, str]:
+        if isinstance(tx, (str, bytes)):
+            psbt2 = PSBT()
+            psbt2.deserialize(tx)
+            tx = psbt2
 
         # Create a transaction with all scriptsigs blanekd out
         blank_tx = CTransaction(tx.tx)

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -36,6 +36,7 @@ from ..serializations import (
     is_p2wsh,
     is_witness,
     CTransaction,
+    PSBT,
 )
 import logging
 import re
@@ -176,7 +177,12 @@ class LedgerClient(HardwareWalletClient):
     # The tx must be in the combined unsigned transaction format
     # Current only supports segwit signing
     @ledger_exception
-    def sign_tx(self, tx):
+    def sign_tx(self, tx: Union[PSBT, str, bytes]) -> Dict[str, str]:
+        if isinstance(tx, (str, bytes)):
+            psbt2 = PSBT()
+            psbt2.deserialize(tx)
+            tx = psbt2
+
         c_tx = CTransaction(tx.tx)
         tx_bytes = c_tx.serialize_with_witness()
 

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -50,6 +50,7 @@ from ..key import (
 )
 from ..serializations import (
     CTxOut,
+    PSBT,
     is_p2pkh,
     is_p2sh,
     is_p2wsh,
@@ -184,7 +185,12 @@ class TrezorClient(HardwareWalletClient):
     # Must return a hex string with the signed transaction
     # The tx must be in the psbt format
     @trezor_exception
-    def sign_tx(self, tx):
+    def sign_tx(self, tx: Union[PSBT, str, bytes]) -> Dict[str, str]:
+        if isinstance(tx, (str, bytes)):
+            psbt2 = PSBT()
+            psbt2.deserialize(tx)
+            tx = psbt2
+
         self._check_unlocked()
 
         # Get this devices master key fingerprint

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -48,8 +48,11 @@ class HardwareWalletClient(object):
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")
 
-    def sign_tx(self, psbt: PSBT) -> Dict[str, str]:
+    def sign_tx(self, psbt: Union[PSBT, str, bytes]) -> Dict[str, str]:
         """Sign a partially signed bitcoin transaction (PSBT).
+
+        Accept an encoded Base64 PSBT (as both str and bytes)
+        or a PSBT object.
 
         Return {"psbt": <base64 psbt string>}.
         """


### PR DESCRIPTION
To facilitate interoperability across different software systems with possibly different implementations of the PSBT standard, B174 advocates base64 encoding as "lingua franca" for PSBT.

For this reason, `sign_tx` should primarily accept that as input, without forcing other system/libraries to use the provided PSBT object as the only possible input.

This pull request leverages  https://github.com/bitcoin-core/HWI/pull/409 to perform a short

```
if isinstance(psbt, (str, bytes)):
    psbt2 = PSBT()
    psbt2.deserialize(psbt)
```

instead of treating bytes and str separately. Anyway, if https://github.com/bitcoin-core/HWI/pull/409 is rejected, this PR could be adapted to be indipendent.

On a related note, this patch would just be 

```
if isinstance(psbt, (str, bytes)):
    psbt = PSBT.deserialize(psbt)
```

if PSBT.deserialize would be defined as @classmethod (e.g. see https://github.com/btclib-org/btclib/blob/840c3b8ae285579490a374c626afac8863e7b813/btclib/psbt.py#L205)