### PR TITLE
Return status indicating if we signed the PSBT

### DIFF
--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -188,7 +188,8 @@ def signtx(client: HardwareWalletClient, psbt: str) -> Dict[str, str]:
     # Deserialize the transaction
     tx = PSBT()
     tx.deserialize(psbt)
-    return {"psbt": client.sign_tx(tx).serialize()}
+    result = client.sign_tx(tx).serialize()
+    return {"psbt": result, "signed": result != psbt}
 
 def getxpub(client: HardwareWalletClient, path: str, expert: bool = False) -> Dict[str, Any]:
     """


### PR DESCRIPTION
Report back whether we were able to sign PSBT, rather than having to compare two long base64 strings by eye; which can be very frustrating during multiple debug sessions.