### PR TITLE
Add missing argument to PassphraseUI.get_passphrase

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -211,7 +211,7 @@ class PassphraseUI:
     def disallow_passphrase(self) -> None:
         self.return_passphrase = False
 
-    def get_passphrase(self) -> str:
+    def get_passphrase(self, available_on_device: bool) -> str:
         if self.return_passphrase:
             return self.passphrase
         raise ValueError('Passphrase from Host is not allowed for Trezor T')


### PR DESCRIPTION
get_passphrase was missing the argument available_on_device which causes some things to fail.

Fixes #489