### PR TITLE
Replace --sh_wpkh and --wpkh with --addr-type

### DIFF
--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -41,7 +41,7 @@ def backup_device_handler(args, client):
     return backup_device(client, label=args.label, backup_passphrase=args.backup_passphrase)
 
 def displayaddress_handler(args, client):
-    return displayaddress(client, desc=args.desc, path=args.path, sh_wpkh=args.sh_wpkh, wpkh=args.wpkh, redeem_script=args.redeem_script)
+    return displayaddress(client, desc=args.desc, path=args.path, addr_type=args.addr_type, redeem_script=args.redeem_script)
 
 def enumerate_handler(args):
     return enumerate(password=args.password)
@@ -175,8 +175,7 @@ def process_commands(cli_args):
     group = displayaddr_parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--desc', help='Output Descriptor. E.g. wpkh([00000000/84h/0h/0h]xpub.../0/0), where 00000000 must match --fingerprint and xpub can be obtained with getxpub. See doc/descriptors.md in Bitcoin Core')
     group.add_argument('--path', help='The BIP 32 derivation path of the key embedded in the address, default follows BIP43 convention, e.g. m/84h/0h/0h/1/*')
-    displayaddr_parser.add_argument('--sh_wpkh', action='store_true', help='Display the p2sh-nested segwit address associated with this key path')
-    displayaddr_parser.add_argument('--wpkh', action='store_true', help='Display the bech32 version of the address associated with this key path')
+    displayaddr_parser.add_argument("--addr-type", help="The address type to display", type=AddressType.argparse, choices=list(AddressType), default=AddressType.PKH)
     displayaddr_parser.add_argument('--redeem_script', help='P2SH redeem script')
     displayaddr_parser.set_defaults(func=displayaddress_handler)
 

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -28,6 +28,7 @@ from .errors import (
     NO_DEVICE_TYPE,
     UNAVAILABLE_ACTION,
 )
+from .serializations import AddressType
 from . import __version__
 
 import argparse
@@ -52,7 +53,7 @@ def getxpub_handler(args, client):
     return getxpub(client, path=args.path)
 
 def getkeypool_handler(args, client):
-    return getkeypool(client, path=args.path, start=args.start, end=args.end, internal=args.internal, keypool=args.keypool, account=args.account, sh_wpkh=args.sh_wpkh, wpkh=args.wpkh, addr_all=args.all)
+    return getkeypool(client, path=args.path, start=args.start, end=args.end, internal=args.internal, keypool=args.keypool, account=args.account, addr_type=args.addr_type, addr_all=args.all)
 
 def getdescriptors_handler(args, client):
     return getdescriptors(client, account=args.account)
@@ -158,11 +159,10 @@ def process_commands(cli_args):
     kparg_group.add_argument('--nokeypool', action='store_false', dest='keypool', help='Indicates that the keys are not to be imported to the keypool', default=False)
     getkeypool_parser.add_argument('--internal', action='store_true', help='Indicates that the keys are change keys')
     kp_type_group = getkeypool_parser.add_mutually_exclusive_group()
-    kp_type_group.add_argument('--sh_wpkh', action='store_true', help='Generate p2sh-nested segwit addresses (default path: m/49h/0h/0h/[0,1]/*)')
-    kp_type_group.add_argument('--wpkh', action='store_true', help='Generate bech32 addresses (default path: m/84h/0h/0h/[0,1]/*)')
+    kp_type_group.add_argument("--addr-type", help="The address type (and default derivation path) to produce descriptors for", type=AddressType.argparse, choices=list(AddressType), default=AddressType.PKH)
     kp_type_group.add_argument('--all', action='store_true', help='Generate addresses for all standard address types (default paths: m/{44,49,84}h/0h/0h/[0,1]/*)')
     getkeypool_parser.add_argument('--account', help='BIP43 account', type=int, default=0)
