### PR TITLE
Have getmasterxpub account for BIP 44 things

### DIFF
--- a/hwilib/_cli.py
+++ b/hwilib/_cli.py
@@ -62,7 +62,7 @@ def enumerate_handler(args: argparse.Namespace) -> List[Dict[str, Any]]:
     return enumerate(password=args.password)
 
 def getmasterxpub_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, str]:
-    return getmasterxpub(client)
+    return getmasterxpub(client, addrtype=args.addr_type, account=args.account)
 
 def getxpub_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, str]:
     return getxpub(client, path=args.path, expert=args.expert)
@@ -152,7 +152,9 @@ def get_parser() -> HWIArgumentParser:
     enumerate_parser = subparsers.add_parser('enumerate', help='List all available devices')
     enumerate_parser.set_defaults(func=enumerate_handler)
 
-    getmasterxpub_parser = subparsers.add_parser('getmasterxpub', help='Get the extended public key at m/44\'/0\'/0\'')
+    getmasterxpub_parser = subparsers.add_parser('getmasterxpub', help='Get the extended public key for BIP 44 standard derivation paths. Convenience function to get xpubs given the address type, account, and chain type.')
+    getmasterxpub_parser.add_argument("--addr-type", help="Get the master xpub used to derive addresses for this address type", type=AddressType.argparse, choices=list(AddressType), default=AddressType.WIT_V0) # type: ignore
+    getmasterxpub_parser.add_argument("--account", help="The account number", type=int, default=0)
     getmasterxpub_parser.set_defaults(func=getmasterxpub_handler)
 
     signtx_parser = subparsers.add_parser('signtx', help='Sign a PSBT')

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -166,7 +166,7 @@ def find_device(
             pass # Ignore things we wouldn't get fingerprints for
     return None
 
-def getmasterxpub(client: HardwareWalletClient) -> Dict[str, str]:
+def getmasterxpub(client: HardwareWalletClient, addrtype: AddressType = AddressType.WIT_V0, account: int = 0) -> Dict[str, str]:
     """
     Get the master extended public key from a client
 
@@ -174,7 +174,7 @@ def getmasterxpub(client: HardwareWalletClient) -> Dict[str, str]:
     :return: A dictionary containing the public key at the ``m/44'/0'/0'`` derivation path.
         Returned as ``{"xpub": <xpub string>}``.
     """
-    return {"xpub": client.get_master_xpub().to_string()}
+    return {"xpub": client.get_master_xpub(addrtype, account).to_string()}
 
 def signtx(client: HardwareWalletClient, psbt: str) -> Dict[str, str]:
     """

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -24,6 +24,8 @@ import platform
 
 from ._base58 import xpub_to_pub_hex
 from .key import (
+    get_bip44_purpose,
+    get_bip44_chain,
     H_,
     HARDENED_FLAG,
     is_hardened,
@@ -49,7 +51,6 @@ from .descriptor import (
 from .devices import __all__ as all_devs
 from .common import (
     AddressType,
-    Chain,
 )
 from .hwwclient import HardwareWalletClient
 from .psbt import PSBT
@@ -292,19 +293,10 @@ def getdescriptor(
     parsed_path = []
     if not path:
         # Purpose
-        if is_wpkh:
-            parsed_path.append(H_(84))
-        elif is_sh_wpkh:
-            parsed_path.append(H_(49))
-        else:
-            assert addr_type == AddressType.LEGACY
-            parsed_path.append(H_(44))
+        parsed_path.append(H_(get_bip44_purpose(addr_type)))
 
         # Coin type
-        if client.chain == Chain.MAIN:
-            parsed_path.append(H_(0))
-        else:
-            parsed_path.append(H_(1))
+        parsed_path.append(H_(get_bip44_chain(client.chain)))
 
         # Account
         parsed_path.append(H_(account))

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -12,7 +12,11 @@ from typing import (
     Union,
 )
 from .descriptor import PubkeyProvider
-from .key import ExtendedKey
+from .key import (
+    ExtendedKey,
+    get_bip44_purpose,
+    get_bip44_chain,
+)
 from .psbt import PSBT
 from .common import AddressType, Chain
 
@@ -41,16 +45,17 @@ class HardwareWalletClient(object):
         self.xpub_cache: Dict[str, str] = {}
         self.expert = expert
 
-    def get_master_xpub(self) -> ExtendedKey:
+    def get_master_xpub(self, addrtype: AddressType = AddressType.WIT_V0, account: int = 0) -> ExtendedKey:
         """
-        Get the master BIP 44 public key.
+        Retrieves a BIP 44 master public key
 
-        Retrieves the public key at the "m/44h/0h/0h" derivation path.
+        Get the extended public key used to derive receiving and change addresses with the BIP 44 derivation path scheme.
+        The returned xpub will be dependent on the address type requested, the chain type, and the BIP 44 account number.
 
-        :return: The extended public key at "m/44h/0h/0h"
+        :return: The extended public key
         """
-        # FIXME testnet is not handled yet
-        return self.get_pubkey_at_path("m/44h/0h/0h")
+        path = f"m/{get_bip44_purpose(addrtype)}h/{get_bip44_chain(self.chain)}h/{account}h"
+        return self.get_pubkey_at_path(path)
 
     def get_master_fingerprint(self) -> bytes:
         """

--- a/hwilib/key.py
+++ b/hwilib/key.py
@@ -12,6 +12,8 @@ Classes and utilities for working with extended public keys, key origins, and ot
 
 from . import _base58 as base58
 from .common import (
+    AddressType,
+    Chain,
     hash256,
     hash160,
 )
@@ -350,3 +352,33 @@ def parse_path(nstr: str) -> List[int]:
         return [str_to_harden(x) for x in n]
     except Exception:
         raise ValueError("Invalid BIP32 path", nstr)
+
+
+def get_bip44_purpose(addrtype: AddressType) -> int:
+    """
+    Determine the BIP 44 purpose based on the given :class:`~hwilib.common.AddressType`.
+
+    :param addrtype: The address type
+    """
+    if addrtype == AddressType.LEGACY:
+        return 44
+    elif addrtype == AddressType.SH_WIT_V0:
+        return 49
+    elif addrtype == AddressType.WIT_V0:
+        return 84
+    else:
+        raise ValueError("Unknown address type")
+
+
+def get_bip44_chain(chain: Chain) -> int:
+    """
+    Determine the BIP 44 coin type based on the Bitcoin chain type.
+
+    For the Bitcoin mainnet chain, this returns 0. For the other chains, this returns 1.
+
+    :param chain: The chain
+    """
+    if chain == Chain.MAIN:
+        return 0
+    else:
+        return 1

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -154,31 +154,31 @@ class TestDeviceConnect(DeviceTestCase):
         self.assertTrue(found)
 
     def test_no_type(self):
-        gmxp_res = self.do_command(['getmasterxpub'])
+        gmxp_res = self.do_command(['getmasterxpub', "--addr-type", "legacy"])
         self.assertIn('error', gmxp_res)
         self.assertEqual(gmxp_res['error'], 'You must specify a device type or fingerprint for all commands except enumerate')
         self.assertIn('code', gmxp_res)
         self.assertEqual(gmxp_res['code'], -1)
 
     def test_path_type(self):
-        gmxp_res = self.do_command(self.get_password_args() + ['-t', self.type, '-d', self.path, 'getmasterxpub'])
+        gmxp_res = self.do_command(self.get_password_args() + ['-t', self.type, '-d', self.path, 'getmasterxpub', "--addr-type", "legacy"])
         self.assertEqual(gmxp_res['xpub'], self.master_xpub)
 
     def test_fingerprint_autodetect(self):
-        gmxp_res = self.do_command(self.get_password_args() + ['-f', self.fingerprint, 'getmasterxpub'])
+        gmxp_res = self.do_command(self.get_password_args() + ['-f', self.fingerprint, 'getmasterxpub', "--addr-type", "legacy"])
         self.assertEqual(gmxp_res['xpub'], self.master_xpub)
 
         # Nonexistent fingerprint
-        gmxp_res = self.do_command(self.get_password_args() + ['-f', '0000ffff', 'getmasterxpub'])
+        gmxp_res = self.do_command(self.get_password_args() + ['-f', '0000ffff', 'getmasterxpub', "--addr-type", "legacy"])
         self.assertEqual(gmxp_res['error'], 'Could not find device with specified fingerprint')
         self.assertEqual(gmxp_res['code'], -3)
 
     def test_type_only_autodetect(self):
-        gmxp_res = self.do_command(self.get_password_args() + ['-t', self.type, 'getmasterxpub'])
+        gmxp_res = self.do_command(self.get_password_args() + ['-t', self.type, 'getmasterxpub', "--addr-type", "legacy"])
         self.assertEqual(gmxp_res['xpub'], self.master_xpub)
 
         # Unknown device type
-        gmxp_res = self.do_command(['-t', 'fakedev', '-d', 'fakepath', 'getmasterxpub'])
+        gmxp_res = self.do_command(['-t', 'fakedev', '-d', 'fakepath', 'getmasterxpub', "--addr-type", "legacy"])
         self.assertEqual(gmxp_res['error'], 'Unknown device type specified')
         self.assertEqual(gmxp_res['code'], -4)
 

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -146,7 +146,7 @@ class TestKeepkeyGetxpub(KeepkeyTestCase):
                 load_device_by_mnemonic(client=self.client, mnemonic=vec['mnemonic'], pin='', passphrase_protection=False, label='test', language='english')
 
                 # Test getmasterxpub
-                gmxp_res = self.do_command(['-t', 'keepkey', '-d', 'udp:127.0.0.1:21324', 'getmasterxpub'])
+                gmxp_res = self.do_command(['-t', 'keepkey', '-d', 'udp:127.0.0.1:21324', 'getmasterxpub', "--addr-type", "legacy"])
                 self.assertEqual(gmxp_res['xpub'], vec['master_xpub'])
 
                 # Test the path derivs

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -148,7 +148,7 @@ class TestTrezorGetxpub(TrezorTestCase):
                 load_device_by_mnemonic(client=self.client, mnemonic=vec['mnemonic'], pin='', passphrase_protection=False, label='test', language='english')
 
                 # Test getmasterxpub
-                gmxp_res = self.do_command(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', 'getmasterxpub'])
+                gmxp_res = self.do_command(['-t', 'trezor', '-d', 'udp:127.0.0.1:21324', 'getmasterxpub', "--addr-type", "legacy"])
                 self.assertEqual(gmxp_res['xpub'], vec['master_xpub'])
 
                 # Test the path derivs


### PR DESCRIPTION
BIP 44 specifies some additional arguments that are used in the derivation path; these are the address type (purpose), the chain type, and account number. Previously `getmasterxpub` would only output the xpub at the fixed path `m/44'/0'/0'`. This PR adds parameters to `getmasterxpub` to specify the purpose (via `--addr-type`), and the account (via `--account`). Additionally, the chain type will also be taken into account when determining the path to use.

Fixes #309

Based on #470 for the addrtype rename.