### PR TITLE
trezor: Enable processing of OP_RETURN outputs

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -328,6 +328,9 @@ class TrezorClient(HardwareWalletClient):
                     txoutput.address = to_address(out.scriptPubKey[3:23], p2pkh_version)
                 elif out.is_p2sh():
                     txoutput.address = to_address(out.scriptPubKey[2:22], p2sh_version)
+                elif out.is_opreturn():
+                    txoutput.script_type = proto.OutputScriptType.PAYTOOPRETURN
+                    txoutput.op_return_data = out.scriptPubKey[2:]
                 else:
                     wit, ver, prog = out.is_witness()
                     if wit:

--- a/hwilib/serializations.py
+++ b/hwilib/serializations.py
@@ -283,6 +283,9 @@ class CTxIn(object):
                self.nSequence)
 
 
+def is_opreturn(script: bytes) -> bool:
+    return script[0] == 0x6a
+
 def is_p2sh(script: bytes) -> bool:
     return len(script) == 23 and script[0] == 0xa9 and script[1] == 0x14 and script[22] == 0x87
 
@@ -335,6 +338,9 @@ class CTxOut(object):
         r += struct.pack("<q", self.nValue)
         r += ser_string(self.scriptPubKey)
         return r
+
+    def is_opreturn(self) -> bool:
+        return is_opreturn(self.scriptPubKey)
 
     def is_p2sh(self) -> bool:
         return is_p2sh(self.scriptPubKey)

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -19,6 +19,10 @@ from hwilib.serializations import PSBT
 
 SUPPORTS_MS_DISPLAY = {'trezor_1', 'keepkey', 'coldcard', 'trezor_t'}
 SUPPORTS_XPUB_MS_DISPLAY = {'trezor_1', 'trezor_t'}
+SUPPORTS_MIXED = {'coldcard', 'trezor_1', 'digitalbitbox', 'keepkey', 'trezor_t'}
+SUPPORTS_MULTISIG = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t'}
+SUPPORTS_EXTERNAL = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t'}
+SUPPORTS_OP_RETURN = {'ledger', 'digitalbitbox', 'trezor_1', 'trezor_t', 'keepkey'}
 
 # Class for emulator control
 class DeviceEmulator():
@@ -424,18 +428,14 @@ class TestSignTx(DeviceTestCase):
 
     # Test wrapper to avoid mixed-inputs signing for Ledger
     def test_signtx(self):
-        supports_mixed = {'coldcard', 'trezor_1', 'digitalbitbox', 'keepkey', 'trezor_t'}
-        supports_multisig = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t'}
-        supports_external = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t'}
-        supports_op_return = {'ledger', 'digitalbitbox', 'trezor_1', 'trezor_t', 'keepkey'}
-        multisig = self.full_type in supports_multisig
-        external = self.full_type in supports_external
-        op_return = self.full_type in supports_op_return
+        multisig = self.full_type in SUPPORTS_MULTISIG
+        external = self.full_type in SUPPORTS_EXTERNAL
+        op_return = self.full_type in SUPPORTS_OP_RETURN
         with self.subTest(addrtype="legacy", multisig=multisig, external=external):
             self._test_signtx("legacy", multisig, external, op_return)
         with self.subTest(addrtype="segwit", multisig=multisig, external=external):
             self._test_signtx("segwit", multisig, external, op_return)
-        if self.full_type in supports_mixed:
+        if self.full_type in SUPPORTS_MIXED:
             with self.subTest(addrtype="all", multisig=multisig, external=external):
                 self._test_signtx("all", multisig, external, op_return)
 

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -354,7 +354,7 @@ class TestSignTx(DeviceTestCase):
 
         return sh_desc, sh_ms_info["address"], sh_wsh_desc, sh_wsh_ms_info["address"], wsh_desc, wsh_ms_info["address"]
 
-    def _test_signtx(self, input_type, multisig, external):
+    def _test_signtx(self, input_type, multisig, external, op_return: bool):
         # Import some keys to the watch only wallet and send coins to them
         keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--all', '30', '50'])
         import_result = self.wrpc.importdescriptors(keypool_desc)
@@ -404,7 +404,14 @@ class TestSignTx(DeviceTestCase):
                 self.assertEqual((i + 1) * in_amt, self.wrpc.getbalance("*", 0, True))
                 change_addr = self.wpk_rpc.getrawchangeaddress()
             out_val = (i + 1) * out_amt
-            psbt = self.wrpc.walletcreatefundedpsbt([], [{self.wpk_rpc.getnewaddress('', 'legacy'): out_val}, {self.wpk_rpc.getnewaddress('', 'p2sh-segwit'): out_val}, {self.wpk_rpc.getnewaddress('', 'bech32'): out_val}], 0, {'includeWatching': True, "changePosition": 3, "changeAddress": change_addr}, True)
+            outputs = [
+                {self.wpk_rpc.getnewaddress('', 'legacy'): out_val},
+                {self.wpk_rpc.getnewaddress('', 'p2sh-segwit'): out_val},
+                {self.wpk_rpc.getnewaddress('', 'bech32'): out_val}
+            ]
+            if op_return:
+                outputs.append({"data": "000102030405060708090a0b0c0d0e0f10111213141516171819101a1b1c1d1e1f"})
+            psbt = self.wrpc.walletcreatefundedpsbt([], outputs, 0, {'includeWatching': True, "changePosition": 3, "changeAddress": change_addr}, True)
 
             if external:
                 # Sign with unknown inputs in two steps
@@ -420,15 +427,17 @@ class TestSignTx(DeviceTestCase):
         supports_mixed = {'coldcard', 'trezor_1', 'digitalbitbox', 'keepkey', 'trezor_t'}
         supports_multisig = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t'}
         supports_external = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t'}
+        supports_op_return = {'ledger', 'digitalbitbox', 'trezor_1', 'trezor_t', 'keepkey'}
         multisig = self.full_type in supports_multisig
         external = self.full_type in supports_external
+        op_return = self.full_type in supports_op_return
         with self.subTest(addrtype="legacy", multisig=multisig, external=external):
-            self._test_signtx("legacy", multisig, external)
+            self._test_signtx("legacy", multisig, external, op_return)
         with self.subTest(addrtype="segwit", multisig=multisig, external=external):
-            self._test_signtx("segwit", multisig, external)
+            self._test_signtx("segwit", multisig, external, op_return)
         if self.full_type in supports_mixed:
             with self.subTest(addrtype="all", multisig=multisig, external=external):
-                self._test_signtx("all", multisig, external)
+                self._test_signtx("all", multisig, external, op_return)
 
     # Make a huge transaction which might cause some problems with different interfaces
     def test_big_tx(self):


### PR DESCRIPTION
Fixes https://github.com/bitcoin-core/HWI/issues/391

Would it be possible to add PSBT with OP_RETURN to the test suite, so we'll have this case covered?