### PR TITLE
Change HardwareWalletClient functions to return objects instead of dictioanries

### DIFF
--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -41,6 +41,7 @@ import logging
 import json
 import sys
 
+
 def backup_device_handler(args, client):
     return backup_device(client, label=args.label, backup_passphrase=args.backup_passphrase)
 
@@ -50,11 +51,11 @@ def displayaddress_handler(args: argparse.Namespace, client: HardwareWalletClien
 def enumerate_handler(args):
     return enumerate(password=args.password)
 
-def getmasterxpub_handler(args, client):
+def getmasterxpub_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, str]:
     return getmasterxpub(client)
 
-def getxpub_handler(args, client):
-    return getxpub(client, path=args.path)
+def getxpub_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, str]:
+    return getxpub(client, path=args.path, expert=args.expert)
 
 def getkeypool_handler(args, client):
     return getkeypool(client, path=args.path, start=args.start, end=args.end, internal=args.internal, keypool=args.keypool, account=args.account, addr_type=args.addr_type, addr_all=args.all)

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -88,7 +88,7 @@ def prompt_pin_handler(args: argparse.Namespace, client: HardwareWalletClient) -
 def toggle_passphrase_handler(args, client):
     return toggle_passphrase(client)
 
-def send_pin_handler(args, client):
+def send_pin_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, bool]:
     return send_pin(client, pin=args.pin)
 
 def install_udev_rules_handler(args):

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -42,7 +42,7 @@ import json
 import sys
 
 
-def backup_device_handler(args, client):
+def backup_device_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, bool]:
     return backup_device(client, label=args.label, backup_passphrase=args.backup_passphrase)
 
 def displayaddress_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, str]:

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -79,7 +79,7 @@ def signmessage_handler(args: argparse.Namespace, client: HardwareWalletClient) 
 def signtx_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, str]:
     return signtx(client, psbt=args.psbt)
 
-def wipe_device_handler(args, client):
+def wipe_device_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, bool]:
     return wipe_device(client)
 
 def prompt_pin_handler(args, client):

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -63,7 +63,7 @@ def getkeypool_handler(args, client):
 def getdescriptors_handler(args, client):
     return getdescriptors(client, account=args.account)
 
-def restore_device_handler(args, client):
+def restore_device_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, bool]:
     if args.interactive:
         return restore_device(client, label=args.label, word_count=args.word_count)
     return {'error': 'restore requires interactive mode', 'code': UNAVAILABLE_ACTION}

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -73,7 +73,7 @@ def setup_device_handler(args, client):
         return setup_device(client, label=args.label, backup_passphrase=args.backup_passphrase)
     return {'error': 'setup requires interactive mode', 'code': UNAVAILABLE_ACTION}
 
-def signmessage_handler(args, client):
+def signmessage_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, str]:
     return signmessage(client, message=args.message, path=args.path)
 
 def signtx_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, str]:

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -29,8 +29,11 @@ from .errors import (
     NO_DEVICE_TYPE,
     UNAVAILABLE_ACTION,
 )
+from .hwwclient import HardwareWalletClient
 from .serializations import AddressType
 from . import __version__
+
+from typing import Dict
 
 import argparse
 import getpass
@@ -41,7 +44,7 @@ import sys
 def backup_device_handler(args, client):
     return backup_device(client, label=args.label, backup_passphrase=args.backup_passphrase)
 
-def displayaddress_handler(args, client):
+def displayaddress_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, str]:
     return displayaddress(client, desc=args.desc, path=args.path, addr_type=args.addr_type)
 
 def enumerate_handler(args):

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -68,7 +68,7 @@ def restore_device_handler(args, client):
         return restore_device(client, label=args.label, word_count=args.word_count)
     return {'error': 'restore requires interactive mode', 'code': UNAVAILABLE_ACTION}
 
-def setup_device_handler(args, client):
+def setup_device_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, bool]:
     if args.interactive:
         return setup_device(client, label=args.label, backup_passphrase=args.backup_passphrase)
     return {'error': 'setup requires interactive mode', 'code': UNAVAILABLE_ACTION}

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -82,7 +82,7 @@ def signtx_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Di
 def wipe_device_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, bool]:
     return wipe_device(client)
 
-def prompt_pin_handler(args, client):
+def prompt_pin_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, bool]:
     return prompt_pin(client)
 
 def toggle_passphrase_handler(args, client):

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -91,7 +91,7 @@ def toggle_passphrase_handler(args: argparse.Namespace, client: HardwareWalletCl
 def send_pin_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, bool]:
     return send_pin(client, pin=args.pin)
 
-def install_udev_rules_handler(args):
+def install_udev_rules_handler(args: argparse.Namespace) -> Dict[str, bool]:
     return install_udev_rules('udev', args.location)
 
 class HWIHelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter):

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -76,7 +76,7 @@ def setup_device_handler(args, client):
 def signmessage_handler(args, client):
     return signmessage(client, message=args.message, path=args.path)
 
-def signtx_handler(args, client):
+def signtx_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, str]:
     return signtx(client, psbt=args.psbt)
 
 def wipe_device_handler(args, client):

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -85,7 +85,7 @@ def wipe_device_handler(args: argparse.Namespace, client: HardwareWalletClient) 
 def prompt_pin_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, bool]:
     return prompt_pin(client)
 
-def toggle_passphrase_handler(args, client):
+def toggle_passphrase_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, bool]:
     return toggle_passphrase(client)
 
 def send_pin_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, bool]:

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -306,8 +306,8 @@ def prompt_pin(client: HardwareWalletClient) -> Dict[str, bool]:
 def send_pin(client: HardwareWalletClient, pin: str) -> Dict[str, bool]:
     return {"success": client.send_pin(pin)}
 
-def toggle_passphrase(client):
-    return client.toggle_passphrase()
+def toggle_passphrase(client: HardwareWalletClient) -> Dict[str, bool]:
+    return {"success": client.toggle_passphrase()}
 
 def install_udev_rules(source, location):
     if platform.system() == "Linux":

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -38,6 +38,7 @@ from .hwwclient import HardwareWalletClient
 from itertools import count
 from typing import Dict
 
+
 py_enumerate = enumerate
 
 
@@ -99,11 +100,11 @@ def find_device(password='', device_type=None, fingerprint=None, expert=False):
 def getmasterxpub(client: HardwareWalletClient) -> Dict[str, str]:
     return {"xpub": client.get_master_xpub().to_string()}
 
-def signtx(client, psbt):
+def signtx(client: HardwareWalletClient, psbt: str) -> Dict[str, str]:
     # Deserialize the transaction
     tx = PSBT()
     tx.deserialize(psbt)
-    return client.sign_tx(tx)
+    return {"psbt": client.sign_tx(tx).serialize()}
 
 def getxpub(client: HardwareWalletClient, path: str, expert: bool = False) -> Dict[str, str]:
     xpub = client.get_pubkey_at_path(path)

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -309,8 +309,8 @@ def send_pin(client: HardwareWalletClient, pin: str) -> Dict[str, bool]:
 def toggle_passphrase(client: HardwareWalletClient) -> Dict[str, bool]:
     return {"success": client.toggle_passphrase()}
 
-def install_udev_rules(source, location):
+def install_udev_rules(source: str, location: str) -> Dict[str, bool]:
     if platform.system() == "Linux":
         from .udevinstaller import UDevInstaller
