### PR TITLE
ledger: Ensure signed message signature is correct length

### DIFF
--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -339,15 +339,10 @@ class LedgerClient(HardwareWalletClient):
 
         # Make signature into standard bitcoin format
         rLength = signature[3]
-        r = signature[4: 4 + rLength]
-        sLength = signature[4 + rLength + 1]
-        s = signature[4 + rLength + 2:]
-        if rLength == 33:
-            r = r[1:]
-        if sLength == 33:
-            s = s[1:]
+        r = int.from_bytes(signature[4: 4 + rLength], byteorder="big", signed=True)
+        s = int.from_bytes(signature[4 + rLength + 2:], byteorder="big", signed=True)
 
-        sig = bytearray(chr(27 + 4 + (signature[0] & 0x01)), 'utf8') + r + s
+        sig = bytearray(chr(27 + 4 + (signature[0] & 0x01)), 'utf8') + r.to_bytes(32, byteorder="big", signed=False) + s.to_bytes(32, byteorder="big", signed=False)
 
         return {"signature": base64.b64encode(sig).decode('utf-8')}
 

--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -9,7 +9,7 @@ import sys
 import time
 import unittest
 
-from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestGetKeypool, TestGetDescriptors, TestSignTx, TestSignMessage
+from test_device import DeviceTestCase, start_bitcoind, TestDeviceConnect, TestGetKeypool, TestGetDescriptors, TestSignTx
 
 from hwilib.devices.digitalbitbox import BitboxSimulator, send_plain, send_encrypt
 
@@ -157,7 +157,6 @@ def digitalbitbox_test_suite(simulator, rpc, userpass, interface):
     suite.addTest(DeviceTestCase.parameterize(TestGetDescriptors, rpc, userpass, type, full_type, path, fingerprint, master_xpub, '0000', interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, type, full_type, path, fingerprint, master_xpub, '0000', interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, type, full_type, path, fingerprint, master_xpub, '0000', interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestSignMessage, rpc, userpass, type, full_type, path, fingerprint, master_xpub, '0000', interface=interface))
 
     result = unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)
     cleanup_simulator()


### PR DESCRIPTION
Ledger returns a DER encoded signature for signed messages. As such, it is possible that the `r` and `s` values could be shorter than 32 bytes. This would cause us to incorrectly serialize the compact signature used for signed messages. This PR fixes this issue by interpreting the `r` and `s` values as ints and then re-serializing them into fixed 32 byte ints.

Also added a test case. With the seed that speculos uses, the message `285`, when signed with the path `m/44'/1'/0'/0/0`, the `s` value is 31 bytes rather than 32 which runs into this issue.

Electrum had a similar issue as well: https://github.com/spesmilo/electrum/pull/7004