-    getkeypool_parser.add_argument('--path', help='Derivation path, default follows BIP43 convention, e.g. m/84h/0h/0h/1/* with --wpkh --internal. If this argument and --internal is not given, both internal and external keypools will be returned.')
+    getkeypool_parser.add_argument('--path', help='Derivation path, default follows BIP43 convention, e.g. m/84h/0h/0h/1/* with --addr-type wpkh --internal. If this argument and --internal is not given, both internal and external keypools will be returned.')
     getkeypool_parser.add_argument('start', type=int, help='The index to start at.')
     getkeypool_parser.add_argument('end', type=int, help='The index to end at.')
     getkeypool_parser.set_defaults(func=getkeypool_handler)

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -6,7 +6,7 @@ import binascii
 import importlib
 import platform
 
-from .serializations import PSBT
+from .serializations import AddressType, PSBT
 from .base58 import xpub_to_pub_hex
 from .key import (
     H_,
@@ -33,15 +33,10 @@ from .descriptor import (
 )
 from .devices import __all__ as all_devs
 
-from enum import Enum
 from itertools import count
 
 py_enumerate = enumerate
 
-class AddressType(Enum):
-    PKH = 1
-    WPKH = 2
-    SH_WPKH = 3
 
 # Get the client for the device
 def get_client(device_type, device_path, password='', expert=False):

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -197,16 +197,11 @@ def getdescriptor(client, master_fpr, testnet=False, path=None, internal=False, 
     else:
         return PKHDescriptor(pubkey)
 
-def getkeypool(client, path, start, end, internal=False, keypool=True, account=0, sh_wpkh=False, wpkh=True, addr_all=False):
+def getkeypool(client, path, start, end, internal=False, keypool=True, account=0, addr_type: AddressType = AddressType.PKH, addr_all=False):
 
-    if sh_wpkh:
-        addr_types = [AddressType.SH_WPKH]
-    elif wpkh:
-        addr_types = [AddressType.WPKH]
-    elif addr_all:
+    addr_types = [addr_type]
+    if addr_all:
         addr_types = list(AddressType)
-    else:
-        addr_types = [AddressType.PKH]
 
     # When no specific path or internal-ness is specified, create standard types
     chains = []

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -247,17 +247,14 @@ def getdescriptors(client, account=0):
 
     return result
 
-def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False, redeem_script=None):
+def displayaddress(client, path=None, desc=None, addr_type: AddressType = AddressType.PKH, redeem_script=None):
     if path is not None:
-        if sh_wpkh and wpkh:
-            return {'error': 'Both `--wpkh` and `--sh_wpkh` can not be selected at the same time.', 'code': BAD_ARGUMENT}
-        return client.display_address(path, sh_wpkh, wpkh, redeem_script=redeem_script)
+        return client.display_address(path, addr_type, redeem_script=redeem_script)
     elif desc is not None:
-        if sh_wpkh or wpkh:
-            return {'error': ' `--wpkh` and `--sh_wpkh` can not be combined with --desc', 'code': BAD_ARGUMENT}
         if redeem_script:
             return {'error': ' `--redeem_script` can not be combined with --desc', 'code': BAD_ARGUMENT}
         descriptor = parse_descriptor(desc)
+        addr_type = AddressType.PKH
         is_sh = isinstance(descriptor, SHDescriptor)
         is_wsh = isinstance(descriptor, WSHDescriptor)
         if is_sh or is_wsh:
@@ -280,7 +277,11 @@ def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False, rede
                     path += ','
                 path = path[0:-1]
                 redeem_script += format(80 + len(descriptor.pubkeys), 'x') + 'ae'
-                return client.display_address(path, is_sh and is_wsh, not is_sh and is_wsh, redeem_script, descriptor=descriptor if xpubs_descriptor else None)
+                if is_sh and is_wsh:
+                    addr_type = AddressType.SH_WPKH
+                elif not is_sh and is_wsh:
+                    addr_type = AddressType.WPKH
+                return client.display_address(path, addr_type, redeem_script, descriptor=descriptor if xpubs_descriptor else None)
         is_wpkh = isinstance(descriptor, WPKHDescriptor)
         if isinstance(descriptor, PKHDescriptor) or is_wpkh:
             pubkey = descriptor.pubkeys[0]
@@ -291,7 +292,11 @@ def displayaddress(client, path=None, desc=None, sh_wpkh=False, wpkh=False, rede
             xpub = client.get_pubkey_at_path(pubkey.origin.get_derivation_path())['xpub']
             if pubkey.pubkey != xpub and pubkey.pubkey != xpub_to_pub_hex(xpub):
                 return {'error': 'Key in descriptor does not match device: ' + desc, 'code': BAD_ARGUMENT}
-            return client.display_address(pubkey.get_full_derivation_path(0), is_sh and is_wpkh, not is_sh and is_wpkh)
+            if is_sh and is_wpkh:
+                addr_type = AddressType.SH_WPKH
+            elif not is_sh and is_wpkh:
+                addr_type = AddressType.WPKH
+            return client.display_address(pubkey.get_full_derivation_path(0), addr_type)
 
 def setup_device(client, label='', backup_passphrase=''):
     return client.setup_device(label, backup_passphrase)

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -16,6 +16,7 @@ from functools import wraps
 
 from ..hwwclient import HardwareWalletClient, Descriptor
 from ..serializations import (
+    AddressType,
     PSBT,
     CTxOut,
     is_p2pkh,
@@ -329,19 +330,18 @@ class Bitbox02Client(HardwareWalletClient):
     def display_address(
         self,
         bip32_path: str,
-        p2sh_p2wpkh: bool,
-        bech32: bool,
+        addr_type: AddressType,
         redeem_script: Optional[str] = None,
         descriptor: Optional[Descriptor] = None,
     ) -> Dict[str, str]:
         if redeem_script:
             raise NotImplementedError("BitBox02 multisig not integrated into HWI yet")
 
-        if p2sh_p2wpkh:
+        if addr_type == AddressType.SH_WPKH:
             script_config = bitbox02.btc.BTCScriptConfig(
                 simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH_P2SH
             )
-        elif bech32:
+        elif addr_type == AddressType.WPKH:
             script_config = bitbox02.btc.BTCScriptConfig(
                 simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH
             )

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -40,6 +40,7 @@ from ..key import (
     ExtendedKey,
 )
 from ..serializations import (
+    AddressType,
     PSBT,
 )
 from hashlib import sha256
@@ -232,14 +233,14 @@ class ColdcardClient(HardwareWalletClient):
 
     # Display address of specified type on the device.
     @coldcard_exception
-    def display_address(self, keypath, p2sh_p2wpkh, bech32, redeem_script=None, descriptor=None):
+    def display_address(self, keypath, addr_type: AddressType, redeem_script=None, descriptor=None):
         self.device.check_mitm()
         keypath = keypath.replace('h', '\'')
         keypath = keypath.replace('H', '\'')
 
-        if p2sh_p2wpkh:
+        if addr_type == AddressType.SH_WPKH:
             addr_fmt = AF_P2WSH_P2SH if redeem_script else AF_P2WPKH_P2SH
-        elif bech32:
+        elif addr_type == AddressType.WPKH:
             addr_fmt = AF_P2WSH if redeem_script else AF_P2WPKH
         else:
             addr_fmt = AF_P2SH if redeem_script else AF_CLASSIC

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -32,6 +32,7 @@ from ..key import (
     ExtendedKey,
 )
 from ..serializations import (
+    AddressType,
     CTransaction,
     hash256,
     is_p2pk,
@@ -546,7 +547,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         return {"signature": base64.b64encode(compact_sig).decode('utf-8')}
 
     # Display address of specified type on the device.
-    def display_address(self, keypath, p2sh_p2wpkh, bech32, redeem_script=None, descriptor=None):
+    def display_address(self, keypath, addr_type: AddressType, redeem_script=None, descriptor=None):
         raise UnavailableActionError('The Digital Bitbox does not have a screen to display addresses on')
 
     # Setup a new device

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -29,6 +29,7 @@ from ..key import (
     ExtendedKey,
 )
 from ..serializations import (
+    AddressType,
     hash256,
     hash160,
     is_p2sh,
@@ -346,12 +347,14 @@ class LedgerClient(HardwareWalletClient):
 
     # Display address of specified type on the device. Only supports single-key based addresses.
     @ledger_exception
-    def display_address(self, keypath, p2sh_p2wpkh, bech32, redeem_script=None, descriptor=None):
+    def display_address(self, keypath, addr_type: AddressType, redeem_script=None, descriptor=None):
         if not check_keypath(keypath):
             raise BadArgumentError("Invalid keypath")
         if redeem_script is not None:
             raise BadArgumentError("The Ledger Nano S and X do not support P2SH address display")
-        output = self.app.getWalletPublicKey(keypath[2:], True, (p2sh_p2wpkh or bech32), bech32)
+        p2sh_p2wpkh = addr_type == AddressType.SH_WPKH
+        bech32 = addr_type == AddressType.WPKH
+        output = self.app.getWalletPublicKey(keypath[2:], True, p2sh_p2wpkh or bech32, bech32)
         return {'address': output['address'][12:-2]} # HACK: A bug in getWalletPublicKey results in the address being returned as the string "bytearray(b'<address>')". This extracts the actual address to work around this.
 
     # Setup a new device

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -49,6 +49,7 @@ from ..key import (
     parse_path,
 )
 from ..serializations import (
+    AddressType,
     CTxOut,
     is_p2pkh,
     is_p2sh,
@@ -412,7 +413,7 @@ class TrezorClient(HardwareWalletClient):
 
     # Display address of specified type on the device.
     @trezor_exception
-    def display_address(self, keypath, p2sh_p2wpkh, bech32, redeem_script=None, descriptor=None):
+    def display_address(self, keypath, addr_type: AddressType, redeem_script=None, descriptor=None):
         self._check_unlocked()
 
         # descriptor means multisig with xpubs
@@ -434,9 +435,9 @@ class TrezorClient(HardwareWalletClient):
             multisig = None
 
         # Script type
-        if p2sh_p2wpkh:
+        if addr_type == AddressType.SH_WPKH:
             script_type = proto.InputScriptType.SPENDP2SHWITNESS
-        elif bech32:
+        elif addr_type == AddressType.WPKH:
             script_type = proto.InputScriptType.SPENDWITNESS
         elif redeem_script:
             script_type = proto.InputScriptType.SPENDMULTISIG

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -2,7 +2,7 @@ from typing import Dict, Optional, Union
 
 from .base58 import get_xpub_fingerprint_hex
 from .descriptor import Descriptor
-from .serializations import PSBT
+from .serializations import AddressType, PSBT
 
 
 class HardwareWalletClient(object):
@@ -75,8 +75,7 @@ class HardwareWalletClient(object):
     def display_address(
         self,
         bip32_path: str,
-        p2sh_p2wpkh: bool,
-        bech32: bool,
+        addr_type: AddressType,
         redeem_script: Optional[str] = None,
         descriptor: Optional[Descriptor] = None,
     ) -> Dict[str, str]:

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -35,6 +35,7 @@ from typing import (
     Sequence,
     Tuple,
     TypeVar,
+    Union,
     Callable,
 )
 from typing_extensions import Protocol
@@ -69,6 +70,18 @@ class AddressType(Enum):
     WPKH = 2
     SH_WPKH = 3
 
+    def __str__(self) -> str:
+        return self.name.lower()
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    @staticmethod
+    def argparse(s: str) -> Union['AddressType', str]:
+        try:
+            return AddressType[s.upper()]
+        except KeyError:
+            return s
 
 # Serialization/deserialization tools
 def ser_compact_size(size: int) -> bytes:

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -24,6 +24,7 @@ import hashlib
 import copy
 import base64
 
+from enum import Enum
 from io import BytesIO, BufferedReader
 from typing import (
     Dict,
@@ -61,6 +62,12 @@ def hash256(s: bytes) -> bytes:
 
 def hash160(s: bytes) -> bytes:
     return ripemd160(sha256(s))
+
+
+class AddressType(Enum):
+    PKH = 1
+    WPKH = 2
+    SH_WPKH = 3
 
 
 # Serialization/deserialization tools

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -192,7 +192,7 @@ class TestGetKeypool(DeviceTestCase):
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress('legacy'))
             self.assertTrue(addr_info['hdkeypath'].startswith("m/44'/1'/0'/1/"))
 
-        shwpkh_keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--sh_wpkh', '0', '20'])
+        shwpkh_keypool_desc = self.do_command(self.dev_args + ['getkeypool', "--addr-type", "sh_wpkh", '0', '20'])
         import_result = self.wrpc.importdescriptors(shwpkh_keypool_desc)
         self.assertTrue(import_result[0]['success'])
         for _ in range(0, 21):
@@ -201,7 +201,7 @@ class TestGetKeypool(DeviceTestCase):
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress('p2sh-segwit'))
             self.assertTrue(addr_info['hdkeypath'].startswith("m/49'/1'/0'/1/"))
 
-        wpkh_keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--wpkh', '0', '20'])
+        wpkh_keypool_desc = self.do_command(self.dev_args + ['getkeypool', "--addr-type", "wpkh", '0', '20'])
         import_result = self.wrpc.importdescriptors(wpkh_keypool_desc)
         self.assertTrue(import_result[0]['success'])
         for _ in range(0, 21):
@@ -214,7 +214,7 @@ class TestGetKeypool(DeviceTestCase):
         all_keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--all', '0', '20'])
         self.assertEqual(all_keypool_desc, pkh_keypool_desc + wpkh_keypool_desc + shwpkh_keypool_desc)
 
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--sh_wpkh', '--account', '3', '0', '20'])
+        keypool_desc = self.do_command(self.dev_args + ['getkeypool', "--addr-type", "sh_wpkh", '--account', '3', '0', '20'])
         import_result = self.wrpc.importdescriptors(keypool_desc)
         self.assertTrue(import_result[0]['success'])
         for _ in range(0, 21):
@@ -222,7 +222,7 @@ class TestGetKeypool(DeviceTestCase):
             self.assertTrue(addr_info['hdkeypath'].startswith("m/49'/1'/3'/0/"))
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress('p2sh-segwit'))
             self.assertTrue(addr_info['hdkeypath'].startswith("m/49'/1'/3'/1/"))
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--wpkh', '--account', '3', '0', '20'])
+        keypool_desc = self.do_command(self.dev_args + ['getkeypool', "--addr-type", "wpkh", '--account', '3', '0', '20'])
         import_result = self.wrpc.importdescriptors(keypool_desc)
         self.assertTrue(import_result[0]['success'])
         for _ in range(0, 21):

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -457,24 +457,18 @@ class TestSignTx(DeviceTestCase):
                 pass
 
 class TestDisplayAddress(DeviceTestCase):
-    def test_display_address_bad_args(self):
-        result = self.do_command(self.dev_args + ['displayaddress', '--sh_wpkh', '--wpkh', '--path', 'm/49h/1h/0h/0/0'])
-        self.assertIn('error', result)
-        self.assertIn('code', result)
-        self.assertEqual(result['code'], -7)
-
     def test_display_address_path(self):
         result = self.do_command(self.dev_args + ['displayaddress', '--path', 'm/44h/1h/0h/0/0'])
         self.assertNotIn('error', result)
         self.assertNotIn('code', result)
         self.assertIn('address', result)
 
-        result = self.do_command(self.dev_args + ['displayaddress', '--sh_wpkh', '--path', 'm/49h/1h/0h/0/0'])
+        result = self.do_command(self.dev_args + ['displayaddress', "--addr-type", "sh_wpkh", '--path', 'm/49h/1h/0h/0/0'])
         self.assertNotIn('error', result)
         self.assertNotIn('code', result)
         self.assertIn('address', result)
 
-        result = self.do_command(self.dev_args + ['displayaddress', '--wpkh', '--path', 'm/84h/1h/0h/0/0'])
+        result = self.do_command(self.dev_args + ['displayaddress', "--addr-type", "wpkh", '--path', 'm/84h/1h/0h/0/0'])
         self.assertNotIn('error', result)
         self.assertNotIn('code', result)
         self.assertIn('address', result)
@@ -573,7 +567,8 @@ class TestDisplayAddress(DeviceTestCase):
                     else:
                         args = ['displayaddress', '--path', path, '--redeem_script', rs]
                         if addrtype != "pkh":
-                            args.append("--{}".format(addrtype))
+                            args.append("--addr-type")
+                            args.append(addrtype)
 
                     result = self.do_command(self.dev_args + args)
                     self.assertNotIn('error', result)


### PR DESCRIPTION
In `getkeypool` and `displayaddress` where we have `--sh_wpkh` and `--wpkh` to determine the address type, replace those options with a new `--addr-type` option. This allows us to remove mutual exclusion checks for `sh_wpkh` and `wpkh`. It will also be easier to handle new address types in the future.