-        return UDevInstaller.install(source, location)
+        return {"success": UDevInstaller.install(source, location)}
     return {'error': 'udev rules are not needed on your platform', 'code': NOT_IMPLEMENTED}

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -291,8 +291,8 @@ def displayaddress(client, path=None, desc=None, addr_type: AddressType = Addres
 def setup_device(client, label='', backup_passphrase=''):
     return client.setup_device(label, backup_passphrase)
 
-def wipe_device(client):
-    return client.wipe_device()
+def wipe_device(client: HardwareWalletClient) -> Dict[str, bool]:
+    return {"success": client.wipe_device()}
 
 def restore_device(client, label='', word_count=24):
     return client.restore_device(label, word_count)

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -300,8 +300,8 @@ def restore_device(client: HardwareWalletClient, label: str = "", word_count: in
 def backup_device(client: HardwareWalletClient, label: str = "", backup_passphrase: str = "") -> Dict[str, bool]:
     return {"success": client.backup_device(label, backup_passphrase)}
 
-def prompt_pin(client):
-    return client.prompt_pin()
+def prompt_pin(client: HardwareWalletClient) -> Dict[str, bool]:
+    return {"success": client.prompt_pin()}
 
 def send_pin(client, pin):
     return client.send_pin(pin)

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -294,8 +294,8 @@ def setup_device(client: HardwareWalletClient, label: str = "", backup_passphras
 def wipe_device(client: HardwareWalletClient) -> Dict[str, bool]:
     return {"success": client.wipe_device()}
 
-def restore_device(client, label='', word_count=24):
-    return client.restore_device(label, word_count)
+def restore_device(client: HardwareWalletClient, label: str = "", word_count: int = 24) -> Dict[str, bool]:
+    return {"success": client.restore_device(label, word_count)}
 
 def backup_device(client, label='', backup_passphrase=''):
     return client.backup_device(label, backup_passphrase)

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -303,8 +303,8 @@ def backup_device(client: HardwareWalletClient, label: str = "", backup_passphra
 def prompt_pin(client: HardwareWalletClient) -> Dict[str, bool]:
     return {"success": client.prompt_pin()}
 
-def send_pin(client, pin):
-    return client.send_pin(pin)
+def send_pin(client: HardwareWalletClient, pin: str) -> Dict[str, bool]:
+    return {"success": client.send_pin(pin)}
 
 def toggle_passphrase(client):
     return client.toggle_passphrase()

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -288,8 +288,8 @@ def displayaddress(client, path=None, desc=None, addr_type: AddressType = Addres
                 addr_type = AddressType.WPKH
             return {"address": client.display_singlesig_address(pubkey.get_full_derivation_path(0), addr_type)}
 
-def setup_device(client, label='', backup_passphrase=''):
-    return client.setup_device(label, backup_passphrase)
+def setup_device(client: HardwareWalletClient, label: str = "", backup_passphrase: str = "") -> Dict[str, bool]:
+    return {"success": client.setup_device(label, backup_passphrase)}
 
 def wipe_device(client: HardwareWalletClient) -> Dict[str, bool]:
     return {"success": client.wipe_device()}

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -35,6 +35,7 @@ from .devices import __all__ as all_devs
 from .common import Chain
 
 from itertools import count
+from typing import Dict
 
 py_enumerate = enumerate
 
@@ -246,9 +247,9 @@ def getdescriptors(client, account=0):
 
     return result
 
-def displayaddress(client, path=None, desc=None, addr_type: AddressType = AddressType.PKH):
+def displayaddress(client, path=None, desc=None, addr_type: AddressType = AddressType.PKH) -> Dict[str, str]:
     if path is not None:
-        return client.display_singlesig_address(path, addr_type)
+        return {"address": client.display_singlesig_address(path, addr_type)}
     elif desc is not None:
         descriptor = parse_descriptor(desc)
         addr_type = AddressType.PKH
@@ -264,7 +265,7 @@ def displayaddress(client, path=None, desc=None, addr_type: AddressType = Addres
                     addr_type = AddressType.SH_WPKH
                 elif not is_sh and is_wsh:
                     addr_type = AddressType.WPKH
-                return client.display_multisig_address(descriptor.thresh, descriptor.pubkeys, addr_type)
+                return {"address": client.display_multisig_address(descriptor.thresh, descriptor.pubkeys, addr_type)}
         is_wpkh = isinstance(descriptor, WPKHDescriptor)
         if isinstance(descriptor, PKHDescriptor) or is_wpkh:
             pubkey = descriptor.pubkeys[0]
@@ -279,7 +280,7 @@ def displayaddress(client, path=None, desc=None, addr_type: AddressType = Addres
                 addr_type = AddressType.SH_WPKH
             elif not is_sh and is_wpkh:
                 addr_type = AddressType.WPKH
-            return client.display_singlesig_address(pubkey.get_full_derivation_path(0), addr_type)
+            return {"address": client.display_singlesig_address(pubkey.get_full_derivation_path(0), addr_type)}
 
 def setup_device(client, label='', backup_passphrase=''):
     return client.setup_device(label, backup_passphrase)

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -113,8 +113,8 @@ def getxpub(client: HardwareWalletClient, path: str, expert: bool = False) -> Di
         result.update(xpub.get_printable_dict())
     return result
 
-def signmessage(client, message, path):
-    return client.sign_message(message, path)
+def signmessage(client: HardwareWalletClient, message: str, path: str) -> Dict[str, str]:
+    return {"signature": client.sign_message(message, path)}
 
 def getkeypool_inner(client, path, start, end, internal=False, keypool=True, account=0, addr_type=AddressType.WPKH):
 

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -297,8 +297,8 @@ def wipe_device(client: HardwareWalletClient) -> Dict[str, bool]:
 def restore_device(client: HardwareWalletClient, label: str = "", word_count: int = 24) -> Dict[str, bool]:
     return {"success": client.restore_device(label, word_count)}
 
-def backup_device(client, label='', backup_passphrase=''):
-    return client.backup_device(label, backup_passphrase)
+def backup_device(client: HardwareWalletClient, label: str = "", backup_passphrase: str = "") -> Dict[str, bool]:
+    return {"success": client.backup_device(label, backup_passphrase)}
 
 def prompt_pin(client):
     return client.prompt_pin()

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -323,7 +323,7 @@ class Bitbox02Client(HardwareWalletClient):
             "The BitBox02 does not need a PIN sent from the host"
         )
 
-    def send_pin(self, pin: str) -> Dict[str, Union[bool, str, int]]:
+    def send_pin(self, pin: str) -> bool:
         raise UnavailableActionError(
             "The BitBox02 does not need a PIN sent from the host"
         )

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -485,7 +485,7 @@ class Bitbox02Client(HardwareWalletClient):
         return address
 
     @bitbox02_exception
-    def sign_tx(self, psbt: PSBT) -> Dict[str, str]:
+    def sign_tx(self, psbt: PSBT) -> PSBT:
         def find_our_key(
             keypaths: Dict[bytes, KeyOriginInfo]
         ) -> Tuple[Optional[bytes], Optional[Sequence[int]]]:
@@ -734,7 +734,7 @@ class Bitbox02Client(HardwareWalletClient):
             # ser_sig_der() adds SIGHASH_ALL
             psbt_in.partial_sigs[pubkey] = ser_sig_der(r, s)
 
-        return {"psbt": psbt.serialize()}
+        return psbt
 
     def sign_message(
         self, message: Union[str, bytes], bip32_path: str

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -738,7 +738,7 @@ class Bitbox02Client(HardwareWalletClient):
 
     def sign_message(
         self, message: Union[str, bytes], bip32_path: str
-    ) -> Dict[str, str]:
+    ) -> str:
         raise UnavailableActionError("The BitBox02 does not support 'signmessage'")
 
     @bitbox02_exception

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -318,7 +318,7 @@ class Bitbox02Client(HardwareWalletClient):
     def get_master_fingerprint_hex(self) -> str:
         return self.get_master_fingerprint().hex()
 
-    def prompt_pin(self) -> Dict[str, Union[bool, str, int]]:
+    def prompt_pin(self) -> bool:
         raise UnavailableActionError(
             "The BitBox02 does not need a PIN sent from the host"
         )

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -775,14 +775,14 @@ class Bitbox02Client(HardwareWalletClient):
     @bitbox02_exception
     def backup_device(
         self, label: str = "", passphrase: str = ""
-    ) -> Dict[str, Union[bool, str, int]]:
+    ) -> bool:
         if label or passphrase:
             raise UnavailableActionError(
                 "Label/passphrase not needed when exporting mnemonic from the BitBox02."
             )
 
         self.init().show_mnemonic()
-        return {"success": True}
+        return True
 
     @bitbox02_exception
     def restore_device(

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -742,14 +742,14 @@ class Bitbox02Client(HardwareWalletClient):
         raise UnavailableActionError("The BitBox02 does not support 'signmessage'")
 
     @bitbox02_exception
-    def toggle_passphrase(self) -> Dict[str, Union[bool, str, int]]:
+    def toggle_passphrase(self) -> bool:
         bb02 = self.init()
         info = bb02.device_info()
         if info["mnemonic_passphrase_enabled"]:
             bb02.disable_mnemonic_passphrase()
         else:
             bb02.enable_mnemonic_passphrase()
-        return {"success": True}
+        return True
 
     @bitbox02_exception
     def setup_device(

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -769,8 +769,8 @@ class Bitbox02Client(HardwareWalletClient):
         return {"success": bb02.create_backup()}
 
     @bitbox02_exception
-    def wipe_device(self) -> Dict[str, Union[bool, str, int]]:
-        return {"success": self.init().reset()}
+    def wipe_device(self) -> bool:
+        return self.init().reset()
 
     @bitbox02_exception
     def backup_device(

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -754,7 +754,7 @@ class Bitbox02Client(HardwareWalletClient):
     @bitbox02_exception
     def setup_device(
         self, label: str = "", passphrase: str = ""
-    ) -> Dict[str, Union[bool, str, int]]:
+    ) -> bool:
         if passphrase:
             raise UnavailableActionError(
                 "Passphrase not needed when setting up a BitBox02."
@@ -765,8 +765,8 @@ class Bitbox02Client(HardwareWalletClient):
         if label:
             bb02.set_device_name(label)
         if not bb02.set_password():
-            return {"success": False}
-        return {"success": bb02.create_backup()}
+            return False
+        return bb02.create_backup()
 
     @bitbox02_exception
     def wipe_device(self) -> bool:

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -418,7 +418,7 @@ class Bitbox02Client(HardwareWalletClient):
         self,
         bip32_path: str,
         addr_type: AddressType,
-    ) -> Dict[str, str]:
+    ) -> str:
         if addr_type == AddressType.SH_WPKH:
             script_config = bitbox02.btc.BTCScriptConfig(
                 simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH_P2SH
@@ -437,7 +437,7 @@ class Bitbox02Client(HardwareWalletClient):
             script_config=script_config,
             display=True,
         )
-        return {"address": address}
+        return address
 
     @bitbox02_exception
     def display_multisig_address(
@@ -445,7 +445,7 @@ class Bitbox02Client(HardwareWalletClient):
         threshold: int,
         pubkeys: List[PubkeyProvider],
         addr_type: AddressType,
-    ) -> Dict[str, str]:
+    ) -> str:
         path_suffixes = set(p.deriv_path for p in pubkeys)
         if len(path_suffixes) != 1:
             # Path suffix refers to the path after the account-level xpub, usually /<change>/<address>.
@@ -480,7 +480,7 @@ class Bitbox02Client(HardwareWalletClient):
         address = bb02.btc_address(
             keypath, coin=self._get_coin(), script_config=script_config, display=True
         )
-        return {"address": address}
+        return address
 
     @bitbox02_exception
     def sign_tx(self, psbt: PSBT) -> Dict[str, str]:

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -787,11 +787,11 @@ class Bitbox02Client(HardwareWalletClient):
     @bitbox02_exception
     def restore_device(
         self, label: str = "", word_count: int = 24
-    ) -> Dict[str, Union[bool, str, int]]:
+    ) -> bool:
         bb02 = self.init(expect_initialized=False)
 
         if label:
             bb02.set_device_name(label)
 
         bb02.restore_from_mnemonic()
-        return {"success": True}
+        return True

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -19,6 +19,7 @@ import base58
 
 from ..descriptor import PubkeyProvider
 from ..hwwclient import HardwareWalletClient
+from ..key import ExtendedKey
 from ..serializations import (
     AddressType,
     PSBT,
@@ -342,13 +343,14 @@ class Bitbox02Client(HardwareWalletClient):
             keypath, coin=self._get_coin(), xpub_type=xpub_type, display=False
         )
 
-    def get_pubkey_at_path(self, bip32_path: str) -> Dict[str, str]:
+    def get_pubkey_at_path(self, bip32_path: str) -> ExtendedKey:
         path_uint32s = parse_path(bip32_path)
         try:
-            xpub = self._get_xpub(path_uint32s)
+            xpub_str = self._get_xpub(path_uint32s)
         except Bitbox02Exception as exc:
             raise BitBox02Error(str(exc))
-        return {"xpub": xpub}
+        xpub = ExtendedKey.deserialize(xpub_str)
+        return xpub
 
     def _maybe_register_script_config(
         self, script_config: bitbox02.btc.BTCScriptConfig, keypath: Sequence[int]

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -320,8 +320,7 @@ class ColdcardClient(HardwareWalletClient):
     def send_pin(self, pin: str) -> bool:
         raise UnavailableActionError('The Coldcard does not need a PIN sent from the host')
 
-    # Toggle passphrase
-    def toggle_passphrase(self):
+    def toggle_passphrase(self) -> bool:
         raise UnavailableActionError('The Coldcard does not support toggling passphrase from the host')
 
 def enumerate(password=''):

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -276,8 +276,7 @@ class ColdcardClient(HardwareWalletClient):
     def setup_device(self, label='', passphrase=''):
         raise UnavailableActionError('The Coldcard does not support software setup')
 
-    # Wipe this device
-    def wipe_device(self):
+    def wipe_device(self) -> bool:
         raise UnavailableActionError('The Coldcard does not support wiping via software')
 
     # Restore device from mnemonic or xprv

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -214,13 +214,12 @@ class ColdcardClient(HardwareWalletClient):
         sig = str(base64.b64encode(raw), 'ascii').replace('\n', '')
         return {"signature": sig}
 
-    # Display address of specified type on the device.
     @coldcard_exception
     def display_singlesig_address(
         self,
         keypath: str,
         addr_type: AddressType,
-    ) -> Dict[str, str]:
+    ) -> str:
         self.device.check_mitm()
         keypath = keypath.replace('h', '\'')
         keypath = keypath.replace('H', '\'')
@@ -238,7 +237,7 @@ class ColdcardClient(HardwareWalletClient):
 
         if self.device.is_simulator:
             self.device.send_recv(CCProtocolPacker.sim_keypress(b'y'))
-        return {'address': address}
+        return address
 
     @coldcard_exception
     def display_multisig_address(
@@ -279,7 +278,7 @@ class ColdcardClient(HardwareWalletClient):
 
         if self.device.is_simulator:
             self.device.send_recv(CCProtocolPacker.sim_keypress(b'y'))
-        return {'address': address}
+        return address
 
     # Setup a new device
     def setup_device(self, label='', passphrase=''):

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -281,9 +281,8 @@ class ColdcardClient(HardwareWalletClient):
     def restore_device(self, label: str = "", word_count: int = 24) -> bool:
         raise UnavailableActionError('The Coldcard does not support restoring via software')
 
-    # Begin backup process
     @coldcard_exception
-    def backup_device(self, label='', passphrase=''):
+    def backup_device(self, label: str = "", passphrase: str = "") -> bool:
         self.device.check_mitm()
 
         ok = self.device.send_recv(CCProtocolPacker.start_backup())
@@ -309,7 +308,7 @@ class ColdcardClient(HardwareWalletClient):
         result = self.device.download_file(result_len, result_sha, file_number=0)
         filename = time.strftime('backup-%Y%m%d-%H%M.7z')
         open(filename, 'wb').write(result)
-        return {'success': True, 'message': 'The backup has been written to {}'.format(filename)}
+        return True
 
     # Close the device
     def close(self):

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -272,8 +272,7 @@ class ColdcardClient(HardwareWalletClient):
             self.device.send_recv(CCProtocolPacker.sim_keypress(b'y'))
         return address
 
-    # Setup a new device
-    def setup_device(self, label='', passphrase=''):
+    def setup_device(self, label: str = "", passphrase: str = "") -> bool:
         raise UnavailableActionError('The Coldcard does not support software setup')
 
     def wipe_device(self) -> bool:

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -102,10 +102,8 @@ class ColdcardClient(HardwareWalletClient):
         # quick method to get fingerprint of wallet
         return hexlify(struct.pack('<I', self.device.master_fingerprint)).decode()
 
-    # Must return a hex string with the signed transaction
-    # The tx must be in the combined unsigned transaction format
     @coldcard_exception
-    def sign_tx(self, tx):
+    def sign_tx(self, tx: PSBT) -> PSBT:
         self.device.check_mitm()
 
         # Get this devices master key fingerprint
@@ -173,7 +171,8 @@ class ColdcardClient(HardwareWalletClient):
 
             tx = PSBT()
             tx.deserialize(base64.b64encode(result).decode())
-        return {'psbt': tx.serialize()}
+
+        return tx
 
     @coldcard_exception
     def sign_message(self, message: Union[str, bytes], keypath: str) -> Dict[str, str]:

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -314,8 +314,7 @@ class ColdcardClient(HardwareWalletClient):
     def close(self):
         self.device.close()
 
-    # Prompt pin
-    def prompt_pin(self):
+    def prompt_pin(self) -> bool:
         raise UnavailableActionError('The Coldcard does not need a PIN sent from the host')
 
     # Send pin

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -175,7 +175,7 @@ class ColdcardClient(HardwareWalletClient):
         return tx
 
     @coldcard_exception
-    def sign_message(self, message: Union[str, bytes], keypath: str) -> Dict[str, str]:
+    def sign_message(self, message: Union[str, bytes], keypath: str) -> str:
         self.device.check_mitm()
         keypath = keypath.replace('h', '\'')
         keypath = keypath.replace('H', '\'')
@@ -204,7 +204,7 @@ class ColdcardClient(HardwareWalletClient):
         _, raw = done
 
         sig = str(base64.b64encode(raw), 'ascii').replace('\n', '')
-        return {"signature": sig}
+        return sig
 
     @coldcard_exception
     def display_singlesig_address(

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -278,8 +278,7 @@ class ColdcardClient(HardwareWalletClient):
     def wipe_device(self) -> bool:
         raise UnavailableActionError('The Coldcard does not support wiping via software')
 
-    # Restore device from mnemonic or xprv
-    def restore_device(self, label='', word_count=24):
+    def restore_device(self, label: str = "", word_count: int = 24) -> bool:
         raise UnavailableActionError('The Coldcard does not support restoring via software')
 
     # Begin backup process

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -317,8 +317,7 @@ class ColdcardClient(HardwareWalletClient):
     def prompt_pin(self) -> bool:
         raise UnavailableActionError('The Coldcard does not need a PIN sent from the host')
 
-    # Send pin
-    def send_pin(self, pin):
+    def send_pin(self, pin: str) -> bool:
         raise UnavailableActionError('The Coldcard does not need a PIN sent from the host')
 
     # Toggle passphrase

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -582,9 +582,8 @@ class DigitalbitboxClient(HardwareWalletClient):
     def restore_device(self, label: str = "", word_count: int = 24) -> bool:
         raise UnavailableActionError('The Digital Bitbox does not support restoring via software')
 
-    # Begin backup process
     @digitalbitbox_exception
-    def backup_device(self, label='', passphrase=''):
+    def backup_device(self, label: str = "", passphrase: str = "") -> bool:
         # Need a wallet name and backup passphrase
         if not label or not passphrase:
             raise BadArgumentError('The label and backup passphrase for a Digital Bitbox backup must be specified and cannot be empty')
@@ -595,7 +594,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         reply = send_encrypt(json.dumps(to_send).encode(), self.password, self.device)
         if 'error' in reply:
             raise DBBError(reply)
-        return {'success': True}
+        return True
 
     # Close the device
     def close(self):

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -506,7 +506,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         return tx
 
     @digitalbitbox_exception
-    def sign_message(self, message: Union[str, bytes], keypath: str) -> Dict[str, str]:
+    def sign_message(self, message: Union[str, bytes], keypath: str) -> str:
         to_hash = b""
         to_hash += self.message_magic
         to_hash += ser_compact_size(len(message))
@@ -540,7 +540,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         compact_sig = ser_sig_compact(r, s, recid)
         logging.debug(binascii.hexlify(compact_sig))
 
-        return {"signature": base64.b64encode(compact_sig).decode('utf-8')}
+        return base64.b64encode(compact_sig).decode('utf-8')
 
     def display_singlesig_address(self, keypath: str, addr_type: AddressType) -> str:
         raise UnavailableActionError('The Digital Bitbox does not have a screen to display addresses on')

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -46,6 +46,7 @@ from ..serializations import (
     is_p2wpkh,
     is_p2wsh,
     is_witness,
+    PSBT,
     ser_sig_der,
     ser_sig_compact,
     ser_string,
@@ -357,10 +358,8 @@ class DigitalbitboxClient(HardwareWalletClient):
             xpub.version = ExtendedKey.TESTNET_PUBLIC
         return xpub
 
-    # Must return a hex string with the signed transaction
-    # The tx must be in the PSBT format
     @digitalbitbox_exception
-    def sign_tx(self, tx):
+    def sign_tx(self, tx: PSBT) -> PSBT:
 
         # Create a transaction with all scriptsigs blanekd out
         blank_tx = CTransaction(tx.tx)
@@ -465,7 +464,7 @@ class DigitalbitboxClient(HardwareWalletClient):
 
         # Return early if nothing to do
         if len(sighash_tuples) == 0:
-            return {'psbt': tx.serialize()}
+            return tx
 
         # Sign the sighashes
         to_send = '{"sign":{"data":['
@@ -504,7 +503,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         for tup, sig in zip(sighash_tuples, der_sigs):
             tx.inputs[tup[2]].partial_sigs[tup[3]] = sig
 
-        return {'psbt': tx.serialize()}
+        return tx
 
     @digitalbitbox_exception
     def sign_message(self, message: Union[str, bytes], keypath: str) -> Dict[str, str]:

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -603,8 +603,7 @@ class DigitalbitboxClient(HardwareWalletClient):
     def prompt_pin(self) -> bool:
         raise UnavailableActionError('The Digital Bitbox does not need a PIN sent from the host')
 
-    # Send pin
-    def send_pin(self, pin):
+    def send_pin(self, pin: str) -> bool:
         raise UnavailableActionError('The Digital Bitbox does not need a PIN sent from the host')
 
     # Toggle passphrase

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -553,8 +553,7 @@ class DigitalbitboxClient(HardwareWalletClient):
 
         return {"signature": base64.b64encode(compact_sig).decode('utf-8')}
 
-    # Display address of specified type on the device.
-    def display_singlesig_address(self, keypath: str, addr_type: AddressType) -> Dict[str, str]:
+    def display_singlesig_address(self, keypath: str, addr_type: AddressType) -> str:
         raise UnavailableActionError('The Digital Bitbox does not have a screen to display addresses on')
 
     def display_multisig_address(self, threshold: int, pubkeys: List[PubkeyProvider], addr_type: AddressType) -> Dict[str, str]:

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -573,13 +573,12 @@ class DigitalbitboxClient(HardwareWalletClient):
             return {'success': False, 'error': reply['error']['message']}
         return {'success': True}
 
-    # Wipe this device
     @digitalbitbox_exception
-    def wipe_device(self):
+    def wipe_device(self) -> bool:
         reply = send_encrypt('{"reset" : "__ERASE__"}', self.password, self.device)
         if 'error' in reply:
-            return {'success': False, 'error': reply['error']['message']}
-        return {'success': True}
+            raise DeviceFailureError(reply["error"]["message"])
+        return True
 
     # Restore device from mnemonic or xprv
     def restore_device(self, label='', word_count=24):

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -548,9 +548,8 @@ class DigitalbitboxClient(HardwareWalletClient):
     def display_multisig_address(self, threshold: int, pubkeys: List[PubkeyProvider], addr_type: AddressType) -> Dict[str, str]:
         raise UnavailableActionError('The Digital Bitbox does not have a screen to display addresses on')
 
-    # Setup a new device
     @digitalbitbox_exception
-    def setup_device(self, label='', passphrase=''):
+    def setup_device(self, label: str = "", passphrase: str = "") -> bool:
         # Make sure this is not initialized
         reply = send_encrypt('{"device" : "info"}', self.password, self.device)
         if 'error' not in reply or ('error' in reply and (reply['error']['code'] != 101 and reply['error']['code'] != '101')):
@@ -570,8 +569,8 @@ class DigitalbitboxClient(HardwareWalletClient):
         to_send = {'seed': {'source': 'create', 'key': key, 'filename': backup_filename}}
         reply = send_encrypt(json.dumps(to_send).encode(), self.password, self.device)
         if 'error' in reply:
-            return {'success': False, 'error': reply['error']['message']}
-        return {'success': True}
+            raise DeviceFailureError(reply['error']['message'])
+        return True
 
     @digitalbitbox_exception
     def wipe_device(self) -> bool:

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -606,8 +606,7 @@ class DigitalbitboxClient(HardwareWalletClient):
     def send_pin(self, pin: str) -> bool:
         raise UnavailableActionError('The Digital Bitbox does not need a PIN sent from the host')
 
-    # Toggle passphrase
-    def toggle_passphrase(self):
+    def toggle_passphrase(self) -> bool:
         raise UnavailableActionError('The Digital Bitbox does not support toggling passphrase from the host')
 
 def enumerate(password=''):

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -600,8 +600,7 @@ class DigitalbitboxClient(HardwareWalletClient):
     def close(self):
         self.device.close()
 
-    # Prompt pin
-    def prompt_pin(self):
+    def prompt_pin(self) -> bool:
         raise UnavailableActionError('The Digital Bitbox does not need a PIN sent from the host')
 
     # Send pin

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -579,8 +579,7 @@ class DigitalbitboxClient(HardwareWalletClient):
             raise DeviceFailureError(reply["error"]["message"])
         return True
 
-    # Restore device from mnemonic or xprv
-    def restore_device(self, label='', word_count=24):
+    def restore_device(self, label: str = "", word_count: int = 24) -> bool:
         raise UnavailableActionError('The Digital Bitbox does not support restoring via software')
 
     # Begin backup process

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -352,8 +352,7 @@ class LedgerClient(HardwareWalletClient):
     ) -> str:
         raise BadArgumentError("The Ledger Nano S and X do not support P2SH address display")
 
-    # Setup a new device
-    def setup_device(self, label='', passphrase=''):
+    def setup_device(self, label: str = "", passphrase: str = "") -> bool:
         raise UnavailableActionError('The Ledger Nano S and X do not support software setup')
 
     def wipe_device(self) -> bool:

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -29,14 +29,13 @@ from .btchip.btchipUtils import compress_public_key
 import base64
 import hid
 import struct
-from .. import base58
 
 from ..key import (
     ExtendedKey,
+    parse_path,
 )
 from ..serializations import (
     AddressType,
-    hash256,
     hash160,
     is_p2sh,
     is_p2wpkh,
@@ -124,10 +123,8 @@ class LedgerClient(HardwareWalletClient):
 
         self.app = btchip(self.dongle)
 
-    # Must return a dict with the xpub
-    # Retrieves the public key at the specified BIP 32 derivation path
     @ledger_exception
-    def get_pubkey_at_path(self, path):
+    def get_pubkey_at_path(self, path: str) -> ExtendedKey:
         if not check_keypath(path):
             raise BadArgumentError("Invalid keypath")
         path = path[2:]
@@ -135,7 +132,8 @@ class LedgerClient(HardwareWalletClient):
         path = path.replace('H', '\'')
         # This call returns raw uncompressed pubkey, chaincode
         pubkey = self.app.getWalletPublicKey(path)
-        if path != "":
+        int_path = parse_path(path)
+        if len(path) > 0:
             parent_path = ""
             for ind in path.split("/")[:-1]:
                 parent_path += ind + "/"
@@ -145,38 +143,22 @@ class LedgerClient(HardwareWalletClient):
             parent = self.app.getWalletPublicKey(parent_path)
             fpr = hash160(compress_public_key(parent["publicKey"]))[:4]
 
-            # Compute child info
-            childstr = path.split("/")[-1]
-            hard = 0
-            if childstr[-1] == "'" or childstr[-1] == "h" or childstr[-1] == "H":
-                childstr = childstr[:-1]
-                hard = 0x80000000
-            child = struct.pack(">I", int(childstr) + hard)
+            child = int_path[-1]
         # Special case for m
         else:
-            child = bytearray.fromhex("00000000")
+            child = 0
             fpr = child
 
-        chainCode = pubkey["chainCode"]
-        publicKey = compress_public_key(pubkey["publicKey"])
-
-        depth = len(path.split("/")) if len(path) > 0 else 0
-        depth = struct.pack("B", depth)
-
-        if self.chain != Chain.MAIN:
-            version = bytearray.fromhex("043587CF")
-        else:
-            version = bytearray.fromhex("0488B21E")
-        extkey = version + depth + fpr + child + chainCode + publicKey
-        checksum = hash256(extkey)[:4]
-
-        xpub = base58.encode(extkey + checksum)
-        result = {"xpub": xpub}
-
-        if self.expert:
-            xpub_obj = ExtendedKey.deserialize(xpub)
-            result.update(xpub_obj.get_printable_dict())
-        return result
+        xpub = ExtendedKey(
+            version=ExtendedKey.MAINNET_PUBLIC if self.chain == Chain.MAIN else ExtendedKey.TESTNET_PUBLIC,
+            depth=len(path.split("/")) if len(path) > 0 else 0,
+            parent_fingerprint=fpr,
+            child_num=child,
+            chaincode=pubkey["chainCode"],
+            privkey=None,
+            pubkey=compress_public_key(pubkey["publicKey"]),
+        )
+        return xpub
 
     # Must return a hex string with the signed transaction
     # The tx must be in the combined unsigned transaction format

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -371,8 +371,7 @@ class LedgerClient(HardwareWalletClient):
     def prompt_pin(self) -> bool:
         raise UnavailableActionError('The Ledger Nano S and X do not need a PIN sent from the host')
 
-    # Send pin
-    def send_pin(self, pin):
+    def send_pin(self, pin: str) -> bool:
         raise UnavailableActionError('The Ledger Nano S and X do not need a PIN sent from the host')
 
     # Toggle passphrase

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -374,8 +374,7 @@ class LedgerClient(HardwareWalletClient):
     def send_pin(self, pin: str) -> bool:
         raise UnavailableActionError('The Ledger Nano S and X do not need a PIN sent from the host')
 
-    # Toggle passphrase
-    def toggle_passphrase(self):
+    def toggle_passphrase(self) -> bool:
         raise UnavailableActionError('The Ledger Nano S and X do not support toggling passphrase from the host')
 
 def enumerate(password=''):

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -361,8 +361,7 @@ class LedgerClient(HardwareWalletClient):
     def restore_device(self, label: str = "", word_count: int = 24) -> bool:
         raise UnavailableActionError('The Ledger Nano S and X do not support restoring via software')
 
-    # Begin backup process
-    def backup_device(self, label='', passphrase=''):
+    def backup_device(self, label: str = "", passphrase: str = "") -> bool:
         raise UnavailableActionError('The Ledger Nano S and X do not support creating a backup via software')
 
     # Close the device

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -358,8 +358,7 @@ class LedgerClient(HardwareWalletClient):
     def wipe_device(self) -> bool:
         raise UnavailableActionError('The Ledger Nano S and X do not support wiping via software')
 
-    # Restore device from mnemonic or xprv
-    def restore_device(self, label='', word_count=24):
+    def restore_device(self, label: str = "", word_count: int = 24) -> bool:
         raise UnavailableActionError('The Ledger Nano S and X do not support restoring via software')
 
     # Begin backup process

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -304,7 +304,7 @@ class LedgerClient(HardwareWalletClient):
         return tx
 
     @ledger_exception
-    def sign_message(self, message: Union[str, bytes], keypath: str) -> Dict[str, str]:
+    def sign_message(self, message: Union[str, bytes], keypath: str) -> str:
         if not check_keypath(keypath):
             raise BadArgumentError("Invalid keypath")
         if isinstance(message, str):
@@ -329,7 +329,7 @@ class LedgerClient(HardwareWalletClient):
 
         sig = bytearray(chr(27 + 4 + (signature[0] & 0x01)), 'utf8') + r + s
 
-        return {"signature": base64.b64encode(sig).decode('utf-8')}
+        return base64.b64encode(sig).decode('utf-8')
 
     @ledger_exception
     def display_singlesig_address(

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -351,19 +351,18 @@ class LedgerClient(HardwareWalletClient):
 
         return {"signature": base64.b64encode(sig).decode('utf-8')}
 
-    # Display address of specified type on the device. Only supports single-key based addresses.
     @ledger_exception
     def display_singlesig_address(
         self,
         keypath: str,
         addr_type: AddressType,
-    ) -> Dict[str, str]:
+    ) -> str:
         if not check_keypath(keypath):
             raise BadArgumentError("Invalid keypath")
         p2sh_p2wpkh = addr_type == AddressType.SH_WPKH
         bech32 = addr_type == AddressType.WPKH
         output = self.app.getWalletPublicKey(keypath[2:], True, p2sh_p2wpkh or bech32, bech32)
-        return {'address': output['address'][12:-2]} # HACK: A bug in getWalletPublicKey results in the address being returned as the string "bytearray(b'<address>')". This extracts the actual address to work around this.
+        return output['address'][12:-2] # HACK: A bug in getWalletPublicKey results in the address being returned as the string "bytearray(b'<address>')". This extracts the actual address to work around this.
 
     @ledger_exception
     def display_multisig_address(
@@ -371,7 +370,7 @@ class LedgerClient(HardwareWalletClient):
         threshold: int,
         pubkeys: List[PubkeyProvider],
         addr_type: AddressType,
-    ) -> Dict[str, str]:
+    ) -> str:
         raise BadArgumentError("The Ledger Nano S and X do not support P2SH address display")
 
     # Setup a new device

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -1,7 +1,6 @@
 # Ledger interaction script
 
 from typing import (
-    Dict,
     List,
     Union,
 )
@@ -357,8 +356,7 @@ class LedgerClient(HardwareWalletClient):
     def setup_device(self, label='', passphrase=''):
         raise UnavailableActionError('The Ledger Nano S and X do not support software setup')
 
-    # Wipe this device
-    def wipe_device(self):
+    def wipe_device(self) -> bool:
         raise UnavailableActionError('The Ledger Nano S and X do not support wiping via software')
 
     # Restore device from mnemonic or xprv

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -368,8 +368,7 @@ class LedgerClient(HardwareWalletClient):
     def close(self):
         self.dongle.close()
 
-    # Prompt pin
-    def prompt_pin(self):
+    def prompt_pin(self) -> bool:
         raise UnavailableActionError('The Ledger Nano S and X do not need a PIN sent from the host')
 
     # Send pin

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -36,12 +36,13 @@ from ..key import (
 )
 from ..serializations import (
     AddressType,
+    CTransaction,
     hash160,
     is_p2sh,
     is_p2wpkh,
     is_p2wsh,
     is_witness,
-    CTransaction,
+    PSBT,
 )
 import logging
 import re
@@ -160,11 +161,8 @@ class LedgerClient(HardwareWalletClient):
         )
         return xpub
 
-    # Must return a hex string with the signed transaction
-    # The tx must be in the combined unsigned transaction format
-    # Current only supports segwit signing
     @ledger_exception
-    def sign_tx(self, tx):
+    def sign_tx(self, tx: PSBT) -> PSBT:
         c_tx = CTransaction(tx.tx)
         tx_bytes = c_tx.serialize_with_witness()
 
@@ -303,7 +301,7 @@ class LedgerClient(HardwareWalletClient):
                     first_input = False
 
         # Send PSBT back
-        return {'psbt': tx.serialize()}
+        return tx
 
     @ledger_exception
     def sign_message(self, message: Union[str, bytes], keypath: str) -> Dict[str, str]:

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -601,16 +601,15 @@ class TrezorClient(HardwareWalletClient):
         device.wipe(self.client)
         return True
 
-    # Restore device from mnemonic or xprv
     @trezor_exception
-    def restore_device(self, label='', word_count=24):
+    def restore_device(self, label: str = "", word_count: int = 24) -> bool:
         self._prepare_device()
         if not self.simulator:
             # Use interactive_get_pin
             self.client.ui.get_pin = MethodType(interactive_get_pin, self.client.ui)
 
         device.recover(self.client, word_count=word_count, label=label, input_callback=mnemonic_words(), passphrase_protection=bool(self.password))
-        return {'success': True}
+        return True
 
     # Begin backup process
     def backup_device(self, label='', passphrase=''):

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -611,8 +611,7 @@ class TrezorClient(HardwareWalletClient):
         device.recover(self.client, word_count=word_count, label=label, input_callback=mnemonic_words(), passphrase_protection=bool(self.password))
         return True
 
-    # Begin backup process
-    def backup_device(self, label='', passphrase=''):
+    def backup_device(self, label: str = "", passphrase: str = "") -> bool:
         raise UnavailableActionError('The {} does not support creating a backup via software'.format(self.type))
 
     # Close the device

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -511,13 +511,12 @@ class TrezorClient(HardwareWalletClient):
         result = btc.sign_message(self.client, self.coin_name, path, message)
         return {'signature': base64.b64encode(result.signature).decode('utf-8')}
 
-    # Display address of specified type on the device.
     @trezor_exception
     def display_singlesig_address(
         self,
         keypath: str,
         addr_type: AddressType,
-    ) -> Dict[str, str]:
+    ) -> str:
         self._check_unlocked()
 
         # Script type
@@ -539,7 +538,7 @@ class TrezorClient(HardwareWalletClient):
                 script_type=script_type,
                 multisig=None,
             )
-            return {'address': address}
+            return address
         except Exception:
             pass
 
@@ -551,7 +550,7 @@ class TrezorClient(HardwareWalletClient):
         threshold: int,
         pubkeys: List[PubkeyProvider],
         addr_type: AddressType
-    ) -> Dict[str, str]:
+    ) -> str:
         self._check_unlocked()
 
         pubkey_objs = []
@@ -587,7 +586,7 @@ class TrezorClient(HardwareWalletClient):
                     script_type=script_type,
                     multisig=multisig,
                 )
