### PR TITLE
Ledger: fix change path check

### DIFF
--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -217,7 +217,7 @@ class LedgerClient(HardwareWalletClient):
                     # For possible matches, check if pubkey matches possible template
                     if hash160(pubkey) in txout.scriptPubKey or hash160(bytearray.fromhex("0014") + hash160(pubkey)) in txout.scriptPubKey:
                         change_path = ''
-                        for index in origin.path[1:]:
+                        for index in origin.path:
                             change_path += str(index) + "/"
                         change_path = change_path[:-1]
 


### PR DESCRIPTION
The original was throwing  `'KeyOriginInfo' object does not support indexing` on a simple (signet) PSBT. It's not entirely clear to me what this code is trying to do, but at least I was able to sign.