### PR TITLE
Fix installing Wine Development and staging builds on Debian Buster

### DIFF
--- a/contrib/build.Dockerfile
+++ b/contrib/build.Dockerfile
@@ -39,9 +39,8 @@ ENV BUILD_TIME="00:00:00"
 RUN eval "$(pyenv init -)" && eval "$(pyenv virtualenv-init -)" && cat /opt/reproducible-python.diff | pyenv install -kp 3.6.12
 
 RUN dpkg --add-architecture i386
-RUN wget -nc https://dl.winehq.org/wine-builds/winehq.key
-RUN apt-key add winehq.key
-RUN echo "deb https://dl.winehq.org/wine-builds/debian/ buster main" >> /etc/apt/sources.list
+RUN wget -O- -q https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/Debian_10/Release.key | apt-key add -
+RUN echo "deb http://download.opensuse.org/repositories/Emulators:/Wine:/Debian/Debian_10 ./" | tee /etc/apt/sources.list.d/wine-obs.list
 RUN apt-get update
 RUN apt-get install --install-recommends -y \
     wine-stable-amd64 \


### PR DESCRIPTION
`libfaudio0` dependency is the missing for Wine staging and Wine development. 

This dependency is not directly available in the official WineHQ Ubuntu and Debian 10 repository because it's not part of the Wine project. It is mentioned (along with a link to a forum post) at the top of the WineHQ Ubuntu and Debian installation pages that users need to download and install this package separately, but many users ignore it / don't read that part. On the other hand, those upgrading from older Wine builds / those that already have the WineHQ repository added never get to the official WineHQ installation page, so they won't notice this very important detail.

It's worth noting that the missing `libfaudio0` dependency has been added to the Debian bullseye / sid and the upcoming Ubuntu 19.10 release, so this is only an issue for older releases.