### PR TITLE
Doc: Change the `getkeypool`'s obsolete `--wpkh`s to `--addr-type wpkh`

### DIFF
--- a/docs/bitcoin-core-usage.md
+++ b/docs/bitcoin-core-usage.md
@@ -47,7 +47,7 @@ We will be fetching keys at the BIP 84 default. If `--path` and `--internal` are
 specified, both receiving and change address descriptors are generated.
 
 ```
-$ ./hwi.py -f 8038ecd9 getkeypool --wpkh 0 1000
+$ ./hwi.py -f 8038ecd9 getkeypool --addr-type wpkh 0 1000
 [{"desc": "wpkh([8038ecd9/84h/0h/0h]xpub6DR4rqx16YnCcfwFqgwvJdKiWrjDRzqxYTY44aoyHwZDSeSB5n2tqt42aYr9qPKhSKUdftPdTjhHrKKD6WGKVbuyhMvGH76VyKKZubg8o4P/0/*)#36sal9a4", "internal": false, "range": [0, 1000], "timestamp": "now", "keypool": true, "watchonly": true}, {"desc": "wpkh([8038ecd9/84h/0h/0h]xpub6DR4rqx16YnCcfwFqgwvJdKiWrjDRzqxYTY44aoyHwZDSeSB5n2tqt42aYr9qPKhSKUdftPdTjhHrKKD6WGKVbuyhMvGH76VyKKZubg8o4P/1/*)#nl2rc26w", "internal": true, "range": [0, 1000], "timestamp": "now", "keypool": true, "watchonly": true}]
 ```
 
@@ -276,8 +276,8 @@ e51392c82e13bbfe714c73361aff14ac1a1637abf37587a562844ae5a4265adf
 When the keypools run out, they can be refilled by using the `getkeypool` commands as done in the beginning, but with different starting and ending indexes. For example, to refill my keypools, I would use the following `getkeypool` commands:
 
 ```
-$ ./hwi.py -f 8038ecd9 getkeypool --wpkh 1000 2000
-$ ./hwi.py -f 8038ecd9 getkeypool --wpkh --internal 1000 2000
+$ ./hwi.py -f 8038ecd9 getkeypool --addr-type wpkh 1000 2000
+$ ./hwi.py -f 8038ecd9 getkeypool --addr-type wpkh --internal 1000 2000
 ```
 The output can be imported with `importmulti` as shown in the Setup steps.
 
@@ -285,8 +285,8 @@ The output can be imported with `importmulti` as shown in the Setup steps.
 
 The instructions above use BIP 84 to derive keys used for P2WPKH addresses (bech32 addresses).
 HWI follows BIPs 44, 84, and 49. By default, descriptors will be for P2PKH addresses with keys derived at `m/44h/0h/0h/0` for normal receiving keys and `m/44h/0h/0h/1` for change keys.
-Using the `--wpkh` option will result in P2WPKH addresses with keys derived at `m/84h/0h/0h/0` for normal receiving keys and `m/84h/0h/0h/1` for change keys.
-Using the `sh_wpkh` option will result in P2SH nested P2WPKH addresses with keys derived at `m/49h/0h/0h/0` for normal receiving keys and `m/49h/0h/0h/1` for change keys.
+Using the `--addr-type wpkh` option will result in P2WPKH addresses with keys derived at `m/84h/0h/0h/0` for normal receiving keys and `m/84h/0h/0h/1` for change keys.
+Using the `--addr-type sh_wpkh` option will result in P2SH nested P2WPKH addresses with keys derived at `m/49h/0h/0h/0` for normal receiving keys and `m/49h/0h/0h/1` for change keys.
 
 To actually get the correct address type when using `getnewaddress` from Bitcoin Core, you will need to additionally set `-addresstype=p2sh-segwit` and `-changetype=p2sh-segwit`.
 This can be set in the command line (as shown in the example) or in your bitcoin.conf file.


### PR DESCRIPTION
While following the steps in `/docs/bitcoin-core-usage.md` I stumbled upon the command-examples for (re)filling the keypools which no longer work since #415 .