### PR TITLE
Rename addrtype enum values to remove misnomer

### DIFF
--- a/docs/examples/bitcoin-core-usage.rst
+++ b/docs/examples/bitcoin-core-usage.rst
@@ -52,7 +52,7 @@ specified, both receiving and change address descriptors are generated.
 
 ::
 
-    $ ./hwi.py -f e5dbc9cb getkeypool --addr-type wit 0 1000
+    $ ./hwi.py -f e5dbc9cb getkeypool 0 1000
     [{"desc": "wpkh([e5dbc9cb/84'/0'/0']xpub6CbtS57jivMSuzcvp5YZxp6JhUU8YWup2axi2xkQRVHY8w4otp8YkEvfWBHgE5rA2AJYNHquuRoLFFdWeSi1UgVohcUeM7SkE9c8NftRwRJ/0/*)#cwyap6p3", "range": [0, 1000], "timestamp": "now", "internal": false, "keypool": true, "active": true, "watchonly": true}, {"desc": "wpkh([e5dbc9cb/84'/0'/0']xpub6CbtS57jivMSuzcvp5YZxp6JhUU8YWup2axi2xkQRVHY8w4otp8YkEvfWBHgE5rA2AJYNHquuRoLFFdWeSi1UgVohcUeM7SkE9c8NftRwRJ/1/*)#f6puu03f", "range": [0, 1000], "timestamp": "now", "internal": true, "keypool": true, "active": true, "watchonly": true}]
 
 We now create a new Bitcoin Core Descriptor Wallet and import the keys into Bitcoin Core. The output is formatted properly for Bitcoin Core so it can be copy and pasted.
@@ -276,8 +276,8 @@ Derivation Path BIP Compliance
 ==============================
 
 The instructions above use BIP 84 to derive keys used for P2WPKH addresses (bech32 addresses).
-HWI follows BIPs 44, 84, and 49. By default, descriptors will be for P2PKH addresses with keys derived at ``m/44h/0h/0h/0`` for normal receiving keys and ``m/44h/0h/0h/1`` for change keys.
-Using the ``--addr-type wit`` option will result in P2WPKH addresses with keys derived at ``m/84h/0h/0h/0`` for normal receiving keys and ``m/84h/0h/0h/1`` for change keys.
+HWI follows BIPs 44, 84, and 49. By default, descriptors will be for P2WPKH addresses with keys derived at ``m/84h/0h/0h/0`` for normal receiving keys and ``m/84h/0h/0h/1`` for change keys.
+Using the ``--addr-type legacy`` option will result in P2PKH addresses with keys derived at ``m/44h/0h/0h/0`` for normal receiving keys and ``m/44h/0h/0h/1`` for change keys.
 Using the ``--addr-type sh_wit`` option will result in P2SH nested P2WPKH addresses with keys derived at ``m/49h/0h/0h/0`` for normal receiving keys and ``m/49h/0h/0h/1`` for change keys.
 
 To actually get the correct address type when using ``getnewaddress`` from Bitcoin Core, you will need to additionally set ``-addresstype=p2sh-segwit`` and ``-changetype=p2sh-segwit``.

--- a/docs/examples/bitcoin-core-usage.rst
+++ b/docs/examples/bitcoin-core-usage.rst
@@ -52,7 +52,7 @@ specified, both receiving and change address descriptors are generated.
 
 ::
 
-    $ ./hwi.py -f e5dbc9cb getkeypool --addr-type wpkh 0 1000
+    $ ./hwi.py -f e5dbc9cb getkeypool --addr-type wit 0 1000
     [{"desc": "wpkh([e5dbc9cb/84'/0'/0']xpub6CbtS57jivMSuzcvp5YZxp6JhUU8YWup2axi2xkQRVHY8w4otp8YkEvfWBHgE5rA2AJYNHquuRoLFFdWeSi1UgVohcUeM7SkE9c8NftRwRJ/0/*)#cwyap6p3", "range": [0, 1000], "timestamp": "now", "internal": false, "keypool": true, "active": true, "watchonly": true}, {"desc": "wpkh([e5dbc9cb/84'/0'/0']xpub6CbtS57jivMSuzcvp5YZxp6JhUU8YWup2axi2xkQRVHY8w4otp8YkEvfWBHgE5rA2AJYNHquuRoLFFdWeSi1UgVohcUeM7SkE9c8NftRwRJ/1/*)#f6puu03f", "range": [0, 1000], "timestamp": "now", "internal": true, "keypool": true, "active": true, "watchonly": true}]
 
 We now create a new Bitcoin Core Descriptor Wallet and import the keys into Bitcoin Core. The output is formatted properly for Bitcoin Core so it can be copy and pasted.
