### PR TITLE
make more distinction between Yes and N/A in the readme table

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,29 +90,33 @@ The below table lists what devices and features are supported for each device.
 
 Please also see [docs](docs/) for additional information about each device.
 
+* `✓` - supported by the firmware and implemented in HWI
+* `✗` - supported by the firmware and not implemented in HWI
+* `-` - not supported by the firmware
+
 | Feature \ Device | Ledger Nano X | Ledger Nano S | Trezor One | Trezor Model T | BitBox01 | BitBox02 | KeepKey | Coldcard |
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Support Planned | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Implemented | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| xpub retrieval | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Message Signing | Yes | Yes | Yes | Yes | Yes | N/A | Yes | Yes |
-| Device Setup | N/A | N/A | Yes | Yes | Yes | Yes | Yes | N/A |
-| Device Wipe | N/A | N/A | Yes | Yes | Yes | Yes | Yes | N/A |
-| Device Recovery | N/A | N/A | Yes | Yes | N/A | Yes | Yes | N/A |
-| Device Backup | N/A | N/A | N/A | N/A | Yes | Yes | N/A | Yes |
-| P2PKH Inputs | Yes | Yes | Yes | Yes | Yes | N/A | Yes | Yes |
-| P2SH-P2WPKH Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| P2WPKH Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| P2SH Multisig Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| P2SH-P2WSH Multisig Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| P2WSH Multisig Inputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Bare Multisig Inputs | Yes | Yes | N/A | N/A | Yes | N/A | N/A | N/A |
-| Arbitrary scriptPubKey Inputs | Yes | Yes | N/A | N/A | Yes | N/A | N/A | N/A |
-| Arbitrary redeemScript Inputs | Yes | Yes | N/A | N/A | Yes | N/A | N/A | N/A |
-| Arbitrary witnessScript Inputs | Yes | Yes | N/A | N/A | Yes | N/A | N/A | N/A |
-| Non-wallet inputs | Yes | Yes | Yes | Yes | Yes | N/A | Yes | Yes |
-| Mixed Segwit and Non-Segwit Inputs | N/A | N/A | Yes | Yes | Yes | Yes | Yes | Yes |
-| Display on device screen | Yes | Yes | Yes | Yes | N/A | Yes | Yes | Yes |
+| Support Planned | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Implemented | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| xpub retrieval | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Message Signing | ✓ | ✓ | ✓ | ✓ | ✓ | - | ✓ | ✓ |
+| Device Setup | - | - | ✓ | ✓ | ✓ | ✓ | ✓ | - |
+| Device Wipe | - | - | ✓ | ✓ | ✓ | ✓ | ✓ | - |
+| Device Recovery | - | - | ✓ | ✓ | - | ✓ | ✓ | - |
+| Device Backup | - | - | - | - | ✓ | ✓ | - | ✓ |
+| P2PKH Inputs | ✓ | ✓ | ✓ | ✓ | ✓ | - | ✓ | ✓ |
+| P2SH-P2WPKH Inputs | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| P2WPKH Inputs | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| P2SH Multisig Inputs | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| P2SH-P2WSH Multisig Inputs | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| P2WSH Multisig Inputs | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Bare Multisig Inputs | ✓ | ✓ | - | - | ✓ | - | - | - |
+| Arbitrary scriptPubKey Inputs | ✓ | ✓ | - | - | ✓ | - | - | - |
+| Arbitrary redeemScript Inputs | ✓ | ✓ | - | - | ✓ | - | - | - |
+| Arbitrary witnessScript Inputs | ✓ | ✓ | - | - | ✓ | - | - | - |
+| Non-wallet inputs | ✓ | ✓ | ✓ | ✓ | ✓ | - | ✓ | ✓ |
+| Mixed Segwit and Non-Segwit Inputs | - | - | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Display on device screen | ✓ | ✓ | ✓ | ✓ | - | ✓ | ✓ | ✓ |
 
 ## Using with Bitcoin Core
 


### PR DESCRIPTION
... by using checkmark ✓ and cross ✗

The original formatting was making the table quite hard to grasp as there were so many letters present on screen at once.

This is how the rendered readme looks like: https://github.com/prusnak/HWI/tree/readme-table#device-support

We might even consider using ❌ and ✅ emojis, but these might not be as widely supported (they are in the Unicode 6.0 standard from 2010). The characters I used are part of Unicode 1.1 from 1993.