### PR TITLE
Remove hidapi.so strip during build_bin.sh

### DIFF
--- a/contrib/build_bin.sh
+++ b/contrib/build_bin.sh
@@ -11,13 +11,6 @@ pip install poetry
 # Setup poetry and install the dependencies
 poetry install -E qt
 
-# We now need to remove debugging symbols and build id from the hidapi SO file
-so_dir=`dirname $(dirname $(poetry run which python))`/lib/python3.6/site-packages
-strip -x ${so_dir}/hid*.so
-if [[ $OSTYPE != *"darwin"* ]]; then
-    strip -R .note.gnu.build-id ${so_dir}/hid*.so
-fi
-
 # We also need to change the timestamps of all of the base library files
 lib_dir=`pyenv root`/versions/3.6.8/lib/python3.6
 TZ=UTC find ${lib_dir} -name '*.py' -type f -execdir touch -t "201901010000.00" '{}' \;


### PR DESCRIPTION
Poetry >=1.1.0 seems to be building the cython .so files
deterministically now so there is no need for us to make it
deterministic by stripping them. Additionally, stripping them when
poetry >=1.1.0 did the build is causing the resulting binaries to fail,
so this should fix that too.