### PR TITLE
Type check (almost) everything

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -128,14 +128,26 @@ basic_test_task:
     - name: Type Check
       type_check_script: >
         poetry run
-        mypy --implicit-reexport --strict
+        mypy
+        hwi.py
         hwilib/base58.py
-        hwilib/errors.py
-        hwilib/serializations.py
-        hwilib/hwwclient.py
-        hwilib/devices/bitbox02.py
-        hwilib/key.py
+        hwilib/bech32.py
+        hwilib/cli.py
+        hwilib/commands.py
         hwilib/descriptor.py
+        hwilib/devices/bitbox02.py
+        hwilib/devices/coldcard.py
+        hwilib/devices/digitalbitbox.py
+        hwilib/devices/__init__.py
+        hwilib/devices/keepkey.py
+        hwilib/devices/ledger.py
+        hwilib/devices/trezor.py
+        hwilib/errors.py
+        hwilib/hwwclient.py
+        hwilib/__init__.py
+        hwilib/key.py
+        hwilib/serializations.py
+        hwilib/udevinstaller.py
     - name: Non-Device Tests
       test_script: cd test; poetry run ./run_tests.py; cd ..
 

--- a/hwilib/cli.py
+++ b/hwilib/cli.py
@@ -27,19 +27,27 @@ from .errors import (
     HELP_TEXT,
     MISSING_ARGUMENTS,
     NO_DEVICE_TYPE,
-    UNAVAILABLE_ACTION,
+    UnavailableActionError,
+    UNKNOWN_ERROR,
 )
 from .hwwclient import HardwareWalletClient
 from .serializations import AddressType
 from . import __version__
-
-from typing import Dict
 
 import argparse
 import getpass
 import logging
 import json
 import sys
+
+from typing import (
+    Any,
+    Dict,
+    IO,
+    List,
+    NoReturn,
+    Optional,
+)
 
 
 def backup_device_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, bool]:
@@ -48,7 +56,7 @@ def backup_device_handler(args: argparse.Namespace, client: HardwareWalletClient
 def displayaddress_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, str]:
     return displayaddress(client, desc=args.desc, path=args.path, addr_type=args.addr_type)
 
-def enumerate_handler(args):
+def enumerate_handler(args: argparse.Namespace) -> List[Dict[str, Any]]:
     return enumerate(password=args.password)
 
 def getmasterxpub_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, str]:
@@ -57,21 +65,21 @@ def getmasterxpub_handler(args: argparse.Namespace, client: HardwareWalletClient
 def getxpub_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, str]:
     return getxpub(client, path=args.path, expert=args.expert)
 
-def getkeypool_handler(args, client):
+def getkeypool_handler(args: argparse.Namespace, client: HardwareWalletClient) -> List[Dict[str, Any]]:
     return getkeypool(client, path=args.path, start=args.start, end=args.end, internal=args.internal, keypool=args.keypool, account=args.account, addr_type=args.addr_type, addr_all=args.all)
 
-def getdescriptors_handler(args, client):
+def getdescriptors_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, List[str]]:
     return getdescriptors(client, account=args.account)
 
 def restore_device_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, bool]:
     if args.interactive:
         return restore_device(client, label=args.label, word_count=args.word_count)
-    return {'error': 'restore requires interactive mode', 'code': UNAVAILABLE_ACTION}
+    raise UnavailableActionError("restore requires interactive mode")
 
 def setup_device_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, bool]:
     if args.interactive:
         return setup_device(client, label=args.label, backup_passphrase=args.backup_passphrase)
-    return {'error': 'setup requires interactive mode', 'code': UNAVAILABLE_ACTION}
+    raise UnavailableActionError("setup requires interactive mode")
 
 def signmessage_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, str]:
     return signmessage(client, message=args.message, path=args.path)
@@ -98,36 +106,36 @@ class HWIHelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescr
     pass
 
 class HWIArgumentParser(argparse.ArgumentParser):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.formatter_class = HWIHelpFormatter
 
-    def print_usage(self, file=None):
+    def print_usage(self, file: Optional[IO[str]] = None) -> None:
         if file is None:
             file = sys.stderr
         super().print_usage(file)
 
