### PR TITLE
bitbox02: fix singlesig signing regression

### DIFF
--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -756,7 +756,10 @@ class Bitbox02Client(HardwareWalletClient):
                 )
 
         assert bip44_account is not None
-        if len(script_configs) == 1 and script_configs[0].script_config.multisig:
+        if (
+            len(script_configs) == 1
+            and script_configs[0].script_config.WhichOneof("config") == "multisig"
+        ):
             self._maybe_register_script_config(
                 script_configs[0].script_config, script_configs[0].keypath
             )


### PR DESCRIPTION
`script_configs[0].script_config.multisig` is always True - a protobuf
pitfall. The way to check which variant it is is by using `WhichOneof`.