### PR TITLE
Refactor client.display_address into single sig and multisig variants

### DIFF
--- a/hwilib/base58.py
+++ b/hwilib/base58.py
@@ -9,8 +9,13 @@
 #
 
 import hashlib
+
 from binascii import hexlify, unhexlify
 from typing import List
+
+from .errors import BadArgumentError
+
+
 b58_digits: str = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 
 def sha256(s: bytes) -> bytes:
@@ -52,7 +57,7 @@ def decode(s: str) -> bytes:
     for c in s:
         n *= 58
         if c not in b58_digits:
-            raise ValueError('Character %r is not a valid base58 character' % c)
+            raise BadArgumentError('Character %r is not a valid base58 character' % c)
         digit = b58_digits.index(c)
         n += digit
 

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -41,7 +41,7 @@ def backup_device_handler(args, client):
     return backup_device(client, label=args.label, backup_passphrase=args.backup_passphrase)
 
 def displayaddress_handler(args, client):
-    return displayaddress(client, desc=args.desc, path=args.path, addr_type=args.addr_type, redeem_script=args.redeem_script)
+    return displayaddress(client, desc=args.desc, path=args.path, addr_type=args.addr_type)
 
 def enumerate_handler(args):
     return enumerate(password=args.password)
@@ -176,7 +176,6 @@ def process_commands(cli_args):
     group.add_argument('--desc', help='Output Descriptor. E.g. wpkh([00000000/84h/0h/0h]xpub.../0/0), where 00000000 must match --fingerprint and xpub can be obtained with getxpub. See doc/descriptors.md in Bitcoin Core')
     group.add_argument('--path', help='The BIP 32 derivation path of the key embedded in the address, default follows BIP43 convention, e.g. m/84h/0h/0h/1/*')
     displayaddr_parser.add_argument("--addr-type", help="The address type to display", type=AddressType.argparse, choices=list(AddressType), default=AddressType.PKH)
-    displayaddr_parser.add_argument('--redeem_script', help='P2SH redeem script')
     displayaddr_parser.set_defaults(func=displayaddress_handler)
 
     setupdev_parser = subparsers.add_parser('setup', help='Setup a device. Passphrase protection uses the password given by -p. Requires interactive mode')

--- a/hwilib/descriptor.py
+++ b/hwilib/descriptor.py
@@ -132,6 +132,27 @@ class PubkeyProvider(object):
             path = path[:-1] + str(pos)
         return path
 
+    def get_full_derivation_int_list(self, pos: int) -> List[int]:
+        """
+        Returns the full derivation path as an integer list at the given position.
+        Includes the origin and master key fingerprint as an int
+        """
+        path: List[int] = self.origin.get_full_int_list() if self.origin is not None else []
+        if self.deriv_path is not None:
+            der_split = self.deriv_path.split("/")
+            for p in der_split:
+                if not p:
+                    continue
+                if p == "*":
+                    i = pos
+                elif p[-1] in "'phHP":
+                    assert len(p) >= 2
+                    i = int(p[:-1]) | 0x80000000
+                else:
+                    i = int(p)
+                path.append(i)
+        return path
+
     def __lt__(self, other: 'PubkeyProvider') -> bool:
         return self.pubkey < other.pubkey
 

--- a/hwilib/descriptor.py
+++ b/hwilib/descriptor.py
@@ -1,5 +1,8 @@
 from .key import ExtendedKey, KeyOriginInfo, parse_path
+from .serializations import hash160, sha256
 
