### PR TITLE
bitbox02: update to v5.2.0

### DIFF
--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -627,4 +627,5 @@ class Bitbox02Client(HardwareWalletClient):
         if label:
             bb02.set_device_name(label)
 
-        return {"success": bb02.restore_from_mnemonic()}
+        bb02.restore_from_mnemonic()
+        return {"success": True}

--- a/poetry.lock
+++ b/poetry.lock
@@ -374,7 +374,7 @@ qt = ["pyside2"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6,<3.10"
-content-hash = "fae8cd4ec5fae48e4eed77a42ff209233bf32fff1e7a79854a492f7c06582c4f"
+content-hash = "569af9248ab36c24591d50a64650e507928acfcfea8258e08dde06a9659564ab"
 
 [metadata.files]
 altgraph = [
@@ -527,7 +527,6 @@ mypy-extensions = [
 ]
 noiseprotocol = [
     {file = "noiseprotocol-0.3.1-py3-none-any.whl", hash = "sha256:2e1a603a38439636cf0ffd8b3e8b12cee27d368a28b41be7dbe568b2abb23111"},
-    {file = "noiseprotocol-0.3.1.tar.gz", hash = "sha256:b092a871b60f6a8f07f17950dc9f7098c8fe7d715b049bd4c24ee3752b90d645"},
 ]
 pefile = [
     {file = "pefile-2019.4.18.tar.gz", hash = "sha256:a5d6e8305c6b210849b47a6174ddf9c452b2888340b8177874b862ba6c207645"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ mnemonic = "~0"
 typing-extensions = "^3.7"
 libusb1 = "^1.7"
 pyside2 = { version = "^5.14.0", optional = true }
-bitbox02 = ">=5.1.0"
+bitbox02 = ">=5.2.0,<6.0.0"
 
 [tool.poetry.extras]
 qt = ["pyside2"]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ package_data = \
 modules = \
 ['hwi', 'hwi-qt']
 install_requires = \
-['bitbox02>=5.1.0',
+['bitbox02>=5.2.0,<6.0.0',
  'ecdsa>=0,<1',
  'hidapi>=0,<1',
  'libusb1>=1.7,<2.0',


### PR DESCRIPTION
Updated pyproject.toml and setup.py, then: `poetry update bitbox02 --lock`.

- Support for antiklepto
- Small function signature change in restore_from_mnemonic
- Add version upper bound following semver