### PR TITLE
bitbox02: update bitbox02 to 5.1.0

### DIFF
--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -615,7 +615,8 @@ class Bitbox02Client(HardwareWalletClient):
                 "Label/passphrase not needed when exporting mnemonic from the BitBox02."
             )
 
-        return {"success": self.init().show_mnemonic()}
+        self.init().show_mnemonic()
+        return {"success": True}
 
     @bitbox02_exception
     def restore_device(

--- a/poetry.lock
+++ b/poetry.lock
@@ -374,7 +374,7 @@ qt = ["pyside2"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6,<3.10"
-content-hash = "7dc8a4a78469f100b9ad15ad96bc7f12b3996fd57d3860b7549b5e2ab0c7569c"
+content-hash = "fae8cd4ec5fae48e4eed77a42ff209233bf32fff1e7a79854a492f7c06582c4f"
 
 [metadata.files]
 altgraph = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ mnemonic = "~0"
 typing-extensions = "^3.7"
 libusb1 = "^1.7"
 pyside2 = { version = "^5.14.0", optional = true }
-bitbox02 = ">=4.1.0"
+bitbox02 = ">=5.1.0"
 
 [tool.poetry.extras]
 qt = ["pyside2"]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ package_data = \
 modules = \
 ['hwi', 'hwi-qt']
 install_requires = \
-['bitbox02>=4.1.0',
+['bitbox02>=5.1.0',
  'ecdsa>=0,<1',
  'hidapi>=0,<1',
  'libusb1>=1.7,<2.0',


### PR DESCRIPTION
Updated pyproject.toml and setup.py, then: `poetry update bitbox02 --lock`.

Also fixes the failing type check CI job.