-    def print_help(self, file=None):
+    def print_help(self, file: Optional[IO[str]] = None) -> None:
         if file is None:
             file = sys.stderr
         super().print_help(file)
         error = {'error': 'Help text requested', 'code': HELP_TEXT}
         print(json.dumps(error))
 
-    def error(self, message):
+    def error(self, message: str) -> NoReturn:
         self.print_usage(sys.stderr)
         args = {'prog': self.prog, 'message': message}
         error = {'error': '%(prog)s: error: %(message)s' % args, 'code': MISSING_ARGUMENTS}
         print(json.dumps(error))
         self.exit(2)
 
-def process_commands(cli_args):
+def process_commands(cli_args: List[str]) -> Any:
     parser = HWIArgumentParser(description='Hardware Wallet Interface, version {}.\nAccess and send commands to a hardware wallet device. Responses are in JSON format.'.format(__version__))
     parser.add_argument('--device-path', '-d', help='Specify the device path of the device to connect to')
     parser.add_argument('--device-type', '-t', help='Specify the type of device that will be connected. If `--device-path` not given, the first device of this type enumerated is used.')
     parser.add_argument('--password', '-p', help='Device password if it has one (e.g. DigitalBitbox)', default='')
     parser.add_argument('--stdinpass', help='Enter the device password on the command line', action='store_true')
-    parser.add_argument('--chain', help='Select chain to work with', type=Chain.argparse, choices=list(Chain), default=Chain.MAIN)
+    parser.add_argument('--chain', help='Select chain to work with', type=Chain.argparse, choices=list(Chain), default=Chain.MAIN) # type: ignore
     parser.add_argument('--debug', help='Print debug statements', action='store_true')
     parser.add_argument('--fingerprint', '-f', help='Specify the device to connect to using the first 4 bytes of the hash160 of the master public key. It will connect to the first device that matches this fingerprint.')
     parser.add_argument('--version', action='version', version='%(prog)s {}'.format(__version__))
@@ -164,7 +172,7 @@ def process_commands(cli_args):
     kparg_group.add_argument('--nokeypool', action='store_false', dest='keypool', help='Indicates that the keys are not to be imported to the keypool', default=False)
     getkeypool_parser.add_argument('--internal', action='store_true', help='Indicates that the keys are change keys')
     kp_type_group = getkeypool_parser.add_mutually_exclusive_group()
-    kp_type_group.add_argument("--addr-type", help="The address type (and default derivation path) to produce descriptors for", type=AddressType.argparse, choices=list(AddressType), default=AddressType.PKH)
+    kp_type_group.add_argument("--addr-type", help="The address type (and default derivation path) to produce descriptors for", type=AddressType.argparse, choices=list(AddressType), default=AddressType.PKH) # type: ignore
     kp_type_group.add_argument('--all', action='store_true', help='Generate addresses for all standard address types (default paths: m/{44,49,84}h/0h/0h/[0,1]/*)')
     getkeypool_parser.add_argument('--account', help='BIP43 account', type=int, default=0)
     getkeypool_parser.add_argument('--path', help='Derivation path, default follows BIP43 convention, e.g. m/84h/0h/0h/1/* with --addr-type wpkh --internal. If this argument and --internal is not given, both internal and external keypools will be returned.')
@@ -180,7 +188,7 @@ def process_commands(cli_args):
     group = displayaddr_parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--desc', help='Output Descriptor. E.g. wpkh([00000000/84h/0h/0h]xpub.../0/0), where 00000000 must match --fingerprint and xpub can be obtained with getxpub. See doc/descriptors.md in Bitcoin Core')
     group.add_argument('--path', help='The BIP 32 derivation path of the key embedded in the address, default follows BIP43 convention, e.g. m/84h/0h/0h/1/*')
-    displayaddr_parser.add_argument("--addr-type", help="The address type to display", type=AddressType.argparse, choices=list(AddressType), default=AddressType.PKH)
+    displayaddr_parser.add_argument("--addr-type", help="The address type to display", type=AddressType.argparse, choices=list(AddressType), default=AddressType.PKH) # type: ignore
     displayaddr_parser.set_defaults(func=displayaddress_handler)
 
     setupdev_parser = subparsers.add_parser('setup', help='Setup a device. Passphrase protection uses the password given by -p. Requires interactive mode')