@@ -277,8 +277,8 @@ Derivation Path BIP Compliance
 
 The instructions above use BIP 84 to derive keys used for P2WPKH addresses (bech32 addresses).
 HWI follows BIPs 44, 84, and 49. By default, descriptors will be for P2PKH addresses with keys derived at ``m/44h/0h/0h/0`` for normal receiving keys and ``m/44h/0h/0h/1`` for change keys.
-Using the ``--addr-type wpkh`` option will result in P2WPKH addresses with keys derived at ``m/84h/0h/0h/0`` for normal receiving keys and ``m/84h/0h/0h/1`` for change keys.
-Using the ``--addr-type sh_wpkh`` option will result in P2SH nested P2WPKH addresses with keys derived at ``m/49h/0h/0h/0`` for normal receiving keys and ``m/49h/0h/0h/1`` for change keys.
+Using the ``--addr-type wit`` option will result in P2WPKH addresses with keys derived at ``m/84h/0h/0h/0`` for normal receiving keys and ``m/84h/0h/0h/1`` for change keys.
+Using the ``--addr-type sh_wit`` option will result in P2SH nested P2WPKH addresses with keys derived at ``m/49h/0h/0h/0`` for normal receiving keys and ``m/49h/0h/0h/1`` for change keys.
 
 To actually get the correct address type when using ``getnewaddress`` from Bitcoin Core, you will need to additionally set ``-addresstype=p2sh-segwit`` and ``-changetype=p2sh-segwit``.
 This can be set in the command line (as shown in the example) or in your bitcoin.conf file.

--- a/docs/examples/walkthrough/walkthrough.rst
+++ b/docs/examples/walkthrough/walkthrough.rst
@@ -35,8 +35,8 @@ Then in another terminal run commands similar to these, adapted to your environm
   # of unknown address on Trezor display. This is not recommended. Use the correct derivation path
   # for the corresponding network!
   wallet=wallet.test
