### PR TITLE
Remove poetry version restriction in build_*.sh

### DIFF
--- a/ci/cirrus.Dockerfile
+++ b/ci/cirrus.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.6
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
@@ -34,3 +34,7 @@ RUN apt-get install -y \
     protobuf-compiler \
     cython3
 RUN pip install poetry flake8
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV LANGUAGE=C.UTF-8

--- a/contrib/build.Dockerfile
+++ b/contrib/build.Dockerfile
@@ -49,3 +49,7 @@ RUN apt-get install --install-recommends -y \
     wine-stable \
     winehq-stable \
     p7zip-full
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV LANGUAGE=C.UTF-8

--- a/contrib/build_bin.sh
+++ b/contrib/build_bin.sh
@@ -6,7 +6,7 @@ set -ex
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 pip install -U pip
-pip install poetry==1.0.10
+pip install poetry
 
 # Setup poetry and install the dependencies
 poetry install -E qt

--- a/contrib/build_dist.sh
+++ b/contrib/build_dist.sh
@@ -6,7 +6,7 @@ set -ex
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
 pip install -U pip
-pip install poetry==1.0.10
+pip install poetry
 
 # Setup poetry and install the dependencies
 poetry install -E qt

--- a/contrib/build_wine.sh
+++ b/contrib/build_wine.sh
@@ -58,7 +58,7 @@ popd
 $PYTHON -m pip install -U pip
 
 # Install Poetry and things needed for pyinstaller
-$PYTHON -m pip install poetry==1.0.10
+$PYTHON -m pip install poetry
 
 # We also need to change the timestamps of all of the base library files
 lib_dir=~/.wine/drive_c/python3/Lib


### PR DESCRIPTION
I found a workaround to this problem by setting a UTF-8 locale, so the version restriction is no longer necessary.

Should also fix the wine_builder CI job.