### PR TITLE
Add some dockerfile steps for local testing

### DIFF
--- a/ci/cirrus.Dockerfile
+++ b/ci/cirrus.Dockerfile
@@ -33,7 +33,47 @@ RUN apt-get install -y \
     libboost-thread-dev \
     protobuf-compiler \
     cython3
+
 RUN pip install poetry flake8
+
+####################
+# Local build/test steps
+# -----------------
+# To install all simulators/tests locally, uncomment the block below,
+# then build the docker image and interactively run the tests
+# as needed.
+# e.g.,
+# docker build -f ci/cirrus.Dockerfile -t hwi_test .
+# docker run -it --entrypoint /bin/bash hwi_tst
+# cd test; poetry run ./run_tests.py --ledger --coldcard --interface=cli --device-only
+####################
+
+####################
+#ENV EMAIL=email
+#COPY pyproject.toml pyproject.toml
+#RUN poetry run pip install construct pyelftools mnemonic jsonschema
+#
+## Set up environments first to take advantage of layer caching
+#RUN mkdir test
+#COPY test/setup_environment.sh test/setup_environment.sh
+#COPY test/data/coldcard-multisig.patch test/data/coldcard-multisig.patch
+## One by one to allow for intermediate caching of successful builds
+#RUN cd test; ./setup_environment.sh --trezor-1
+#RUN cd test; ./setup_environment.sh --trezor-t
+#RUN cd test; ./setup_environment.sh --coldcard
+#RUN cd test; ./setup_environment.sh --bitbox01
+#RUN cd test; ./setup_environment.sh --ledger
+#RUN cd test; ./setup_environment.sh --keepkey
+#RUN cd test; ./setup_environment.sh --bitcoind
+#
+## Once everything has been built, put rest of files in place
+## which have higher turn-over.
+#COPY test/ test/
+#COPY hwi.py hwi-qt.py README.md /
+#COPY hwilib/ /hwilib/
+#RUN poetry install
+#
+####################
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8


### PR DESCRIPTION
I'd really like local testing to be easier. Ideally we'd use docker's layer/caching to take care of everything for us rather than rely on additional layers of caching, making it efficient to test hwi changes.

For now, I added some steps that can be uncommented out for quick local testing.

As a follow-up I'm looking at having these lines run in the base image, but have to make sure they don't conflict with other things such as the various simulator patches(coldcard only for now), and making sure the additional build time is worth it from a CI perspective since a number of simulator building steps are re-done for each cirrus job.