-                return {"address": address}
+                return address
             except Exception:
                 pass
 

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -50,6 +50,7 @@ from ..serializations import (
     is_p2sh,
     is_p2wsh,
     is_witness,
+    PSBT,
     ser_uint256,
 )
 from ..common import Chain
@@ -266,10 +267,8 @@ class TrezorClient(HardwareWalletClient):
             xpub.version = ExtendedKey.TESTNET_PUBLIC
         return xpub
 
-    # Must return a hex string with the signed transaction
-    # The tx must be in the psbt format
     @trezor_exception
-    def sign_tx(self, tx):
+    def sign_tx(self, tx: PSBT) -> PSBT:
         self._check_unlocked()
 
         # Get this devices master key fingerprint
@@ -495,7 +494,7 @@ class TrezorClient(HardwareWalletClient):
 
             p += 1
 
-        return {'psbt': tx.serialize()}
+        return tx
 
     @trezor_exception
     def sign_message(self, message: Union[str, bytes], keypath: str) -> Dict[str, str]:

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -649,9 +649,8 @@ class TrezorClient(HardwareWalletClient):
             return False
         return True
 
-    # Toggle passphrase
     @trezor_exception
-    def toggle_passphrase(self):
+    def toggle_passphrase(self) -> bool:
         self._check_unlocked()
         try:
             device.apply_settings(self.client, use_passphrase=not self.client.features.passphrase_protection)
