### PR TITLE
Convenience scripts for making SHA256SUMS.txt.asc

### DIFF
--- a/contrib/build_bin.sh
+++ b/contrib/build_bin.sh
@@ -29,5 +29,13 @@ OS=`uname | tr '[:upper:]' '[:lower:]'`
 if [[ $OS == "darwin" ]]; then
     OS="mac"
 fi
-tar -czf "hwi-${VERSION}-${OS}-amd64.tar.gz" hwi hwi-qt
+target_tarfile="hwi-${VERSION}-${OS}-amd64.tar.gz"
+tar -czf $target_tarfile hwi hwi-qt
+
+# Copy the binaries to subdir for shasum
+target_dir="$target_tarfile.dir"
+mkdir $target_dir
+mv hwi $target_dir
+mv hwi-qt $target_dir
+
 popd

--- a/contrib/build_wine.sh
+++ b/contrib/build_wine.sh
@@ -89,5 +89,13 @@ unset PYTHONHASHSEED
 # Make the final compressed package
 pushd dist
 VERSION=`$POETRY run hwi --version | cut -d " " -f 2 | dos2unix`
-zip "hwi-${VERSION}-windows-amd64.zip" hwi.exe hwi-qt.exe
+target_zipfile="hwi-${VERSION}-windows-amd64.zip"
+zip $target_zipfile hwi.exe hwi-qt.exe
+
+# Copy the binaries to subdir for shasum
+target_dir="$target_zipfile.dir"
+mkdir $target_dir
+mv hwi.exe $target_dir
+mv hwi-qt.exe $target_dir
+
 popd

--- a/contrib/make_shasums.sh
+++ b/contrib/make_shasums.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+# Script for generating the SHA256SUMS.txt file
+
+set -ex
+
+pushd dist
+
+sums=SHA256SUMS.txt
+sum_files=`find . -type f -not -name *$sums* | sort`
+sha256sum $sum_files > $sums
+sed -i 's/\.\///g' $sums
+sed -i 's/\.dir//g' $sums
+
+popd

--- a/docs/development/release-process.rst
+++ b/docs/development/release-process.rst
@@ -5,8 +5,10 @@ Release Process
 2. Build distribution archives for PyPi with ``contrib/build_dist.sh``
 3. For MacOS and Linux, use ``contrib/build_bin.sh``. This needs to be run on a MacOS machine for the MacOS binary and on a Linux machine for the linux one.
 4. For Windows, use ``contrib/build_wine.sh`` to build the Windows binary using wine
-5. Upload distribution archives to PyPi
-6. Upload distribution archives and standalone binaries to Github
+5. Make ``SHA256SUMS.txt`` using ``contrib/make_shasums.sh``.
+6. Make ``SHA256SUMS.txt.asc`` using ``gpg --clearsign SHA256SUMS.txt``
+7. Upload distribution archives to PyPi
+8. Upload distribution archives and standalone binaries to Github
 
 Deterministic builds with Docker
 ================================


### PR DESCRIPTION
These scripts make it easier for me to make the GPG signed sha256sums file. The individual binaries are copied to subdirs named after the tarball or zipfile. Then the `make_shasums.sh` script can make the `SHA256SUMS.txt` file. Lastly, the release process docs are updated to mention this part of the process.