### PR TITLE
Fix release builds docker container

### DIFF
--- a/contrib/build.Dockerfile
+++ b/contrib/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:stretch-slim
 
 SHELL ["/bin/bash", "-c"]
 
@@ -44,7 +44,7 @@ RUN eval "$(pyenv init --path)" && eval "$(pyenv virtualenv-init -)" && cat /opt
 RUN dpkg --add-architecture i386
 RUN wget -nc https://dl.winehq.org/wine-builds/winehq.key
 RUN apt-key add winehq.key
-RUN echo "deb https://dl.winehq.org/wine-builds/debian/ buster main" >> /etc/apt/sources.list
+RUN echo "deb https://dl.winehq.org/wine-builds/debian/ stretch main" >> /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get install --install-recommends -y \
     wine-stable-amd64 \

--- a/contrib/build.Dockerfile
+++ b/contrib/build.Dockerfile
@@ -31,12 +31,14 @@ RUN apt-get install -y \
     g++-mingw-w64-x86-64
 
 RUN curl https://pyenv.run | bash
-ENV PATH="/root/.pyenv/bin:$PATH"
+ENV PYENV_ROOT="/root/.pyenv"
+ENV PATH="$PYENV_ROOT/bin:$PATH"
+
 COPY contrib/reproducible-python.diff /opt/reproducible-python.diff
 ENV PYTHON_CONFIGURE_OPTS="--enable-shared"
 ENV BUILD_DATE="Jan  1 2019"
 ENV BUILD_TIME="00:00:00"
-RUN eval "$(pyenv init -)" && eval "$(pyenv virtualenv-init -)" && cat /opt/reproducible-python.diff | pyenv install -kp 3.6.12
+RUN eval "$(pyenv init --path)" && eval "$(pyenv virtualenv-init -)" && cat /opt/reproducible-python.diff | pyenv install -kp 3.6.12
 
 RUN dpkg --add-architecture i386
 RUN wget -nc https://dl.winehq.org/wine-builds/winehq.key

--- a/contrib/build.Dockerfile
+++ b/contrib/build.Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get install -y \
     faketime \
     zip \
     dos2unix \
-    g++-mingw-w64-x86-64
+    g++-mingw-w64-x86-64 \
+    qt5-default
 
 RUN curl https://pyenv.run | bash
 ENV PYENV_ROOT="/root/.pyenv"

--- a/contrib/build_bin.sh
+++ b/contrib/build_bin.sh
@@ -3,7 +3,7 @@
 
 set -ex
 
-eval "$(pyenv init -)"
+eval "$(pyenv init --path)"
 eval "$(pyenv virtualenv-init -)"
 pip install -U pip
 pip install poetry

--- a/contrib/build_dist.sh
+++ b/contrib/build_dist.sh
@@ -3,7 +3,7 @@
 
 set -ex
 
-eval "$(pyenv init -)"
+eval "$(pyenv init --path)"
 eval "$(pyenv virtualenv-init -)"
 pip install -U pip
 pip install poetry


### PR DESCRIPTION
Repairs the docker container used for release builds

* Pyenv made some changes to how it is activated, update the pyenv commands to match those
* Downgrade to Debian stretch to fix #506. Stretch uses an older glibc. Somehow this change does not reintroduce #480
* Install `qt5-default` in the container. Pyinstaller now seems to be having some problems with missing libraries when qt5 is not installed. 