### PR TITLE
trezor: Return PASSPHRASE_ON_DEVICE if passphrase entry on device is available

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -29,7 +29,7 @@ from ..errors import (
     common_err_msgs,
     handle_errors,
 )
-from .trezorlib.client import TrezorClient as Trezor
+from .trezorlib.client import TrezorClient as Trezor, PASSPHRASE_ON_DEVICE
 from .trezorlib.debuglink import TrezorClientDebugLink
 from .trezorlib.exceptions import Cancelled, TrezorFailure
 from .trezorlib.transport import (
@@ -211,7 +211,9 @@ class PassphraseUI:
     def disallow_passphrase(self) -> None:
         self.return_passphrase = False
 
-    def get_passphrase(self, available_on_device: bool) -> str:
+    def get_passphrase(self, available_on_device: bool) -> object:
+        if available_on_device:
+            return PASSPHRASE_ON_DEVICE
         if self.return_passphrase:
             return self.passphrase
         raise ValueError('Passphrase from Host is not allowed for Trezor T')


### PR DESCRIPTION
Somewhere between firmware versions 2.3.0 and 2.3.6, the Trezor T started using a slightly different message which results in our passphrase handling incorrectly giving the passphrase from the host instead of forcing passphrase entry on device. We fix this issue by returning the correct object to indicate that passphrase entry should occur on device.