### PR TITLE
ledger: Fix KeyOriginInfo is not subscritable error

### DIFF
--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -206,12 +206,12 @@ class LedgerClient(HardwareWalletClient):
             # Find which wallet key could be change based on hdsplit: m/.../1/k
             # Wallets shouldn't be sending to change address as user action
             # otherwise this will get confused
-            for pubkey, path in tx.outputs[i_num].hd_keypaths.items():
-                if path.fingerprint == master_fpr and len(path.path) > 1 and path[-1] == 1:
+            for pubkey, origin in tx.outputs[i_num].hd_keypaths.items():
+                if origin.fingerprint == master_fpr and len(origin.path) > 1 and origin.path[-2] == 1:
                     # For possible matches, check if pubkey matches possible template
                     if hash160(pubkey) in txout.scriptPubKey or hash160(bytearray.fromhex("0014") + hash160(pubkey)) in txout.scriptPubKey:
                         change_path = ''
-                        for index in path[1:]:
+                        for index in origin.path[1:]:
                             change_path += str(index) + "/"
                         change_path = change_path[:-1]
 

--- a/test/data/speculos-automation.json
+++ b/test/data/speculos-automation.json
@@ -2,7 +2,7 @@
     "version": 1,
     "rules": [
         {
-            "regexp": "^(Address|Review|Amount|Fee|Confirm|The derivation|Derivation path|Reject if you're).*",
+            "regexp": "^(Address|Review|Amount|Fee|Confirm|The derivation|Derivation path|Reject if you're|The change path|Change path).*",
             "actions": [
                 [ "button", 2, true ],
                 [ "button", 2, false ]

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -374,7 +374,7 @@ class TestSignTx(DeviceTestCase):
         self.assertTrue(multi_result[2]['success'])
 
         in_amt = 3
-        out_amt = in_amt // 3
+        out_amt = in_amt // 3 * 0.9
         number_inputs = 0
         # Single-sig
         if input_type == 'segwit' or input_type == 'all':
@@ -399,9 +399,12 @@ class TestSignTx(DeviceTestCase):
         # Spend different amounts, requiring 1 to 3 inputs
         for i in range(number_inputs):
             # Create a psbt spending the above
+            change_addr = self.wrpc.getrawchangeaddress()
             if i == number_inputs - 1:
-                self.assertTrue((i + 1) * in_amt == self.wrpc.getbalance("*", 0, True))
-            psbt = self.wrpc.walletcreatefundedpsbt([], [{self.wpk_rpc.getnewaddress('', 'legacy'): (i + 1) * out_amt}, {self.wpk_rpc.getnewaddress('', 'p2sh-segwit'): (i + 1) * out_amt}, {self.wpk_rpc.getnewaddress('', 'bech32'): (i + 1) * out_amt}], 0, {'includeWatching': True, 'subtractFeeFromOutputs': [0, 1, 2]}, True)
+                self.assertEqual((i + 1) * in_amt, self.wrpc.getbalance("*", 0, True))
+                change_addr = self.wpk_rpc.getrawchangeaddress()
+            out_val = (i + 1) * out_amt
+            psbt = self.wrpc.walletcreatefundedpsbt([], [{self.wpk_rpc.getnewaddress('', 'legacy'): out_val}, {self.wpk_rpc.getnewaddress('', 'p2sh-segwit'): out_val}, {self.wpk_rpc.getnewaddress('', 'bech32'): out_val}], 0, {'includeWatching': True, "changePosition": 3, "changeAddress": change_addr}, True)
 
             if external:
                 # Sign with unknown inputs in two steps


### PR DESCRIPTION
Fixes a bug in Ledger `sign_tx` implementation which would cause it to error with `{"error": "'KeyOriginInfo' object is not subscriptable", "code": -13}` during change detection.