@@ -660,7 +659,7 @@ class TrezorClient(HardwareWalletClient):
                 print('Confirm the action by entering your PIN', file=sys.stderr)
                 print('Use \'sendpin\' to provide the number positions for the PIN as displayed on your device\'s screen', file=sys.stderr)
                 print(PIN_MATRIX_DESCRIPTION, file=sys.stderr)
-        return {'success': True}
+        return True
 
 def enumerate(password=''):
     results = []

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -633,9 +633,8 @@ class TrezorClient(HardwareWalletClient):
         self.client.call_raw(messages.GetPublicKey(address_n=[0x8000002c, 0x80000001, 0x80000000], ecdsa_curve_name=None, show_display=False, coin_name=self.coin_name, script_type=messages.InputScriptType.SPENDADDRESS))
         return True
 
-    # Send the pin
     @trezor_exception
-    def send_pin(self, pin):
+    def send_pin(self, pin: str) -> bool:
         self.client.open()
         if not pin.isdigit():
             raise BadArgumentError("Non-numeric PIN provided")
@@ -647,8 +646,8 @@ class TrezorClient(HardwareWalletClient):
                     raise DeviceAlreadyUnlockedError('This device does not need a PIN')
                 if self.client.features.unlocked:
                     raise DeviceAlreadyUnlockedError('The PIN has already been sent to this device')
