### PR TITLE
ledger: ensure only Bitcoin and Bitcoin Test apps are active

### DIFF
--- a/hwilib/devices/btchip/btchip.py
+++ b/hwilib/devices/btchip/btchip.py
@@ -26,8 +26,10 @@ from binascii import hexlify, unhexlify
 
 class btchip:
 	BTCHIP_CLA = 0xe0
+	BTCHIP_CLA_COMMON_SDK = 0xb0
 	BTCHIP_JC_EXT_CLA = 0xf0
 
+	BTCHIP_INS_GET_APP_NAME_AND_VERSION = 0x01
 	BTCHIP_INS_SET_ALTERNATE_COIN_VERSION = 0x14
 	BTCHIP_INS_SETUP = 0x20
 	BTCHIP_INS_VERIFY_PIN = 0x22
@@ -406,6 +408,23 @@ class btchip:
 		apdu.extend(params)
 		response = self.dongle.exchange(bytearray(apdu))
 		return response
+
+	def getAppName(self):
+		apdu = [ self.BTCHIP_CLA_COMMON_SDK, self.BTCHIP_INS_GET_APP_NAME_AND_VERSION, 0x00, 0x00, 0x00 ]
+		try:
+			response = self.dongle.exchange(bytearray(apdu))
+			name_len = response[1]
+			name = response[2:][:name_len]
+			if b'OLOS' not in name:
+				return name.decode('ascii')
+		except BTChipException as e:
+			if e.sw == 0x6faa:
+				# ins not implemented"
+				return None
+			if e.sw == 0x6d00:
+				# Not in an app, return just a string saying that
+				return "not in an app"
+			raise
 
 	def getFirmwareVersion(self):
 		result = {}

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -21,6 +21,7 @@ from ..errors import (
     DeviceConnectionError,
     DeviceFailureError,
     UnavailableActionError,
+    UnknownDeviceError,
     common_err_msgs,
     handle_errors,
 )
@@ -135,6 +136,9 @@ class LedgerClient(HardwareWalletClient):
             self.dongle = HIDDongleHIDAPI(device, True, logging.getLogger().getEffectiveLevel() == logging.DEBUG)
 
         self.app = btchip(self.dongle)
+
+        if self.app.getAppName() not in ["Bitcoin", "Bitcoin Test", "app"]:
+            raise UnknownDeviceError("Ledger is not in either the Bitcoin or Bitcoin Testnet app")
 
     @ledger_exception
     def get_pubkey_at_path(self, path: str) -> ExtendedKey:
@@ -460,6 +464,9 @@ def enumerate(password: str = '') -> List[Dict[str, Any]]:
                         continue
                     else:
                         raise
+                except UnknownDeviceError:
+                    # This only happens if the ledger is not in the Bitcoin app, so skip it
+                    continue
 
             if client:
                 client.close()


### PR DESCRIPTION
When the user is in an app on the Ledger that is not Bitcoin or Bitcoin Test, we should not be enumerating the device or allowing them to use HWI as unexpected and unsupported behavior may occur. To do this, this PR pulls in (part of) #362 in order to get the current app name. Then it checks that the app name is one of `Bitcoin`, `Bitcoin Test`, or `app` (for the app included in Speculos). For older devices which do not implement this instruction, the name is returned as `None`. Such devices will be enumerated and accessible as previously as we do not want to lock out users using old devices.

Closes #158