-  rec=$(hwi --testnet -f $FINGERPRINT_TESTNET getkeypool --addr-type wpkh --path m/84h/${DERIVATIONPATH_TESTNET}h/0h/0/* --keypool 0 1000)
-  chg=$(hwi --testnet -f $FINGERPRINT_TESTNET getkeypool --addr-type wpkh --path m/84h/${DERIVATIONPATH_TESTNET}h/0h/1/* --keypool --internal 0 1000)
+  rec=$(hwi --testnet -f $FINGERPRINT_TESTNET getkeypool --addr-type wit --path m/84h/${DERIVATIONPATH_TESTNET}h/0h/0/* --keypool 0 1000)
+  chg=$(hwi --testnet -f $FINGERPRINT_TESTNET getkeypool --addr-type wit --path m/84h/${DERIVATIONPATH_TESTNET}h/0h/1/* --keypool --internal 0 1000)
   bitcoin-cli -testnet createwallet "$wallet" true
   bitcoin-cli -testnet -rpcwallet="$wallet" importmulti "$rec"
   bitcoin-cli -testnet -rpcwallet="$wallet" importmulti "$chg"
@@ -184,5 +184,5 @@ Versions Used
 =============
 
 * This walk-trough was done in Janary 2021
-* HWI version 1.2.1
+* HWI version 2.0.0-dev
 * Bitcoin 0.21.0

--- a/hwilib/_cli.py
+++ b/hwilib/_cli.py
@@ -174,7 +174,7 @@ def get_parser() -> HWIArgumentParser:
     kparg_group.add_argument('--nokeypool', action='store_false', dest='keypool', help='Indicates that the keys are not to be imported to the keypool', default=False)
     getkeypool_parser.add_argument('--internal', action='store_true', help='Indicates that the keys are change keys')
     kp_type_group = getkeypool_parser.add_mutually_exclusive_group()
-    kp_type_group.add_argument("--addr-type", help="The address type (and default derivation path) to produce descriptors for", type=AddressType.argparse, choices=list(AddressType), default=AddressType.PKH) # type: ignore
+    kp_type_group.add_argument("--addr-type", help="The address type (and default derivation path) to produce descriptors for", type=AddressType.argparse, choices=list(AddressType), default=AddressType.LEGACY) # type: ignore
     kp_type_group.add_argument('--all', action='store_true', help='Generate addresses for all standard address types (default paths: ``m/{44,49,84}h/0h/0h/[0,1]/*)``')
     getkeypool_parser.add_argument('--account', help='BIP43 account', type=int, default=0)
     getkeypool_parser.add_argument('--path', help='Derivation path, default follows BIP43 convention, e.g. ``m/84h/0h/0h/1/*`` with --addr-type wpkh --internal. If this argument and --internal is not given, both internal and external keypools will be returned.')
@@ -190,7 +190,7 @@ def get_parser() -> HWIArgumentParser:
     group = displayaddr_parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--desc', help='Output Descriptor. E.g. wpkh([00000000/84h/0h/0h]xpub.../0/0), where 00000000 must match --fingerprint and xpub can be obtained with getxpub. See doc/descriptors.md in Bitcoin Core')
     group.add_argument('--path', help='The BIP 32 derivation path of the key embedded in the address, default follows BIP43 convention, e.g. ``m/84h/0h/0h/1/*``')
-    displayaddr_parser.add_argument("--addr-type", help="The address type to display", type=AddressType.argparse, choices=list(AddressType), default=AddressType.PKH) # type: ignore
+    displayaddr_parser.add_argument("--addr-type", help="The address type to display", type=AddressType.argparse, choices=list(AddressType), default=AddressType.LEGACY) # type: ignore
     displayaddr_parser.set_defaults(func=displayaddress_handler)
 
     setupdev_parser = subparsers.add_parser('setup', help='Setup a device. Passphrase protection uses the password given by -p. Requires interactive mode')

--- a/hwilib/_cli.py
+++ b/hwilib/_cli.py
@@ -174,7 +174,7 @@ def get_parser() -> HWIArgumentParser:
     kparg_group.add_argument('--nokeypool', action='store_false', dest='keypool', help='Indicates that the keys are not to be imported to the keypool', default=False)
     getkeypool_parser.add_argument('--internal', action='store_true', help='Indicates that the keys are change keys')
     kp_type_group = getkeypool_parser.add_mutually_exclusive_group()
-    kp_type_group.add_argument("--addr-type", help="The address type (and default derivation path) to produce descriptors for", type=AddressType.argparse, choices=list(AddressType), default=AddressType.LEGACY) # type: ignore
+    kp_type_group.add_argument("--addr-type", help="The address type (and default derivation path) to produce descriptors for", type=AddressType.argparse, choices=list(AddressType), default=AddressType.WIT) # type: ignore
     kp_type_group.add_argument('--all', action='store_true', help='Generate addresses for all standard address types (default paths: ``m/{44,49,84}h/0h/0h/[0,1]/*)``')
     getkeypool_parser.add_argument('--account', help='BIP43 account', type=int, default=0)
     getkeypool_parser.add_argument('--path', help='Derivation path, default follows BIP43 convention, e.g. ``m/84h/0h/0h/1/*`` with --addr-type wpkh --internal. If this argument and --internal is not given, both internal and external keypools will be returned.')
@@ -190,7 +190,7 @@ def get_parser() -> HWIArgumentParser:
     group = displayaddr_parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--desc', help='Output Descriptor. E.g. wpkh([00000000/84h/0h/0h]xpub.../0/0), where 00000000 must match --fingerprint and xpub can be obtained with getxpub. See doc/descriptors.md in Bitcoin Core')
     group.add_argument('--path', help='The BIP 32 derivation path of the key embedded in the address, default follows BIP43 convention, e.g. ``m/84h/0h/0h/1/*``')
-    displayaddr_parser.add_argument("--addr-type", help="The address type to display", type=AddressType.argparse, choices=list(AddressType), default=AddressType.LEGACY) # type: ignore
+    displayaddr_parser.add_argument("--addr-type", help="The address type to display", type=AddressType.argparse, choices=list(AddressType), default=AddressType.WIT) # type: ignore
     displayaddr_parser.set_defaults(func=displayaddress_handler)
 
     setupdev_parser = subparsers.add_parser('setup', help='Setup a device. Passphrase protection uses the password given by -p. Requires interactive mode')

--- a/hwilib/_gui.py
+++ b/hwilib/_gui.py
@@ -171,11 +171,14 @@ class DisplayAddressDialog(QDialog):
     @Slot()
     def go_button_clicked(self):
         path = self.ui.path_lineedit.text()
-        addrtype = AddressType.LEGACY
         if self.ui.sh_wpkh_radio.isChecked():
             addrtype = AddressType.SH_WIT
         elif self.ui.wpkh_radio.isChecked():
             addrtype = AddressType.WIT
+        elif self.ui.pkh_radio.isChecked():
+            addrtype = AddressType.LEGACY
+        else:
+            assert False # How did this happen?
         res = do_command(commands.displayaddress, self.client, path, addr_type=addrtype)
         self.ui.address_lineedit.setText(res['address'])
 
@@ -445,6 +448,8 @@ class HWIQt(QMainWindow):
             self.getkeypool_opts['addrtype'] = AddressType.SH_WIT
         if self.current_dialog.ui.wpkh_radio.isChecked():
             self.getkeypool_opts['addrtype'] = AddressType.WIT
+        if self.current_dialog.ui.pkh_radio.isChecked():
+            self.getkeypool_opts['addrtype'] = AddressType.LEGACY
         if self.current_dialog.ui.account_radio.isChecked():
             self.getkeypool_opts['account'] = self.current_dialog.ui.account_spinbox.value()
             self.getkeypool_opts['account_used'] = True

--- a/hwilib/_gui.py
+++ b/hwilib/_gui.py
@@ -171,11 +171,11 @@ class DisplayAddressDialog(QDialog):
     @Slot()
     def go_button_clicked(self):
         path = self.ui.path_lineedit.text()
-        addrtype = AddressType.PKH
+        addrtype = AddressType.LEGACY
         if self.ui.sh_wpkh_radio.isChecked():
-            addrtype = AddressType.SH_WPKH
+            addrtype = AddressType.SH_WIT
         elif self.ui.wpkh_radio.isChecked():
-            addrtype = AddressType.WPKH
+            addrtype = AddressType.WIT
         res = do_command(commands.displayaddress, self.client, path, addr_type=addrtype)
         self.ui.address_lineedit.setText(res['address'])
 
@@ -204,9 +204,9 @@ class GetKeypoolOptionsDialog(QDialog):
             self.ui.path_lineedit.setEnabled(True)
             self.ui.account_spinbox.setEnabled(False)
             self.ui.path_lineedit.setText(opts['path'])
-        self.ui.sh_wpkh_radio.setChecked(opts['addrtype'] == AddressType.SH_WPKH)
-        self.ui.wpkh_radio.setChecked(opts['addrtype'] == AddressType.WPKH)
-        self.ui.pkh_radio.setChecked(opts['addrtype'] == AddressType.PKH)
+        self.ui.sh_wpkh_radio.setChecked(opts['addrtype'] == AddressType.SH_WIT)
+        self.ui.wpkh_radio.setChecked(opts['addrtype'] == AddressType.WIT)
+        self.ui.pkh_radio.setChecked(opts['addrtype'] == AddressType.LEGACY)
 
         self.ui.account_radio.toggled.connect(self.toggle_account)
 
@@ -282,7 +282,7 @@ class HWIQt(QMainWindow):
             'account': 0,
             'internal': False,
             'keypool': True,
-            'addrtype': AddressType.SH_WPKH,
+            'addrtype': AddressType.SH_WIT,
             'path': None,
             'account_used': True
         }
@@ -440,11 +440,11 @@ class HWIQt(QMainWindow):
         self.getkeypool_opts['end'] = self.current_dialog.ui.end_spinbox.value()
         self.getkeypool_opts['internal'] = self.current_dialog.ui.internal_checkbox.isChecked()
         self.getkeypool_opts['keypool'] = self.current_dialog.ui.keypool_checkbox.isChecked()
-        self.getkeypool_opts['addrtype'] = AddressType.PKH
+        self.getkeypool_opts['addrtype'] = AddressType.LEGACY
         if self.current_dialog.ui.sh_wpkh_radio.isChecked():
-            self.getkeypool_opts['addrtype'] = AddressType.SH_WPKH
+            self.getkeypool_opts['addrtype'] = AddressType.SH_WIT
         if self.current_dialog.ui.wpkh_radio.isChecked():
-            self.getkeypool_opts['addrtype'] = AddressType.WPKH
+            self.getkeypool_opts['addrtype'] = AddressType.WIT
         if self.current_dialog.ui.account_radio.isChecked():
             self.getkeypool_opts['account'] = self.current_dialog.ui.account_spinbox.value()
             self.getkeypool_opts['account_used'] = True

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -225,7 +225,7 @@ def getkeypool_inner(
     internal: bool = False,
     keypool: bool = True,
     account: int = 0,
-    addr_type: AddressType = AddressType.WPKH
+    addr_type: AddressType = AddressType.WIT
 ) -> List[Dict[str, Any]]:
     """
     :meta private:
@@ -263,7 +263,7 @@ def getdescriptor(
     master_fpr: bytes,
     path: Optional[str] = None,
     internal: bool = False,
-    addr_type: AddressType = AddressType.WPKH,
+    addr_type: AddressType = AddressType.WIT,
     account: int = 0,
     start: Optional[int] = None,
     end: Optional[int] = None
@@ -282,8 +282,8 @@ def getdescriptor(
     :return: The descriptor constructed given the above arguments and key fetched from the device
     :raises: BadArgumentError: if an argument is malformed or missing.
     """
-    is_wpkh = addr_type is AddressType.WPKH
-    is_sh_wpkh = addr_type is AddressType.SH_WPKH
+    is_wpkh = addr_type is AddressType.WIT
+    is_sh_wpkh = addr_type is AddressType.SH_WIT
 
     parsed_path = []
     if not path:
@@ -293,7 +293,7 @@ def getdescriptor(
         elif is_sh_wpkh:
             parsed_path.append(H_(49))
         else:
-            assert addr_type == AddressType.PKH
+            assert addr_type == AddressType.LEGACY
             parsed_path.append(H_(44))
 
         # Coin type
@@ -353,7 +353,7 @@ def getkeypool(
     internal: bool = False,
     keypool: bool = True,
     account: int = 0,
-    addr_type: AddressType = AddressType.PKH,
+    addr_type: AddressType = AddressType.LEGACY,
     addr_all: bool = False
 ) -> List[Dict[str, Any]]:
     """
@@ -408,7 +408,7 @@ def getdescriptors(
 
     for internal in [False, True]:
         descriptors = []
-        for addr_type in (AddressType.PKH, AddressType.SH_WPKH, AddressType.WPKH):
+        for addr_type in (AddressType.LEGACY, AddressType.SH_WIT, AddressType.WIT):
             try:
                 desc = getdescriptor(client, master_fpr=master_fpr, internal=internal, addr_type=addr_type, account=account)
             except UnavailableActionError:
@@ -428,7 +428,7 @@ def displayaddress(
     client: HardwareWalletClient,
     path: Optional[str] = None,
     desc: Optional[str] = None,
-    addr_type: AddressType = AddressType.PKH
+    addr_type: AddressType = AddressType.LEGACY
 ) -> Dict[str, str]:
     """
     Display an address on the device for client.
@@ -446,7 +446,7 @@ def displayaddress(
         return {"address": client.display_singlesig_address(path, addr_type)}
     elif desc is not None:
         descriptor = parse_descriptor(desc)
-        addr_type = AddressType.PKH
+        addr_type = AddressType.LEGACY
         is_sh = isinstance(descriptor, SHDescriptor)
         is_wsh = isinstance(descriptor, WSHDescriptor)
         if is_sh or is_wsh:
@@ -458,9 +458,9 @@ def displayaddress(
                 descriptor = descriptor.subdescriptor
             if isinstance(descriptor, MultisigDescriptor):
                 if is_sh and is_wsh:
-                    addr_type = AddressType.SH_WPKH
+                    addr_type = AddressType.SH_WIT
                 elif not is_sh and is_wsh:
-                    addr_type = AddressType.WPKH
+                    addr_type = AddressType.WIT
                 return {"address": client.display_multisig_address(descriptor.thresh, descriptor.pubkeys, addr_type)}
         is_wpkh = isinstance(descriptor, WPKHDescriptor)
         if isinstance(descriptor, PKHDescriptor) or is_wpkh:
@@ -473,9 +473,9 @@ def displayaddress(
             if pubkey.pubkey != xpub and pubkey.pubkey != xpub_to_pub_hex(xpub):
                 raise BadArgumentError(f"Key in descriptor does not match device: {desc}")
             if is_sh and is_wpkh:
-                addr_type = AddressType.SH_WPKH
+                addr_type = AddressType.SH_WIT
             elif not is_sh and is_wpkh:
-                addr_type = AddressType.WPKH
+                addr_type = AddressType.WIT
             return {"address": client.display_singlesig_address(pubkey.get_full_derivation_path(0), addr_type)}
     raise BadArgumentError("Missing both path and descriptor")
 

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -353,7 +353,7 @@ def getkeypool(
     internal: bool = False,
     keypool: bool = True,
     account: int = 0,
-    addr_type: AddressType = AddressType.LEGACY,
+    addr_type: AddressType = AddressType.WIT,
     addr_all: bool = False
 ) -> List[Dict[str, Any]]:
     """
@@ -428,7 +428,7 @@ def displayaddress(
     client: HardwareWalletClient,
     path: Optional[str] = None,
     desc: Optional[str] = None,
-    addr_type: AddressType = AddressType.LEGACY
+    addr_type: AddressType = AddressType.WIT
 ) -> Dict[str, str]:
     """
     Display an address on the device for client.

--- a/hwilib/common.py
+++ b/hwilib/common.py
@@ -37,9 +37,9 @@ class AddressType(Enum):
     """
     The type of address to use
     """
-    PKH = 1 #: Legacy address type. P2PKH for single sig, P2SH for scripts.
-    WPKH = 2 #: Native segwit address type. P2WPKH for single sig, P2WPSH for scripts.
-    SH_WPKH = 3 #: Nested segwit address type. P2SH-P2WPKH for single sig, P2SH-P2WPSH for scripts.
+    LEGACY = 1 #: Legacy address type. P2PKH for single sig, P2SH for scripts.
+    WIT = 2 #: Native segwit v0 address type. P2WPKH for single sig, P2WPSH for scripts.
+    SH_WIT = 3 #: Nested segwit v0 address type. P2SH-P2WPKH for single sig, P2SH-P2WPSH for scripts.
 
     def __str__(self) -> str:
         return self.name.lower()

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -451,11 +451,11 @@ class Bitbox02Client(HardwareWalletClient):
         bip32_path: str,
         addr_type: AddressType,
     ) -> str:
-        if addr_type == AddressType.SH_WPKH:
+        if addr_type == AddressType.SH_WIT:
             script_config = bitbox02.btc.BTCScriptConfig(
                 simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH_P2SH
             )
-        elif addr_type == AddressType.WPKH:
+        elif addr_type == AddressType.WIT:
             script_config = bitbox02.btc.BTCScriptConfig(
                 simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH
             )
@@ -492,9 +492,9 @@ class Bitbox02Client(HardwareWalletClient):
             key_origin_infos[pk.extkey.serialize()] = pk.origin
             keypaths[pk.extkey.serialize()] = pk.get_full_derivation_path(0)
 
-        if addr_type == AddressType.SH_WPKH:
+        if addr_type == AddressType.SH_WIT:
             script_type = bitbox02.btc.BTCScriptConfig.Multisig.P2WSH_P2SH
-        elif addr_type == AddressType.WPKH:
+        elif addr_type == AddressType.WIT:
             script_type = bitbox02.btc.BTCScriptConfig.Multisig.P2WSH
         else:
             raise BadArgumentError(

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -459,10 +459,12 @@ class Bitbox02Client(HardwareWalletClient):
             script_config = bitbox02.btc.BTCScriptConfig(
                 simple_type=bitbox02.btc.BTCScriptConfig.P2WPKH
             )
-        else:
+        elif addr_type == AddressType.LEGACY:
             raise UnavailableActionError(
                 "The BitBox02 does not support legacy p2pkh addresses"
             )
+        else:
+            raise BadArgumentError("Unknown address type")
         address = self.init().btc_address(
             parse_path(bip32_path),
             coin=self._get_coin(),

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -235,9 +235,9 @@ class ColdcardClient(HardwareWalletClient):
         keypath = keypath.replace('h', '\'')
         keypath = keypath.replace('H', '\'')
 
-        if addr_type == AddressType.SH_WPKH:
+        if addr_type == AddressType.SH_WIT:
             addr_fmt = AF_P2WPKH_P2SH
-        elif addr_type == AddressType.WPKH:
+        elif addr_type == AddressType.WIT:
             addr_fmt = AF_P2WPKH
         else:
             addr_fmt = AF_CLASSIC
@@ -260,9 +260,9 @@ class ColdcardClient(HardwareWalletClient):
     ) -> str:
         self.device.check_mitm()
 
-        if addr_type == AddressType.SH_WPKH:
+        if addr_type == AddressType.SH_WIT:
             addr_fmt = AF_P2WSH_P2SH
-        elif addr_type == AddressType.WPKH:
+        elif addr_type == AddressType.WIT:
             addr_fmt = AF_P2WSH
         else:
             addr_fmt = AF_P2SH

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -239,8 +239,10 @@ class ColdcardClient(HardwareWalletClient):
             addr_fmt = AF_P2WPKH_P2SH
         elif addr_type == AddressType.WIT:
             addr_fmt = AF_P2WPKH
-        else:
+        elif addr_type == AddressType.LEGACY:
             addr_fmt = AF_CLASSIC
+        else:
+            raise BadArgumentError("Unknown address type")
 
         payload = CCProtocolPacker.show_address(keypath, addr_fmt=addr_fmt)
 
@@ -264,8 +266,10 @@ class ColdcardClient(HardwareWalletClient):
             addr_fmt = AF_P2WSH_P2SH
         elif addr_type == AddressType.WIT:
             addr_fmt = AF_P2WSH
-        else:
+        elif addr_type == AddressType.LEGACY:
             addr_fmt = AF_P2SH
+        else:
+            raise BadArgumentError("Unknown address type")
 
         if not 1 <= len(pubkeys) <= 15:
             raise BadArgumentError("Must provide 1 to 15 keypaths to display a multisig address")

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -348,8 +348,8 @@ class LedgerClient(HardwareWalletClient):
     ) -> str:
         if not check_keypath(keypath):
             raise BadArgumentError("Invalid keypath")
-        p2sh_p2wpkh = addr_type == AddressType.SH_WPKH
-        bech32 = addr_type == AddressType.WPKH
+        p2sh_p2wpkh = addr_type == AddressType.SH_WIT
+        bech32 = addr_type == AddressType.WIT
         output = self.app.getWalletPublicKey(keypath[2:], True, p2sh_p2wpkh or bech32, bech32)
         assert isinstance(output["address"], str)
         return output['address'][12:-2] # HACK: A bug in getWalletPublicKey results in the address being returned as the string "bytearray(b'<address>')". This extracts the actual address to work around this.

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -543,8 +543,10 @@ class TrezorClient(HardwareWalletClient):
             script_type = messages.InputScriptType.SPENDP2SHWITNESS
         elif addr_type == AddressType.WIT:
             script_type = messages.InputScriptType.SPENDWITNESS
-        else:
+        elif addr_type == AddressType.LEGACY:
             script_type = messages.InputScriptType.SPENDADDRESS
+        else:
+            raise BadArgumentError("Unknown address type")
 
         expanded_path = parse_path(keypath)
 
@@ -590,8 +592,10 @@ class TrezorClient(HardwareWalletClient):
             script_type = messages.InputScriptType.SPENDP2SHWITNESS
         elif addr_type == AddressType.WIT:
             script_type = messages.InputScriptType.SPENDWITNESS
-        else:
+        elif addr_type == AddressType.LEGACY:
             script_type = messages.InputScriptType.SPENDMULTISIG
+        else:
+            raise BadArgumentError("Unknown address type")
 
         for p in pubkeys:
             keypath = p.origin.get_derivation_path() if p.origin is not None else "m/"

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -539,9 +539,9 @@ class TrezorClient(HardwareWalletClient):
         self._check_unlocked()
 
         # Script type
-        if addr_type == AddressType.SH_WPKH:
+        if addr_type == AddressType.SH_WIT:
             script_type = messages.InputScriptType.SPENDP2SHWITNESS
-        elif addr_type == AddressType.WPKH:
+        elif addr_type == AddressType.WIT:
             script_type = messages.InputScriptType.SPENDWITNESS
         else:
             script_type = messages.InputScriptType.SPENDADDRESS
@@ -586,9 +586,9 @@ class TrezorClient(HardwareWalletClient):
         multisig = messages.MultisigRedeemScriptType(m=threshold, signatures=[b''] * len(pubkey_objs), pubkeys=pubkey_objs)
 
         # Script type
-        if addr_type == AddressType.SH_WPKH:
+        if addr_type == AddressType.SH_WIT:
             script_type = messages.InputScriptType.SPENDP2SHWITNESS
-        elif addr_type == AddressType.WPKH:
+        elif addr_type == AddressType.WIT:
             script_type = messages.InputScriptType.SPENDWITNESS
         else:
             script_type = messages.InputScriptType.SPENDMULTISIG

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -197,7 +197,7 @@ class TestGetKeypool(DeviceTestCase):
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress('legacy'))
             self.assertTrue(addr_info['hdkeypath'].startswith("m/44'/1'/0'/1/"))
 
-        shwpkh_keypool_desc = self.do_command(self.dev_args + ['getkeypool', "--addr-type", "sh_wpkh", '0', '20'])
+        shwpkh_keypool_desc = self.do_command(self.dev_args + ['getkeypool', "--addr-type", "sh_wit", '0', '20'])
         import_result = self.wrpc.importdescriptors(shwpkh_keypool_desc)
         self.assertTrue(import_result[0]['success'])
         for _ in range(0, 21):
@@ -206,7 +206,7 @@ class TestGetKeypool(DeviceTestCase):
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress('p2sh-segwit'))
             self.assertTrue(addr_info['hdkeypath'].startswith("m/49'/1'/0'/1/"))
 
-        wpkh_keypool_desc = self.do_command(self.dev_args + ['getkeypool', "--addr-type", "wpkh", '0', '20'])
+        wpkh_keypool_desc = self.do_command(self.dev_args + ['getkeypool', "--addr-type", "wit", '0', '20'])
         import_result = self.wrpc.importdescriptors(wpkh_keypool_desc)
         self.assertTrue(import_result[0]['success'])
         for _ in range(0, 21):
@@ -219,7 +219,7 @@ class TestGetKeypool(DeviceTestCase):
         all_keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--all', '0', '20'])
         self.assertEqual(all_keypool_desc, pkh_keypool_desc + wpkh_keypool_desc + shwpkh_keypool_desc)
 
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', "--addr-type", "sh_wpkh", '--account', '3', '0', '20'])
+        keypool_desc = self.do_command(self.dev_args + ['getkeypool', "--addr-type", "sh_wit", '--account', '3', '0', '20'])
         import_result = self.wrpc.importdescriptors(keypool_desc)
         self.assertTrue(import_result[0]['success'])
         for _ in range(0, 21):
@@ -227,7 +227,7 @@ class TestGetKeypool(DeviceTestCase):
             self.assertTrue(addr_info['hdkeypath'].startswith("m/49'/1'/3'/0/"))
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress('p2sh-segwit'))
             self.assertTrue(addr_info['hdkeypath'].startswith("m/49'/1'/3'/1/"))
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', "--addr-type", "wpkh", '--account', '3', '0', '20'])
+        keypool_desc = self.do_command(self.dev_args + ['getkeypool', "--addr-type", "wit", '--account', '3', '0', '20'])
         import_result = self.wrpc.importdescriptors(keypool_desc)
         self.assertTrue(import_result[0]['success'])
         for _ in range(0, 21):
@@ -476,12 +476,12 @@ class TestDisplayAddress(DeviceTestCase):
         self.assertNotIn('code', result)
         self.assertIn('address', result)
 
-        result = self.do_command(self.dev_args + ['displayaddress', "--addr-type", "sh_wpkh", '--path', 'm/49h/1h/0h/0/0'])
+        result = self.do_command(self.dev_args + ['displayaddress', "--addr-type", "sh_wit", '--path', 'm/49h/1h/0h/0/0'])
         self.assertNotIn('error', result)
         self.assertNotIn('code', result)
         self.assertIn('address', result)
 
-        result = self.do_command(self.dev_args + ['displayaddress', "--addr-type", "wpkh", '--path', 'm/84h/1h/0h/0/0'])
+        result = self.do_command(self.dev_args + ['displayaddress', "--addr-type", "wit", '--path', 'm/84h/1h/0h/0/0'])
         self.assertNotIn('error', result)
         self.assertNotIn('code', result)
         self.assertIn('address', result)

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -188,7 +188,7 @@ class TestGetKeypool(DeviceTestCase):
         self.setup_wallets()
 
     def test_getkeypool(self):
-        pkh_keypool_desc = self.do_command(self.dev_args + ['getkeypool', '0', '20'])
+        pkh_keypool_desc = self.do_command(self.dev_args + ['getkeypool', "--addr-type", "legacy", '0', '20'])
         import_result = self.wrpc.importdescriptors(pkh_keypool_desc)
         self.assertTrue(import_result[0]['success'])
         for _ in range(0, 21):
@@ -206,7 +206,7 @@ class TestGetKeypool(DeviceTestCase):
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress('p2sh-segwit'))
             self.assertTrue(addr_info['hdkeypath'].startswith("m/49'/1'/0'/1/"))
 
-        wpkh_keypool_desc = self.do_command(self.dev_args + ['getkeypool', "--addr-type", "wit", '0', '20'])
+        wpkh_keypool_desc = self.do_command(self.dev_args + ['getkeypool', '0', '20'])
         import_result = self.wrpc.importdescriptors(wpkh_keypool_desc)
         self.assertTrue(import_result[0]['success'])
         for _ in range(0, 21):
@@ -227,7 +227,7 @@ class TestGetKeypool(DeviceTestCase):
             self.assertTrue(addr_info['hdkeypath'].startswith("m/49'/1'/3'/0/"))
             addr_info = self.wrpc.getaddressinfo(self.wrpc.getrawchangeaddress('p2sh-segwit'))
             self.assertTrue(addr_info['hdkeypath'].startswith("m/49'/1'/3'/1/"))
-        keypool_desc = self.do_command(self.dev_args + ['getkeypool', "--addr-type", "wit", '--account', '3', '0', '20'])
+        keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--account', '3', '0', '20'])
         import_result = self.wrpc.importdescriptors(keypool_desc)
         self.assertTrue(import_result[0]['success'])
         for _ in range(0, 21):
@@ -240,7 +240,7 @@ class TestGetKeypool(DeviceTestCase):
         import_result = self.wrpc.importdescriptors(keypool_desc)
         self.assertTrue(import_result[0]['success'])
         for _ in range(0, 21):
-            addr_info = self.wrpc.getaddressinfo(self.wrpc.getnewaddress('', 'legacy'))
+            addr_info = self.wrpc.getaddressinfo(self.wrpc.getnewaddress('', 'bech32'))
             self.assertTrue(addr_info['hdkeypath'].startswith("m/0'/0'/4'/"))
 
         keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--path', '/0h/0h/4h/*', '0', '20'])
@@ -471,7 +471,7 @@ class TestSignTx(DeviceTestCase):
 
 class TestDisplayAddress(DeviceTestCase):
     def test_display_address_path(self):
-        result = self.do_command(self.dev_args + ['displayaddress', '--path', 'm/44h/1h/0h/0/0'])
+        result = self.do_command(self.dev_args + ['displayaddress', "--addr-type", "legacy", '--path', 'm/44h/1h/0h/0/0'])
         self.assertNotIn('error', result)
         self.assertNotIn('code', result)
         self.assertIn('address', result)
@@ -612,7 +612,7 @@ class TestSignMessage(DeviceTestCase):
         self.assertIn("signature", sign_res)
         sig = sign_res["signature"]
 
-        addr = self.do_command(self.dev_args + ['displayaddress', '--path', addr_path])["address"]
+        addr = self.do_command(self.dev_args + ['displayaddress', "--addr-type", "legacy", '--path', addr_path])["address"]
         addr = to_address(decode(addr)[1:-4], b"\x6F")
 
         self.assertTrue(self.rpc.verifymessage(addr, sig, msg))


### PR DESCRIPTION
As noted previously, the current `AddrType` enums are a misnomer for multisig addresses, and in general, things that are not single keys. This PR fixes that by renaming them. PKH is now LEGACY, SH_WPKH is SH_WIT_V0, and WPKH is WIT_V0.

I decided to go wit_v0 to be more explicit about the segwit version. This will let us unambiguously have future address types that are other segwit versions.

Additionally this PR makes WIT_V0 the default address type instead of LEGACY.