-            return {'success': False}
-        return {'success': True}
+            return False
+        return True
 
     # Toggle passphrase
     @trezor_exception

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -619,9 +619,8 @@ class TrezorClient(HardwareWalletClient):
     def close(self):
         self.client.close()
 
-    # Prompt for a pin on device
     @trezor_exception
-    def prompt_pin(self):
+    def prompt_pin(self) -> bool:
         self.coin_name = 'Bitcoin' if self.chain == Chain.MAIN else 'Testnet'
         self.client.open()
         self._prepare_device()
@@ -632,7 +631,7 @@ class TrezorClient(HardwareWalletClient):
         print('Use \'sendpin\' to provide the number positions for the PIN as displayed on your device\'s screen', file=sys.stderr)
         print(PIN_MATRIX_DESCRIPTION, file=sys.stderr)
         self.client.call_raw(messages.GetPublicKey(address_n=[0x8000002c, 0x80000001, 0x80000000], ecdsa_curve_name=None, show_display=False, coin_name=self.coin_name, script_type=messages.InputScriptType.SPENDADDRESS))
-        return {'success': True}
+        return True
 
     # Send the pin
     @trezor_exception

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -497,11 +497,11 @@ class TrezorClient(HardwareWalletClient):
         return tx
 
     @trezor_exception