@@ -237,7 +245,7 @@ def process_commands(cli_args):
     device_type = args.device_type
     password = args.password
     command = args.command
-    result = {}
+    result: Dict[str, Any] = {}
 
     # Setup debug logging
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.WARNING)
@@ -270,6 +278,9 @@ def process_commands(cli_args):
     else:
         return {'error': 'You must specify a device type or fingerprint for all commands except enumerate', 'code': NO_DEVICE_TYPE}
 
+    if client is None:
+        return {"error": "Unable to communicated with device", "code": UNKNOWN_ERROR}
+
     client.chain = args.chain
 
     # Do the commands
@@ -281,6 +292,6 @@ def process_commands(cli_args):
 
     return result
 
-def main():
+def main() -> None:
     result = process_commands(sys.argv[1:])
     print(json.dumps(result))

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -47,7 +47,7 @@ from ..key import (
 )
 from ..common import Chain
 
-import hid  # type: ignore
+import hid
 
 from bitbox02 import util
 from bitbox02 import bitbox02

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -20,7 +20,12 @@ from .trezorlib.messages import (
     ResetDevice,
 )
 
-from typing import Dict
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
 
 py_enumerate = enumerate # Need to use the enumerate built-in but there's another function already named that
 
@@ -31,20 +36,20 @@ HID_IDS.update(KEEPKEY_HID_IDS)
 WEBUSB_IDS.update(KEEPKEY_WEBUSB_IDS)
 
 
