### PR TITLE
Properly handle and test sortedmulti descriptors

### DIFF
--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -457,7 +457,7 @@ def displayaddress(
                     addr_type = AddressType.SH_WIT
                 elif not is_sh and is_wsh:
                     addr_type = AddressType.WIT
-                return {"address": client.display_multisig_address(descriptor.thresh, descriptor.pubkeys, addr_type)}
+                return {"address": client.display_multisig_address(addr_type, descriptor)}
         is_wpkh = isinstance(descriptor, WPKHDescriptor)
         if isinstance(descriptor, PKHDescriptor) or is_wpkh:
             pubkey = descriptor.pubkeys[0]

--- a/hwilib/descriptor.py
+++ b/hwilib/descriptor.py
@@ -306,7 +306,8 @@ class MultisigDescriptor(Descriptor):
         """
         super().__init__(pubkeys, None, "sortedmulti" if is_sorted else "multi")
         self.thresh = thresh
-        if is_sorted:
+        self.is_sorted = is_sorted
+        if self.is_sorted:
             self.pubkeys.sort()
 
     def to_string_no_checksum(self) -> str:
@@ -319,8 +320,10 @@ class MultisigDescriptor(Descriptor):
             m = (self.thresh + 0x50).to_bytes(1, "big") if self.thresh > 0 else b"\x00"
         n = (len(self.pubkeys) + 0x50).to_bytes(1, "big") if len(self.pubkeys) > 0 else b"\x00"
         script: bytes = m
-        for p in self.pubkeys:
-            pk = p.get_pubkey_bytes(pos)
+        der_pks = [p.get_pubkey_bytes(pos) for p in self.pubkeys]
+        if self.is_sorted:
+            der_pks.sort()
+        for pk in der_pks:
             script += len(pk).to_bytes(1, "big") + pk
         script += n + b"\xae"
 

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -31,7 +31,7 @@ from ..common import (
     Chain,
     hash256,
 )
-from ..descriptor import PubkeyProvider
+from ..descriptor import MultisigDescriptor
 from ..hwwclient import HardwareWalletClient
 from ..errors import (
     ActionCanceledError,
@@ -581,7 +581,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         """
         raise UnavailableActionError('The Digital Bitbox does not have a screen to display addresses on')
 
-    def display_multisig_address(self, threshold: int, pubkeys: List[PubkeyProvider], addr_type: AddressType) -> str:
+    def display_multisig_address(self, addr_type: AddressType, multisig: MultisigDescriptor) -> str:
         """
         The BitBox01 does not have a screen to display addresses on.
 

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -13,7 +13,7 @@ from typing import (
     Tuple,
 )
 
-from ..descriptor import PubkeyProvider
+from ..descriptor import MultisigDescriptor
 from ..hwwclient import HardwareWalletClient
 from ..errors import (
     ActionCanceledError,
@@ -361,9 +361,8 @@ class LedgerClient(HardwareWalletClient):
     @ledger_exception
     def display_multisig_address(
         self,
-        threshold: int,
-        pubkeys: List[PubkeyProvider],
         addr_type: AddressType,
+        multisig: MultisigDescriptor,
     ) -> str:
         raise BadArgumentError("The Ledger Nano S and X do not support P2SH address display")
 

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -7,11 +7,10 @@ The :class:`HardwareWalletClient` is the class which all of the specific device 
 
 from typing import (
     Dict,
-    List,
     Optional,
     Union,
 )
-from .descriptor import PubkeyProvider
+from .descriptor import MultisigDescriptor
 from .key import (
     ExtendedKey,
     get_bip44_purpose,
@@ -123,16 +122,14 @@ class HardwareWalletClient(object):
 
     def display_multisig_address(
         self,
-        threshold: int,
-        pubkeys: List[PubkeyProvider],
         addr_type: AddressType,
+        multisig: MultisigDescriptor,
     ) -> str:
         """
-        Display and return the multisig address of specified type given the threshold and pubkeys.
+        Display and return the multisig address of specified type given the descriptor.
 
-        :param threshold: The number of signers required in the multisig
-        :param pubkeys: The public keys, as found in a descriptor, in the multisig
         :param addr_type: The address type
+        :param multisig: A :class:`~hwilib.descriptor.MultisigDescriptor` that describes the multisig to display.
         :return: The retrieved address also being shown by the device
         """
         raise NotImplementedError("The HardwareWalletClient base class "


### PR DESCRIPTION
Implements better handling of `sortedmulti` descriptors. This is an API breaking change as `display_multisig_address` is changed to take the underlying `MultisigDescriptor` directly instead of the parameters stored within it.

For BitBox02 and Coldcard, since they only use BIP 67, they now require `sortedmulti` descriptors only.

For Trezors, `sortedmulti` is now being handled correctly. If a `sortedmulti` is provided, then the keys will be sorted appropriately prior to being sent to the Trezor for handling.

Lastly, tests are added to test both `multi` and `sortedmulti`, as well as both hex pubkeys and xpubs.

Fixes #487