-    def sign_message(self, message: Union[str, bytes], keypath: str) -> Dict[str, str]:
+    def sign_message(self, message: Union[str, bytes], keypath: str) -> str:
         self._check_unlocked()
         path = parse_path(keypath)
         result = btc.sign_message(self.client, self.coin_name, path, message)
-        return {'signature': base64.b64encode(result.signature).decode('utf-8')}
+        return base64.b64encode(result.signature).decode('utf-8')
 
     @trezor_exception
     def display_singlesig_address(

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -583,9 +583,8 @@ class TrezorClient(HardwareWalletClient):
 
         raise BadArgumentError("No path supplied matched device keys")
 
-    # Setup a new device
     @trezor_exception
-    def setup_device(self, label='', passphrase=''):
+    def setup_device(self, label: str = "", passphrase: str = "") -> bool:
         self._prepare_device()
         if not self.simulator:
             # Use interactive_get_pin
@@ -594,7 +593,7 @@ class TrezorClient(HardwareWalletClient):
         if self.client.features.initialized:
             raise DeviceAlreadyInitError('Device is already initialized. Use wipe first and try again')
         device.reset(self.client, passphrase_protection=bool(self.password))
-        return {'success': True}
+        return True
 
     @trezor_exception
     def wipe_device(self) -> bool:

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -1,7 +1,6 @@
 # Trezor interaction script
 
 from typing import (
-    Dict,
     List,
     Union,
 )
@@ -597,12 +596,11 @@ class TrezorClient(HardwareWalletClient):
         device.reset(self.client, passphrase_protection=bool(self.password))
         return {'success': True}
 
-    # Wipe this device
     @trezor_exception
-    def wipe_device(self):
+    def wipe_device(self) -> bool:
         self._check_unlocked()
         device.wipe(self.client)
-        return {'success': True}
+        return True
 
     # Restore device from mnemonic or xprv
     @trezor_exception

--- a/hwilib/errors.py
+++ b/hwilib/errors.py
@@ -91,6 +91,10 @@ class DeviceBusyError(HWWError):
     def __init__(self, msg: str):
         HWWError.__init__(self, msg, DEVICE_BUSY)
 
+class NeedsRootError(HWWError):
+    def __init__(self, msg: str):
+        HWWError.__init__(self, msg, NEED_TO_BE_ROOT)
+
 @contextmanager
 def handle_errors(
     msg: Optional[str] = None,

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -119,14 +119,12 @@ class HardwareWalletClient(object):
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")
 
-    def wipe_device(self) -> Dict[str, Union[bool, str, int]]:
-        """Wipe the HID device.
+    def wipe_device(self) -> bool:
+        """
+        Wipe the device.
 
-        Must return a dictionary with the "success" key,
-        possibly including also "error" and "code", e.g.:
-        {"success": bool, "error": srt, "code": int}.
-
-        Raise UnavailableActionError if appropriate for the device.
+        :return: Whether the wipe was successful
+        :raises UnavailableActionError: if appropriate for the device.
         """
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -190,14 +190,12 @@ class HardwareWalletClient(object):
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")
 
-    def toggle_passphrase(self) -> Dict[str, Union[bool, str, int]]:
-        """Toggle passphrase.
+    def toggle_passphrase(self) -> bool:
+        """
+        Toggle passphrase.
 
-        Must return a dictionary with the "success" key,
-        possibly including also "error" and "code", e.g.:
-        {"success": bool, "error": srt, "code": int}.
-
-        Raise UnavailableActionError if appropriate for the device.
+        :return: Whether the passphrase was successfully toggled
+        :raises UnavailableActionError: if appropriate for the device.
         """
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -72,16 +72,16 @@ class HardwareWalletClient(object):
 
     def sign_message(
         self, message: Union[str, bytes], bip32_path: str
-    ) -> Dict[str, str]:
-        """Sign a message (bitcoin message signing).
+    ) -> str:
+        """
+        Sign a message (bitcoin message signing).
 
-        Sign the message according to the bitcoin message signing standard:
-        usually, the message is a string that is encoded to bytes;
-        anyway, if the message is already bytes it is processed untouched.
+        Signs a message using the legacy Bitcoin Core signed message format.
+        The message is signed with the key at the given path.
 
-        Retrieve the signing key at the specified BIP32 derivation path.
-
-        Return {"signature": <base64 signature string>}.
+        :param message: The message to be signed. First encoded as bytes if not already.
+        :param bip32_path: The BIP 32 derivation for the key to sign the message with.
+        :return: The signature
         """
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -60,10 +60,12 @@ class HardwareWalletClient(object):
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")
 
-    def sign_tx(self, psbt: PSBT) -> Dict[str, str]:
-        """Sign a partially signed bitcoin transaction (PSBT).
+    def sign_tx(self, psbt: PSBT) -> PSBT:
+        """
+        Sign a partially signed bitcoin transaction (PSBT).
 
-        Return {"psbt": <base64 psbt string>}.
+        :param psbt: The PSBT to sign
+        :return: The PSBT after being processed by the hardware wallet
         """
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -143,14 +143,12 @@ class HardwareWalletClient(object):
 
     def restore_device(
         self, label: str = "", word_count: int = 24
-    ) -> Dict[str, Union[bool, str, int]]:
-        """Restore the HID device from mnemonic.
+    ) -> bool:
+        """
+        Restore the device.
 
-        Must return a dictionary with the "success" key,
-        possibly including also "error" and "code", e.g.:
-        {"success": bool, "error": srt, "code": int}.
-
-        Raise UnavailableActionError if appropriate for the device.
+        :return: Whether the restore was successful
+        :raises UnavailableActionError: if appropriate for the device.
         """
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -170,14 +170,12 @@ class HardwareWalletClient(object):
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")
 
-    def prompt_pin(self) -> Dict[str, Union[bool, str, int]]:
-        """Prompt for PIN.
+    def prompt_pin(self) -> bool:
+        """
+        Prompt for PIN.
 
-        Must return a dictionary with the "success" key,
-        possibly including also "error" and "code", e.g.:
-        {"success": bool, "error": srt, "code": int}.
-
-        Raise UnavailableActionError if appropriate for the device.
+        :return: Whether the PIN prompt was successful
+        :raises UnavailableActionError: if appropriate for the device.
         """
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -81,12 +81,14 @@ class HardwareWalletClient(object):
         self,
         bip32_path: str,
         addr_type: AddressType,
-    ) -> Dict[str, str]:
-        """Display and return the single sig address of specified type.
+    ) -> str:
+        """
+        Display and return the single sig address of specified type
+        at the given derivation path.
 
-        Retrieve the public key at the specified BIP32 derivation path.
-
-        Return {"address": <base58 or bech32 address string>}.
+        :param bip32_path: The BIP 32 derivation path to get the address for
+        :param addr_type: The address type
+        :return: The retrieved address also being shown by the device
         """
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")
@@ -96,10 +98,14 @@ class HardwareWalletClient(object):
         threshold: int,
         pubkeys: List[PubkeyProvider],
         addr_type: AddressType,
-    ) -> Dict[str, str]:
-        """Display and return the multisig address of specified type given the threshold and pubkeys.
+    ) -> str:
+        """
+        Display and return the multisig address of specified type given the threshold and pubkeys.
 
-        Return {"address": <base58 or bech32 address string>}.
+        :param threshold: The number of signers required in the multisig
+        :param pubkeys: The public keys, as found in a descriptor, in the multisig
+        :param addr_type: The address type
+        :return: The retrieved address also being shown by the device
         """
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -180,14 +180,12 @@ class HardwareWalletClient(object):
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")
 