+from binascii import unhexlify
+from collections import namedtuple
 from enum import Enum
 from typing import (
     List,
@@ -8,6 +11,8 @@ from typing import (
 )
 
 # From: https://github.com/bitcoin/bitcoin/blob/master/src/script/descriptor.cpp
+
+ExpandedScripts = namedtuple("ExpandedScripts", ["output_script", "redeem_script", "witness_script"])
 
 def PolyMod(c: int, val: int) -> int:
     c0 = c >> 35
@@ -104,6 +109,19 @@ class PubkeyProvider(object):
             s += self.deriv_path
         return s
 
+    def get_pubkey_bytes(self, pos: int) -> bytes:
+        if self.extkey is not None:
+            if self.deriv_path is not None:
+                path_str = self.deriv_path[1:]
+                if path_str[-1] == "*":
+                    path_str = path_str[-1] + str(pos)
+                path = parse_path(path_str)
+                child_key = self.extkey.derive_pub_path(path)
+                return child_key.pubkey
+            else:
+                return self.extkey.pubkey
+        return unhexlify(self.pubkey)
+
     def get_full_derivation_path(self, pos: int) -> str:
         """
         Returns the full derivation path at the given position, including the origin
@@ -139,6 +157,12 @@ class Descriptor(object):
     def to_string(self) -> str:
         return AddChecksum(self.to_string_no_checksum())
 
+    def expand(self, pos: int) -> "ExpandedScripts":
+        """
+        Returns the scripts for a descriptor at the given `pos` for ranged descriptors.
+        """
+        raise NotImplementedError("The Descriptor base class does not implement this method")
+
 
 class PKHDescriptor(Descriptor):
     def __init__(
@@ -147,6 +171,10 @@ class PKHDescriptor(Descriptor):
     ) -> None:
         super().__init__([pubkey], None, "pkh")
 
+    def expand(self, pos: int) -> "ExpandedScripts":
+        script = b"\x76\xa9\x14" + hash160(self.pubkeys[0].get_pubkey_bytes(pos)) + b"\x88\xac"
+        return ExpandedScripts(script, None, None)
+
 
 class WPKHDescriptor(Descriptor):
     def __init__(
@@ -154,6 +182,10 @@ class WPKHDescriptor(Descriptor):
         pubkey: 'PubkeyProvider'
     ) -> None:
         super().__init__([pubkey], None, "wpkh")
+
+    def expand(self, pos: int) -> "ExpandedScripts":
+        script = b"\x00\x14" + hash160(self.pubkeys[0].get_pubkey_bytes(pos))
+        return ExpandedScripts(script, None, None)
 
 
 class MultisigDescriptor(Descriptor):
@@ -171,6 +203,20 @@ class MultisigDescriptor(Descriptor):
     def to_string_no_checksum(self) -> str:
         return "{}({},{})".format(self.name, self.thresh, ",".join([p.to_string() for p in self.pubkeys]))
 
+    def expand(self, pos: int) -> "ExpandedScripts":
+        if self.thresh > 16:
+            m = b"\x01" + self.thresh.to_bytes(1, "big")
+        else:
+            m = (self.thresh + 0x50).to_bytes(1, "big") if self.thresh > 0 else b"\x00"
+        n = (len(self.pubkeys) + 0x50).to_bytes(1, "big") if len(self.pubkeys) > 0 else b"\x00"
+        script: bytes = m
+        for p in self.pubkeys:
+            pk = p.get_pubkey_bytes(pos)
+            script += len(pk).to_bytes(1, "big") + pk
+        script += n + b"\xae"
+
+        return ExpandedScripts(script, None, None)
+
 
 class SHDescriptor(Descriptor):
     def __init__(
@@ -179,6 +225,12 @@ class SHDescriptor(Descriptor):
     ) -> None:
         super().__init__([], subdescriptor, "sh")
 
+    def expand(self, pos: int) -> "ExpandedScripts":
+        assert self.subdescriptor
+        redeem_script, _, witness_script = self.subdescriptor.expand(pos)
+        script = b"\xa9\x14" + hash160(redeem_script) + b"\x87"
+        return ExpandedScripts(script, redeem_script, witness_script)
+
 
 class WSHDescriptor(Descriptor):
     def __init__(
@@ -186,6 +238,12 @@ class WSHDescriptor(Descriptor):
         subdescriptor: Optional['Descriptor']
     ) -> None:
         super().__init__([], subdescriptor, "wsh")
+
+    def expand(self, pos: int) -> "ExpandedScripts":
+        assert self.subdescriptor
+        witness_script, _, _ = self.subdescriptor.expand(pos)
+        script = b"\x00\x20" + sha256(witness_script)
+        return ExpandedScripts(script, None, witness_script)
 
 
 def _get_func_expr(s: str) -> Tuple[str, str]:

--- a/hwilib/descriptor.py
+++ b/hwilib/descriptor.py
@@ -1,4 +1,4 @@
-from .key import KeyOriginInfo
+from .key import ExtendedKey, KeyOriginInfo, parse_path
 
 from enum import Enum
 from typing import (
@@ -67,6 +67,15 @@ class PubkeyProvider(object):
         self.origin = origin
         self.pubkey = pubkey
         self.deriv_path = deriv_path
+
+        # Make ExtendedKey from pubkey if it isn't hex
+        self.extkey = None
+        try:
+            unhexlify(self.pubkey)
+            # Is hex, normal pubkey
+        except Exception:
+            # Not hex, maybe xpub
+            self.extkey = ExtendedKey.deserialize(self.pubkey)
 
     @classmethod
     def parse(cls, s: str) -> 'PubkeyProvider':

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -14,7 +14,8 @@ import builtins
 import sys
 from functools import wraps
 
-from ..hwwclient import HardwareWalletClient, Descriptor
+from ..descriptor import PubkeyProvider
+from ..hwwclient import HardwareWalletClient
 from ..serializations import (
     AddressType,
     PSBT,
@@ -327,16 +328,11 @@ class Bitbox02Client(HardwareWalletClient):
         return {"xpub": xpub}
 
     @bitbox02_exception
-    def display_address(
+    def display_singlesig_address(
         self,
         bip32_path: str,
         addr_type: AddressType,
-        redeem_script: Optional[str] = None,
-        descriptor: Optional[Descriptor] = None,
     ) -> Dict[str, str]:
-        if redeem_script:
-            raise NotImplementedError("BitBox02 multisig not integrated into HWI yet")
-
         if addr_type == AddressType.SH_WPKH:
             script_config = bitbox02.btc.BTCScriptConfig(
                 simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH_P2SH
@@ -356,6 +352,15 @@ class Bitbox02Client(HardwareWalletClient):
             display=True,
         )
         return {"address": address}
+
+    @bitbox02_exception
+    def display_multisig_address(
+        self,
+        threshold: int,
+        pubkeys: List[PubkeyProvider],
+        addr_type: AddressType,
+    ) -> Dict[str, str]:
+        raise NotImplementedError("BitBox02 multisig not integrated into HWI yet")
 
     @bitbox02_exception
     def sign_tx(self, psbt: PSBT) -> Dict[str, str]:

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -13,8 +13,13 @@ import logging
 import socket
 import sys
 import time
-from typing import Dict, Union
+from typing import (
+    Dict,
+    List,
+    Union,
+)
 
+from ..descriptor import PubkeyProvider
 from ..hwwclient import HardwareWalletClient
 from ..errors import (
     ActionCanceledError,
@@ -547,7 +552,10 @@ class DigitalbitboxClient(HardwareWalletClient):
         return {"signature": base64.b64encode(compact_sig).decode('utf-8')}
 
     # Display address of specified type on the device.
-    def display_address(self, keypath, addr_type: AddressType, redeem_script=None, descriptor=None):
+    def display_singlesig_address(self, keypath: str, addr_type: AddressType) -> Dict[str, str]:
+        raise UnavailableActionError('The Digital Bitbox does not have a screen to display addresses on')
+
+    def display_multisig_address(self, threshold: int, pubkeys: List[PubkeyProvider], addr_type: AddressType) -> Dict[str, str]:
         raise UnavailableActionError('The Digital Bitbox does not have a screen to display addresses on')
 
     # Setup a new device

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -1,7 +1,11 @@
-from typing import Dict, Optional, Union
-
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Union,
+)
 from .base58 import get_xpub_fingerprint_hex
-from .descriptor import Descriptor
+from .descriptor import PubkeyProvider
 from .serializations import AddressType, PSBT
 
 
@@ -72,18 +76,27 @@ class HardwareWalletClient(object):
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")
 
-    def display_address(
+    def display_singlesig_address(
         self,
         bip32_path: str,
         addr_type: AddressType,
-        redeem_script: Optional[str] = None,
-        descriptor: Optional[Descriptor] = None,
     ) -> Dict[str, str]:
-        """Display and return the address of specified type.
-
-        redeem_script is a hex-string.
+        """Display and return the single sig address of specified type.
 
         Retrieve the public key at the specified BIP32 derivation path.
+
+        Return {"address": <base58 or bech32 address string>}.
+        """
+        raise NotImplementedError("The HardwareWalletClient base class "
+                                  "does not implement this method")
+
+    def display_multisig_address(
+        self,
+        threshold: int,
+        pubkeys: List[PubkeyProvider],
+        addr_type: AddressType,
+    ) -> Dict[str, str]:
+        """Display and return the multisig address of specified type given the threshold and pubkeys.
 
         Return {"address": <base58 or bech32 address string>}.
         """

--- a/hwilib/key.py
+++ b/hwilib/key.py
@@ -4,6 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 from . import base58
+from .errors import BadArgumentError
 
 import binascii
 import hmac
@@ -109,6 +110,8 @@ class ExtendedKey(object):
         data = base58.decode(xpub)[:-4] # Decoded xpub without checksum
 
         version = data[0:4]
+        if version not in [ExtendedKey.MAINNET_PRIVATE, ExtendedKey.MAINNET_PUBLIC, ExtendedKey.TESTNET_PRIVATE, ExtendedKey.TESTNET_PUBLIC]:
+            raise BadArgumentError(f"Extended key magic of {version.hex()} is invalid")
         is_private = version == ExtendedKey.MAINNET_PRIVATE or version == ExtendedKey.TESTNET_PRIVATE
         depth = data[4]
         parent_fingerprint = data[5:9]

--- a/hwilib/key.py
+++ b/hwilib/key.py
@@ -12,6 +12,7 @@ import hashlib
 import struct
 from typing import (
     Dict,
+    List,
     Optional,
     Sequence,
     Tuple,
@@ -252,6 +253,15 @@ class KeyOriginInfo(object):
         Return the hex for just the fingerprint
         """
         return binascii.hexlify(self.fingerprint).decode()
+
+    def get_full_int_list(self) -> List[int]:
+        """
+        Return a list of ints representing this KeyOriginInfo.
+        The first int is the fingerprint, followed by the path
+        """
+        xfp = [struct.unpack("<I", self.fingerprint)[0]]
+        xfp.extend(self.path)
+        return xfp
 
 
 def parse_path(nstr: str) -> Sequence[int]:

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -570,29 +570,22 @@ class TestDisplayAddress(DeviceTestCase):
             raise unittest.SkipTest("{} does not support multisig display".format(self.full_type))
 
         for addrtype in ["pkh", "sh_wpkh", "wpkh"]:
-            for use_desc in [True, False]:
-                with self.subTest(addrtype=addrtype, use_desc=use_desc):
-                    addr, desc, rs, path = self._make_single_multisig(addrtype)
+            with self.subTest(addrtype=addrtype):
+                addr, desc, rs, path = self._make_single_multisig(addrtype)
 
-                    if use_desc:
-                        args = ['displayaddress', '--desc', desc]
-                    else:
-                        args = ['displayaddress', '--path', path, '--redeem_script', rs]
-                        if addrtype != "pkh":
-                            args.append("--addr-type")
-                            args.append(addrtype)
+                args = ['displayaddress', '--desc', desc]
 
-                    result = self.do_command(self.dev_args + args)
-                    self.assertNotIn('error', result)
-                    self.assertNotIn('code', result)
-                    self.assertIn('address', result)
+                result = self.do_command(self.dev_args + args)
+                self.assertNotIn('error', result)
+                self.assertNotIn('code', result)
+                self.assertIn('address', result)
 
-                    if addrtype == "wpkh":
-                        # removes prefix and checksum since regtest gives
-                        # prefix `bcrt` on Bitcoin Core while wallets return testnet `tb` prefix
-                        self.assertEqual(addr[4:58], result['address'][2:56])
-                    else:
-                        self.assertEqual(addr, result['address'])
+                if addrtype == "wpkh":
+                    # removes prefix and checksum since regtest gives
+                    # prefix `bcrt` on Bitcoin Core while wallets return testnet `tb` prefix
+                    self.assertEqual(addr[4:58], result['address'][2:56])
+                else:
+                    self.assertEqual(addr, result['address'])
 
     def test_display_address_xpub_multisig(self):
         if self.full_type not in SUPPORTS_XPUB_MS_DISPLAY:


### PR DESCRIPTION
Instead of having `display_address` handle both single sig and multisig address display, it is refactored into `display_singlesig_address` to display single sig addresses, and `display_multisig_address` to display multisig addresses. Additionally the `redeem_script`
parameter is removed as descriptors provide everything we need.

Supersedes #416. I think this approach is nicer to work with.

Based on #415