### PR TITLE
Use buster-slim for binary build

### DIFF
--- a/contrib/build.Dockerfile
+++ b/contrib/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
Bumps the dockerfile used for the binary build to use buster-slim instead of stretch-slim.

Appears to fix #480