-    def send_pin(self, pin: str) -> Dict[str, Union[bool, str, int]]:
-        """Send PIN.
+    def send_pin(self, pin: str) -> bool:
+        """
+        Send PIN.
 
-        Must return a dictionary with the "success" key,
-        possibly including also "error" and "code", e.g.:
-        {"success": bool, "error": srt, "code": int}.
-
-        Raise UnavailableActionError if appropriate for the device.
+        :return: Whether the PIN successfully unlocked the device
+        :raises UnavailableActionError: if appropriate for the device.
         """
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -4,8 +4,8 @@ from typing import (
     Optional,
     Union,
 )
-from .base58 import get_xpub_fingerprint_hex
 from .descriptor import PubkeyProvider
+from .key import ExtendedKey
 from .serializations import AddressType, PSBT
 from .common import Chain
 
@@ -27,28 +27,35 @@ class HardwareWalletClient(object):
         self.xpub_cache: Dict[str, str] = {}
         self.expert = expert
 
-    def get_master_xpub(self) -> Dict[str, str]:
-        """Return the master BIP44 public key.
+    def get_master_xpub(self) -> ExtendedKey:
+        """
+        Get the master BIP 44 public key.
 
-        Retrieve the public key at the "m/44h/0h/0h" derivation path.
+        Retrieves the public key at the "m/44h/0h/0h" derivation path.
 
-        Return {"xpub": <xpub string>}.
+        :return: The extended public key at "m/44h/0h/0h"
         """
         # FIXME testnet is not handled yet
         return self.get_pubkey_at_path("m/44h/0h/0h")
 
     def get_master_fingerprint_hex(self) -> str:
