### PR TITLE
Handle PassphraseRequest after sending pin

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -685,6 +685,10 @@ class TrezorClient(HardwareWalletClient):
                 if self.client.features.unlocked:
                     raise DeviceAlreadyUnlockedError('The PIN has already been sent to this device')
             return False
+        elif isinstance(resp, messages.PassphraseRequest):
+            pass_resp = self.client.call_raw(messages.PassphraseAck(passphrase=self.client.ui.get_passphrase(available_on_device=False), on_device=False))
+            if isinstance(pass_resp, messages.Deprecated_PassphraseStateRequest):
+                self.client.call_raw(messages.Deprecated_PassphraseStateAck())
         return True
 
     @trezor_exception

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -339,10 +339,10 @@ def trezor_test_suite(emulator, rpc, userpass, interface, model):
     suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestSignMessage, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
-    suite.addTest(TrezorTestCase.parameterize(TestTrezorGetxpub, emulator=dev_emulator, interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'trezor_{}_simulator'.format(model), full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     if model != 't':
         suite.addTest(TrezorTestCase.parameterize(TestTrezorManCommands, emulator=dev_emulator, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'trezor_{}_simulator'.format(model), full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
+    suite.addTest(TrezorTestCase.parameterize(TestTrezorGetxpub, emulator=dev_emulator, interface=interface))
 
     result = unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)
     sys.stderr = sys.__stderr__

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -217,7 +217,7 @@ class TestTrezorManCommands(TrezorTestCase):
 
         # Set a PIN
         device.wipe(self.client)
-        load_device_by_mnemonic(client=self.client, mnemonic='alcohol woman abuse must during monitor noble actual mixed trade anger aisle', pin='1234', passphrase_protection=False, label='test')
+        load_device_by_mnemonic(client=self.client, mnemonic='alcohol woman abuse must during monitor noble actual mixed trade anger aisle', pin='1234', passphrase_protection=True, label='test')
         self.client.lock(_refresh_features=False)
         self.client.end_session()
         result = self.do_command(self.dev_args + ['enumerate'])


### PR DESCRIPTION
After sending the PIN to a Trezor 1, it is possible that a `PassphraseRequest` is returned. When the device does this, it enters a state where it expects only a limited set of messages. To resolve this, we need to send the passphrase to the device so that it proceeds to its normal state. Otherwise any attempts to communicate with the device will fail. This can be observed after doing `sendpin` and then `enumerate`. In the `enumerate` result, there will be an error for the device.

Also added a test for this. The `sendpin` test is updated to set a passphrase on the Trezor.

Fixes #476