-class KeepkeyFeatures(Features):
+class KeepkeyFeatures(Features): # type: ignore
     def __init__(
         self,
         *,
-        firmware_variant: str = None,
-        firmware_hash: bytes = None,
-        **kwargs,
+        firmware_variant: Optional[str] = None,
+        firmware_hash: Optional[bytes] = None,
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.firmware_variant = firmware_variant
         self.firmware_hash = firmware_hash
 
     @classmethod
-    def get_fields(cls) -> Dict:
+    def get_fields(cls) -> Dict[int, p.FieldInfo]:
         return {
             1: ('vendor', p.UnicodeType, None),
             2: ('major_version', p.UVarintType, None),
@@ -69,18 +74,18 @@ class KeepkeyFeatures(Features):
         }
 
 
-class KeepkeyResetDevice(ResetDevice):
+class KeepkeyResetDevice(ResetDevice): # type: ignore
     def __init__(
         self,
         *,
-        auto_lock_delay_ms: int = None,
-        **kwargs,
+        auto_lock_delay_ms: Optional[int] = None,
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.auto_lock_delay_ms = auto_lock_delay_ms
 
     @classmethod
-    def get_fields(cls) -> Dict:
+    def get_fields(cls) -> Dict[int, p.FieldInfo]:
         return {
             1: ('display_random', p.BoolType, None),
             2: ('strength', p.UVarintType, 256),  # default=256
@@ -94,15 +99,15 @@ class KeepkeyResetDevice(ResetDevice):
         }
 
 
-class KeepkeyDebugLinkState(DebugLinkState):
+class KeepkeyDebugLinkState(DebugLinkState): # type: ignore
     def __init__(
         self,
         *,
-        recovery_cipher: str = None,
-        recovery_auto_completed_word: str = None,
-        firmware_hash: bytes = None,
-        storage_hash: bytes = None,
-        **kwargs,
+        recovery_cipher: Optional[str] = None,
+        recovery_auto_completed_word: Optional[str] = None,
+        firmware_hash: Optional[bytes] = None,
+        storage_hash: Optional[bytes] = None,
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.recovery_cipher = recovery_cipher
@@ -111,7 +116,7 @@ class KeepkeyDebugLinkState(DebugLinkState):
         self.storage_hash = storage_hash
 
     @classmethod
-    def get_fields(cls) -> Dict:
+    def get_fields(cls) -> Dict[int, p.FieldType]:
         return {
             1: ('layout', p.BytesType, None),
             2: ('pin', p.UnicodeType, None),
@@ -131,7 +136,7 @@ class KeepkeyDebugLinkState(DebugLinkState):
 
 
 class KeepkeyClient(TrezorClient):
-    def __init__(self, path, password='', expert=False):
+    def __init__(self, path: str, password: str = "", expert: bool = False) -> None:
         super(KeepkeyClient, self).__init__(path, password, expert)
         self.type = 'Keepkey'
         self.client.vendors = ("keepkey.com")
@@ -142,13 +147,13 @@ class KeepkeyClient(TrezorClient):
             self.client.debug.map_type_to_class_override[KeepkeyDebugLinkState.MESSAGE_WIRE_TYPE] = KeepkeyDebugLinkState
 
 
-def enumerate(password=''):
+def enumerate(password: str = "") -> List[Dict[str, Any]]:
     results = []
     devs = hid.HidTransport.enumerate(usb_ids=KEEPKEY_HID_IDS)
     devs.extend(webusb.WebUsbTransport.enumerate(usb_ids=KEEPKEY_WEBUSB_IDS))
     devs.extend(udp.UdpTransport.enumerate())
     for dev in devs:
-        d_data = {}
+        d_data: Dict[str, Any] = {}
 
         d_data['type'] = 'keepkey'
         d_data['model'] = 'keepkey'

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -1,8 +1,12 @@
 # Ledger interaction script
 
 from typing import (
+    Any,
+    Callable,
+    Dict,
     List,
     Union,
+    Tuple,
 )
 
 from ..descriptor import PubkeyProvider
@@ -59,7 +63,7 @@ LEDGER_LEGACY_PRODUCT_IDS = {
 }
 
 # minimal checking of string keypath
-def check_keypath(key_path):
+def check_keypath(key_path: str) -> bool:
     parts = re.split("/", key_path)
     if parts[0] != "m":
         return False
@@ -84,8 +88,8 @@ cancels = [
     0x6985, # BTCHIP_SW_CONDITIONS_OF_USE_NOT_SATISFIED
 ]
 
-def ledger_exception(f):
-    def func(*args, **kwargs):
+def ledger_exception(f: Callable[..., Any]) -> Any:
+    def func(*args: Any, **kwargs: Any) -> Any:
         try:
             return f(*args, **kwargs)
         except ValueError as e:
@@ -106,7 +110,7 @@ def ledger_exception(f):
 # This class extends the HardwareWalletClient for Ledger Nano S and Nano X specific things
 class LedgerClient(HardwareWalletClient):
 
-    def __init__(self, path, password='', expert=False):
+    def __init__(self, path: str, password: str = "", expert: bool = False) -> None:
         super(LedgerClient, self).__init__(path, password, expert)
 
         if path.startswith('tcp'):
@@ -147,7 +151,7 @@ class LedgerClient(HardwareWalletClient):
         # Special case for m
         else:
             child = 0
-            fpr = child
+            fpr = b"\x00\x00\x00\x00"
 
         xpub = ExtendedKey(
             version=ExtendedKey.MAINNET_PUBLIC if self.chain == Chain.MAIN else ExtendedKey.TESTNET_PUBLIC,
@@ -168,7 +172,7 @@ class LedgerClient(HardwareWalletClient):
         # Master key fingerprint
         master_fpr = hash160(compress_public_key(self.app.getWalletPublicKey('')["publicKey"]))[:4]
         # An entry per input, each with 0 to many keys to sign with
-        all_signature_attempts = [[]] * len(c_tx.vin)
+        all_signature_attempts: List[List[Tuple[str, bytes]]] = [[]] * len(c_tx.vin)
 
         # Get the app version to determine whether to use Trusted Input for segwit
         version = self.app.getFirmwareVersion()
@@ -184,7 +188,7 @@ class LedgerClient(HardwareWalletClient):
         has_segwit = False
         has_legacy = False
 
-        script_codes = [[]] * len(c_tx.vin)
+        script_codes: List[bytes] = [b""] * len(c_tx.vin)
 
         # Detect changepath, (p2sh-)p2(w)pkh only
         change_path = ''
@@ -203,11 +207,7 @@ class LedgerClient(HardwareWalletClient):
 
         for txin, psbt_in, i_num in zip(c_tx.vin, tx.inputs, range(len(c_tx.vin))):
 
-            seq = format(txin.nSequence, 'x')
-            seq = seq.zfill(8)
-            seq = bytearray.fromhex(seq)
-            seq.reverse()
-            seq_hex = ''.join('{:02x}'.format(x) for x in seq)
+            seq_hex = txin.nSequence.to_bytes(4, byteorder="little").hex()
 
             scriptcode = b""
             utxo = None
@@ -243,6 +243,7 @@ class LedgerClient(HardwareWalletClient):
             else:
                 # We only need legacy inputs in the case where all inputs are legacy, we check
                 # later
+                assert psbt_in.non_witness_utxo is not None
                 ledger_prevtx = bitcoinTransaction(psbt_in.non_witness_utxo.serialize())
                 legacy_inputs.append(self.app.getTrustedInput(ledger_prevtx, txin.prevout.n))
                 legacy_inputs[-1]["sequence"] = seq_hex
@@ -269,7 +270,7 @@ class LedgerClient(HardwareWalletClient):
                 if master_fpr == keypath.fingerprint:
                     # Add the keypath strings
                     keypath_str = keypath.get_derivation_path()[2:] # Drop the leading m/
-                    signature_attempts.append([keypath_str, pubkey])
+                    signature_attempts.append((keypath_str, pubkey))
 
             all_signature_attempts[i_num] = signature_attempts
 
@@ -341,6 +342,7 @@ class LedgerClient(HardwareWalletClient):
         p2sh_p2wpkh = addr_type == AddressType.SH_WPKH
         bech32 = addr_type == AddressType.WPKH
         output = self.app.getWalletPublicKey(keypath[2:], True, p2sh_p2wpkh or bech32, bech32)
+        assert isinstance(output["address"], str)
         return output['address'][12:-2] # HACK: A bug in getWalletPublicKey results in the address being returned as the string "bytearray(b'<address>')". This extracts the actual address to work around this.
 
     @ledger_exception
@@ -364,8 +366,7 @@ class LedgerClient(HardwareWalletClient):
     def backup_device(self, label: str = "", passphrase: str = "") -> bool:
         raise UnavailableActionError('The Ledger Nano S and X do not support creating a backup via software')
 
-    # Close the device
-    def close(self):
+    def close(self) -> None:
         self.dongle.close()
 
     def prompt_pin(self) -> bool:
@@ -377,7 +378,7 @@ class LedgerClient(HardwareWalletClient):
     def toggle_passphrase(self) -> bool:
         raise UnavailableActionError('The Ledger Nano S and X do not support toggling passphrase from the host')
 
-def enumerate(password=''):
+def enumerate(password: str = '') -> List[Dict[str, Any]]:
     results = []
     devices = []
     devices.extend(hid.enumerate(LEDGER_VENDOR_ID, 0))
@@ -386,7 +387,7 @@ def enumerate(password=''):
     for d in devices:
         if ('interface_number' in d and d['interface_number'] == 0
                 or ('usage_page' in d and d['usage_page'] == 0xffa0)):
-            d_data = {}
+            d_data: Dict[str, Any] = {}
 
             path = d['path'].decode()
             d_data['type'] = 'ledger'

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -1,7 +1,14 @@
 # Trezor interaction script
 
 from typing import (
+    Any,
+    Callable,
+    Dict,
     List,
+    NoReturn,
+    Optional,
+    Sequence,
+    Tuple,
     Union,
 )
 from ..descriptor import PubkeyProvider
@@ -72,8 +79,11 @@ Use the numeric keypad to describe number positions. The layout is:
     1 2 3
 """.strip()
 
+Device = Union[hid.HidTransport, webusb.WebUsbTransport, udp.UdpTransport]
+
+
 # Only handles up to 15 of 15
-def parse_multisig(script):
+def parse_multisig(script: bytes) -> Tuple[bool, Optional[messages.MultisigRedeemScriptType]]:
     # Get m
     m = script[0] - 80
     if m < 1 or m > 15:
@@ -107,8 +117,8 @@ def parse_multisig(script):
     return (True, multisig)
 
 
-def trezor_exception(f):
-    def func(*args, **kwargs):
+def trezor_exception(f: Callable[..., Any]) -> Any:
+    def func(*args: Any, **kwargs: Any) -> Any:
         try:
             return f(*args, **kwargs)
         except ValueError as e:
@@ -120,7 +130,7 @@ def trezor_exception(f):
     return func
 
 
-def interactive_get_pin(self, code=None):
+def interactive_get_pin(self: object, code: Optional[int] = None) -> str:
     if code == messages.PinMatrixRequestType.Currrent:
         desc = "current PIN"
     elif code == messages.PinMatrixRequestType.NewFirst:
@@ -140,13 +150,12 @@ def interactive_get_pin(self, code=None):
             return pin
 
 
-def mnemonic_words(expand=False, language="english"):
+def mnemonic_words(expand: bool = False, language: str = "english") -> Callable[[Any], str]:
+    wordlist: Sequence[str] = []
     if expand:
         wordlist = Mnemonic(language).wordlist
-    else:
-        wordlist = set()
 
-    def expand_word(word):
+    def expand_word(word: str) -> str:
         if not expand:
             return word
         if word in wordlist:
@@ -157,7 +166,7 @@ def mnemonic_words(expand=False, language="english"):
         print("Choose one of: " + ", ".join(matches), file=sys.stderr)
         raise KeyError(word)
 
-    def get_word(type):
+    def get_word(type: messages.WordRequestType) -> str:
         assert type == messages.WordRequestType.Plain
         while True:
             try:
@@ -172,26 +181,26 @@ def mnemonic_words(expand=False, language="english"):
 
 
 class PassphraseUI:
-    def __init__(self, passphrase):
+    def __init__(self, passphrase: str) -> None:
         self.passphrase = passphrase
         self.pinmatrix_shown = False
         self.prompt_shown = False
         self.always_prompt = False
         self.return_passphrase = True
 
-    def button_request(self, code):
+    def button_request(self, code: Optional[int]) -> None:
         if not self.prompt_shown:
             print("Please confirm action on your Trezor device", file=sys.stderr)
         if not self.always_prompt:
             self.prompt_shown = True
 
-    def get_pin(self, code=None):
+    def get_pin(self, code: Optional[int] = None) -> NoReturn:
         raise NotImplementedError('get_pin is not needed')
 
-    def disallow_passphrase(self):
+    def disallow_passphrase(self) -> None:
         self.return_passphrase = False
 
-    def get_passphrase(self):
+    def get_passphrase(self) -> str:
         if self.return_passphrase:
             return self.passphrase
         raise ValueError('Passphrase from Host is not allowed for Trezor T')
@@ -201,7 +210,7 @@ HID_IDS = {DEV_TREZOR1}
 WEBUSB_IDS = TREZORS.copy()
 
 
-def get_path_transport(path: str):
+def get_path_transport(path: str) -> Device:
     devs = hid.HidTransport.enumerate(usb_ids=HID_IDS)
     devs.extend(webusb.WebUsbTransport.enumerate(usb_ids=WEBUSB_IDS))
     devs.extend(udp.UdpTransport.enumerate())
@@ -214,7 +223,7 @@ def get_path_transport(path: str):
 # This class extends the HardwareWalletClient for Trezor specific things
 class TrezorClient(HardwareWalletClient):
 
-    def __init__(self, path, password='', expert=False):
+    def __init__(self, path: str, password: str = "", expert: bool = False) -> None:
         super(TrezorClient, self).__init__(path, password, expert)
         self.simulator = False
         transport = get_path_transport(path)
@@ -233,7 +242,7 @@ class TrezorClient(HardwareWalletClient):
         self.password = password
         self.type = 'Trezor'
 
-    def _prepare_device(self):
+    def _prepare_device(self) -> None:
         self.coin_name = 'Bitcoin' if self.chain == Chain.MAIN else 'Testnet'
         resp = self.client.refresh_features()
         # If this is a Trezor One or Keepkey, do Initialize
@@ -246,7 +255,7 @@ class TrezorClient(HardwareWalletClient):
             except TrezorFailure:
                 self.client.init_device()
 
-    def _check_unlocked(self):
+    def _check_unlocked(self) -> None:
         self._prepare_device()
         if self.client.features.model == 'T' and isinstance(self.client.ui, PassphraseUI):
             self.client.ui.disallow_passphrase()
@@ -332,7 +341,7 @@ class TrezorClient(HardwareWalletClient):
                     scriptcode = psbt_in.witness_script
                     p2wsh = True
 
-                def ignore_input():
+                def ignore_input() -> None:
                     txinputtype.address_n = [0x80000000 | 84, 0x80000000 | (0 if self.chain == Chain.MAIN else 1), 0x80000000, 0, 0]
                     txinputtype.multisig = None
                     txinputtype.script_type = messages.InputScriptType.SPENDWITNESS
@@ -468,6 +477,7 @@ class TrezorClient(HardwareWalletClient):
                         )
                         t.bin_outputs.append(o)
                     logging.debug(psbt_in.non_witness_utxo.hash)
+                    assert psbt_in.non_witness_utxo.sha256 is not None
                     prevtxs[ser_uint256(psbt_in.non_witness_utxo.sha256)[::-1]] = t
 
             # Sign the transaction
@@ -529,6 +539,7 @@ class TrezorClient(HardwareWalletClient):
                 script_type=script_type,
                 multisig=None,
             )
+            assert isinstance(address, str)
             return address
         except Exception:
             pass
@@ -549,7 +560,7 @@ class TrezorClient(HardwareWalletClient):
             if p.extkey is not None:
                 xpub = p.extkey
                 hd_node = messages.HDNodeType(depth=xpub.depth, fingerprint=int.from_bytes(xpub.parent_fingerprint, 'big'), child_num=xpub.child_num, chain_code=xpub.chaincode, public_key=xpub.pubkey)
-                pubkey_objs.append(messages.HDNodePathType(node=hd_node, address_n=parse_path("m" + p.deriv_path)))
+                pubkey_objs.append(messages.HDNodePathType(node=hd_node, address_n=parse_path("m" + p.deriv_path if p.deriv_path is not None else "")))
             else:
                 hd_node = messages.HDNodeType(depth=0, fingerprint=0, child_num=0, chain_code=b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', public_key=p.get_pubkey_bytes(0))
                 pubkey_objs.append(messages.HDNodePathType(node=hd_node, address_n=[]))
@@ -577,6 +588,7 @@ class TrezorClient(HardwareWalletClient):
                     script_type=script_type,
                     multisig=multisig,
                 )
+                assert isinstance(address, str)
                 return address
             except Exception:
                 pass
@@ -614,9 +626,8 @@ class TrezorClient(HardwareWalletClient):
     def backup_device(self, label: str = "", passphrase: str = "") -> bool:
         raise UnavailableActionError('The {} does not support creating a backup via software'.format(self.type))
 
-    # Close the device
     @trezor_exception
-    def close(self):
+    def close(self) -> None:
         self.client.close()
 
     @trezor_exception
@@ -661,13 +672,13 @@ class TrezorClient(HardwareWalletClient):
                 print(PIN_MATRIX_DESCRIPTION, file=sys.stderr)
         return True
 
-def enumerate(password=''):
+def enumerate(password: str = "") -> List[Dict[str, Any]]:
     results = []
     devs = hid.HidTransport.enumerate()
     devs.extend(webusb.WebUsbTransport.enumerate())
     devs.extend(udp.UdpTransport.enumerate())
     for dev in devs:
-        d_data = {}
+        d_data: Dict[str, Any] = {}
 
         d_data['type'] = 'trezor'
         d_data['path'] = dev.get_path()

--- a/hwilib/key.py
+++ b/hwilib/key.py
@@ -264,7 +264,7 @@ class KeyOriginInfo(object):
         return xfp
 
 
-def parse_path(nstr: str) -> Sequence[int]:
+def parse_path(nstr: str) -> List[int]:
     """
     Convert BIP32 path string to list of uint32 integers with hardened flags.
     Several conventions are supported to set the hardened flag: -1, 1', 1h

--- a/hwilib/udevinstaller.py
+++ b/hwilib/udevinstaller.py
@@ -19,41 +19,41 @@ class UDevInstaller(object):
             raise
         return True
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._udevadm = '/sbin/udevadm'
         self._groupadd = '/usr/sbin/groupadd'
         self._usermod = '/usr/sbin/usermod'
 
-    def _execute(self, command, *args):
-        command = [command] + list(args)
+    def _execute(self, cmd: str, *args: str) -> None:
+        command = [cmd] + list(args)
         check_call(command, stderr=DEVNULL, stdout=DEVNULL)
 
-    def trigger(self):
+    def trigger(self) -> None:
         self._execute(self._udevadm, 'trigger')
 
-    def reload_rules(self):
+    def reload_rules(self) -> None:
         self._execute(self._udevadm, 'control', '--reload-rules')
 
-    def add_user_plugdev_group(self):
+    def add_user_plugdev_group(self) -> None:
         self._create_group('plugdev')
         self._add_user_to_group(getlogin(), 'plugdev')
 
-    def _create_group(self, name):
+    def _create_group(self, name: str) -> None:
         try:
             self._execute(self._groupadd, name)
         except CalledProcessError as e:
             if e.returncode != 9: # group already exists
                 raise
 
-    def _add_user_to_group(self, user, group):
+    def _add_user_to_group(self, user: str, group: str) -> None:
         self._execute(self._usermod, '-aG', group, user)
 
-    def copy_udev_rule_files(self, source, location):
+    def copy_udev_rule_files(self, source: str, location: str) -> None:
         src_dir_path = source
         for rules_file_name in listdir(_resource_path(src_dir_path)):
             if '.rules' in rules_file_name:
                 rules_file_path = _resource_path(path.join(src_dir_path, rules_file_name))
                 copy(rules_file_path, location)
 
-def _resource_path(relative_path):
+def _resource_path(relative_path: str) -> str:
     return path.join(path.dirname(__file__), relative_path)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,15 @@
 [mypy]
-# Do not type check trezorlib because it does not provide types.
-[mypy-hwilib.devices.trezorlib.*]
-follow_imports = skip
+warn_unused_configs = True
+disallow_any_generics = True
+disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = True
+implicit_reexport = True
+strict_equality = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,6 +20,9 @@ follow_imports = skip
 [mypy-hwilib.devices.trezorlib.*]
 follow_imports = skip
 
+[mypy-hwilib.devices.btchip.*]
+follow_imports = skip
+
 [mypy-hid]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -17,8 +17,17 @@ strict_equality = True
 [mypy-hwilib.devices.ckcc.*]
 follow_imports = skip
 
+[mypy-hwilib.devices.trezorlib.*]
+follow_imports = skip
+
 [mypy-hid]
 ignore_missing_imports = True
 
 [mypy-pyaes]
+ignore_missing_imports = True
+
+[mypy-usb1]
+ignore_missing_imports = True
+
+[mypy-mnemonic]
 ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,3 +13,9 @@ warn_unused_ignores = True
 warn_return_any = True
 implicit_reexport = True
 strict_equality = True
+
+[mypy-hwilib.devices.ckcc.*]
+follow_imports = skip
+
+[mypy-hid]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,3 +19,6 @@ follow_imports = skip
 
 [mypy-hid]
 ignore_missing_imports = True
+
+[mypy-pyaes]
+ignore_missing_imports = True


### PR DESCRIPTION
Adds type hints and enables type checking for almost everything. All commands, cli functions, and device implementations now have full type hints and will be checked by the type checker CI job.

The only things missing type hints are the gui stuff (autogenerated ui files don't have type hints) and all local library copies. Even though trezorlib has type hints, some of it is wrong, and some is missing, so it is being ignored for now. The btchip and ckcc lack type hints.

Based on #449 as it adds type hints for a lot of stuff too.