-        """Return the master public key fingerprint as hex-string.
-
-        Retrieve the master public key at the "m/0h" derivation path.
         """
-        master_xpub = self.get_pubkey_at_path("m/0h")["xpub"]
-        return get_xpub_fingerprint_hex(master_xpub)
+        Get the master public key fingerprint as a hex string.
 
-    def get_pubkey_at_path(self, bip32_path: str) -> Dict[str, str]:
-        """Return the public key at the BIP32 derivation path.
+        Retrieves the fingerprint of the master public key of a device.
+        Typically implemented by fetching the extended public key at "m/0h"
+        and extracting the parent fingerprint from it.
 
-        Return {"xpub": <xpub string>}.
+        :return: The fingerprint as a hex string
+        """
+        return self.get_pubkey_at_path("m/0h").parent_fingerprint.hex()
+
+    def get_pubkey_at_path(self, bip32_path: str) -> ExtendedKey:
+        """
+        Get the public key at the BIP 32 derivation path.
+
+        :param bip32_path: The BIP 32 derivation path
+        :return: The extended public key
         """
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -155,14 +155,12 @@ class HardwareWalletClient(object):
 
     def backup_device(
         self, label: str = "", passphrase: str = ""
-    ) -> Dict[str, Union[bool, str, int]]:
-        """Backup the HID device.
+    ) -> bool:
+        """
+        Backup the device.
 
-        Must return a dictionary with the "success" key,
-        possibly including also "error" and "code", e.g.:
-        {"success": bool, "error": srt, "code": int}.
-
-        Raise UnavailableActionError if appropriate for the device.
+        :return: Whether the backup was successful
+        :raises UnavailableActionError: if appropriate for the device.
         """
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -131,14 +131,12 @@ class HardwareWalletClient(object):
 
     def setup_device(
         self, label: str = "", passphrase: str = ""
-    ) -> Dict[str, Union[bool, str, int]]:
-        """Setup the HID device.
+    ) -> bool:
+        """
+        Setup the device.
 
-        Must return a dictionary with the "success" key,
-        possibly including also "error" and "code", e.g.:
-        {"success": bool, "error": str, "code": int}.
-
-        Raise UnavailableActionError if appropriate for the device.
+        :return: Whether the setup was successful
+        :raises UnavailableActionError: if appropriate for the device.
         """
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")

--- a/hwilib/udevinstaller.py
+++ b/hwilib/udevinstaller.py
@@ -1,11 +1,12 @@
+from .errors import NeedsRootError
+
 from subprocess import check_call, CalledProcessError, DEVNULL
-from .errors import NEED_TO_BE_ROOT
 from shutil import copy
 from os import path, listdir, getlogin, geteuid
 
 class UDevInstaller(object):
     @staticmethod
-    def install(source, location):
+    def install(source: str, location: str) -> bool:
         try:
             udev_installer = UDevInstaller()
             udev_installer.copy_udev_rule_files(source, location)
@@ -14,9 +15,9 @@ class UDevInstaller(object):
             udev_installer.add_user_plugdev_group()
         except CalledProcessError:
             if geteuid() != 0:
-                return {'error': 'Need to be root.', 'code': NEED_TO_BE_ROOT}
+                raise NeedsRootError("Need to be root.")
             raise
-        return {"success": True}
+        return True
 
     def __init__(self):
         self._udevadm = '/sbin/udevadm'

--- a/test/test_coldcard.py
+++ b/test/test_coldcard.py
@@ -2,6 +2,7 @@
 
 import argparse
 import atexit
+import glob
 import os
 import signal
 import subprocess
@@ -69,9 +70,8 @@ def coldcard_test_suite(simulator, rpc, userpass, interface):
         def test_backup(self):
             result = self.do_command(self.dev_args + ['backup'])
             self.assertTrue(result['success'])
-            self.assertIn('The backup has been written to', result['message'])
-            backup_filename = result['message'].split(' ')[-1]
-            os.remove(backup_filename)
+            for filename in glob.glob("backup-*.7z"):
+                os.remove(filename)
 
         def test_pin(self):
             result = self.do_command(self.dev_args + ['promptpin'])

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -186,7 +186,7 @@ class TestKeepkeyManCommands(KeepkeyTestCase):
         t_client.client.ui.get_pin = MethodType(get_pin, t_client.client.ui)
         t_client.client.ui.pin = '1234'
         result = t_client.setup_device()
-        self.assertTrue(result['success'])
+        self.assertTrue(result)
 
         # Make sure device is init, setup should fail
         result = self.do_command(self.dev_args + ['-i', 'setup'])

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -230,7 +230,7 @@ class TestKeepkeyManCommands(KeepkeyTestCase):
         self.assertEqual(result['code'], -7)
 
         result = self.do_command(self.dev_args + ['sendpin', '00000'])
-        self.assertFalse(result['success'])
+        self.assertFalse(result["success"])
 
         # Make sure we get a needs pin message
         result = self.do_command(self.dev_args + ['getxpub', 'm/0h'])

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -188,7 +188,7 @@ class TestTrezorManCommands(TrezorTestCase):
         t_client.client.ui.get_pin = MethodType(get_pin, t_client.client.ui)
         t_client.client.ui.pin = '1234'
         result = t_client.setup_device()
-        self.assertTrue(result['success'])
+        self.assertTrue(result)
 
         # Make sure device is init, setup should fail
         result = self.do_command(self.dev_args + ['-i', 'setup'])


### PR DESCRIPTION
For the functions in HardwareWalletClient, it doesn't quite make sense to have it return the dictionary that for cli output. Instead they should return the correct objects and types, which the caller can convert to the dictionary for cli output.