### PR TITLE
Repair CI and update tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -121,7 +121,7 @@ lint_task:
   test_script:
     - flake8
 
-basic_test_task:
+task:
   install_script:
     - poetry install
   matrix:
@@ -171,7 +171,7 @@ bitcoind_builder_task:
     BUILD_BITCOIND: 1
   build_script: cd test; ./setup_environment.sh --bitcoind; cd ..
 
-sim_builder_task:
+task:
   matrix:
     << : *SIM_BUILD_MATRIX_TEMPLATE
   build_script: cd test; ./setup_environment.sh $DEVICE; cd ..
@@ -185,7 +185,7 @@ dist_builder_task:
     - contrib/build_dist.sh
     - sha256sum dist/*
 
-dist_test_task:
+task:
   matrix:
     << : *DEVICE_MATRIX_TEMPLATE
   << : *DIST_CACHE_TEMPLATE
@@ -203,7 +203,7 @@ dist_test_task:
   on_failure:
     failed_script: tail -v -n +1 test/*.std*
 
-device_test_task:
+task:
   matrix:
     << : *DEVICE_MATRIX_TEMPLATE
   << : *BITCOIND_CACHE_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -159,7 +159,7 @@ wine_builder_task:
     dockerfile: contrib/build.Dockerfile
   build_script:
     - contrib/build_wine.sh
-    - sha256sum dist/*
+    - find dist -type f -exec sha256sum {} \;
 
 bitcoind_builder_task:
   << : *BITCOIND_CACHE_TEMPLATE
@@ -183,7 +183,7 @@ dist_builder_task:
   build_script:
     - contrib/build_bin.sh
     - contrib/build_dist.sh
-    - sha256sum dist/*
+    - find dist -type f -exec sha256sum {} \;
 
 task:
   matrix:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,9 +4,6 @@ container:
 env:
   EMAIL: cirrus@cirrus-ci.org
 
-sim_cache_fpr_template: &SIM_CACHE_FPR_TEMPLATE
-    fingerprint_script: echo $CIRRUS_BUILD_ID $DEVICE Simulator
-
 device_matrix_template: &DEVICE_MATRIX_TEMPLATE
   - env:
       DEVICE: --trezor-1
@@ -14,28 +11,36 @@ device_matrix_template: &DEVICE_MATRIX_TEMPLATE
       - Trezor 1 Sim Builder
       - dist_builder
       - bitcoind_builder
-    sim_work_cache:
-      folder: test/work/trezor-firmware
-      << : *SIM_CACHE_FPR_TEMPLATE
+    fetch_sim_script:
+      - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/Trezor 1 Sim Builder/sim/trezor-firmware.tar.gz"
+      - tar -xvf "trezor-firmware.tar.gz"
+      - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/bitcoind_builder/bitcoin/bitcoin.tar.gz"
+      - tar -xvf "bitcoin.tar.gz"
   - env:
       DEVICE: --trezor-t
     depends_on:
       - Trezor T Sim Builder
       - dist_builder
       - bitcoind_builder
-    sim_work_cache:
-      folder: test/work/trezor-firmware
-      << : *SIM_CACHE_FPR_TEMPLATE
+    fetch_sim_script:
+      - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/Trezor T Sim Builder/sim/trezor-firmware.tar.gz"
+      - tar -xvf "trezor-firmware.tar.gz"
+      - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/bitcoind_builder/bitcoin/bitcoin.tar.gz"
+      - tar -xvf "bitcoin.tar.gz"
   - env:
       DEVICE: --coldcard
     depends_on:
       - Coldcard Sim Builder
       - dist_builder
       - bitcoind_builder
-    sim_work_cache:
-      folder: test/work/firmware
-      << : *SIM_CACHE_FPR_TEMPLATE
+    fetch_sim_script:
+      - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/Coldcard Sim Builder/sim/coldcard-mpy.tar.gz"
+      - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/bitcoind_builder/bitcoin/bitcoin.tar.gz"
+      - tar -xvf "bitcoin.tar.gz"
     sim_install_script:
+      - pushd test/work; git clone --recursive https://github.com/Coldcard/firmware.git; popd
+      - tar -xvf "coldcard-mpy.tar.gz"
+      - pushd test/work/firmware; git am ../../data/coldcard-multisig.patch; popd
       - poetry run pip install -r test/work/firmware/requirements.txt
       - pip install -r test/work/firmware/requirements.txt
   - env:
@@ -44,18 +49,22 @@ device_matrix_template: &DEVICE_MATRIX_TEMPLATE
       - Bitbox01 Sim Builder
       - dist_builder
       - bitcoind_builder
-    sim_work_cache:
-      folder: test/work/mcu
-      << : *SIM_CACHE_FPR_TEMPLATE
+    fetch_sim_script:
+      - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/Bitbox01 Sim Builder/sim/mcu.tar.gz"
+      - tar -xvf "mcu.tar.gz"
+      - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/bitcoind_builder/bitcoin/bitcoin.tar.gz"
+      - tar -xvf "bitcoin.tar.gz"
   - env:
       DEVICE: --ledger
     depends_on:
       - Ledger Sim Builder
       - dist_builder
       - bitcoind_builder
-    sim_work_cache:
-      folder: test/work/speculos
-      << : *SIM_CACHE_FPR_TEMPLATE
+    fetch_sim_script:
+      - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/Ledger Sim Builder/sim/speculos.tar.gz"
+      - tar -xvf "speculos.tar.gz"
+      - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/bitcoind_builder/bitcoin/bitcoin.tar.gz"
+      - tar -xvf "bitcoin.tar.gz"
     sim_install_script:
       - poetry run pip install construct pyelftools mnemonic jsonschema
       - pip install construct pyelftools mnemonic jsonschema
@@ -65,57 +74,11 @@ device_matrix_template: &DEVICE_MATRIX_TEMPLATE
       - Keepkey Sim Builder
       - dist_builder
       - bitcoind_builder
-    sim_work_cache:
-      folder: test/work/keepkey-firmware
-      << : *SIM_CACHE_FPR_TEMPLATE
-
-sim_build_matrix_template: &SIM_BUILD_MATRIX_TEMPLATE
-  - env:
-      DEVICE: --trezor-1
-    name: Trezor 1 Sim Builder
-    sim_work_cache:
-      folder: test/work/trezor-firmware
-      << : *SIM_CACHE_FPR_TEMPLATE
-  - env:
-      DEVICE: --trezor-t
-    name: Trezor T Sim Builder
-    sim_work_cache:
-      folder: test/work/trezor-firmware
-      << : *SIM_CACHE_FPR_TEMPLATE
-  - env:
-      DEVICE: --coldcard
-    name: Coldcard Sim Builder
-    sim_work_cache:
-      folder: test/work/firmware
-      << : *SIM_CACHE_FPR_TEMPLATE
-  - env:
-      DEVICE: --bitbox01
-    name: Bitbox01 Sim Builder
-    sim_work_cache:
-      folder: test/work/mcu
-      << : *SIM_CACHE_FPR_TEMPLATE
-  - env:
-      DEVICE: --ledger
-    name: Ledger Sim Builder
-    sim_work_cache:
-      folder: test/work/speculos
-      << : *SIM_CACHE_FPR_TEMPLATE
-  - env:
-      DEVICE: --keepkey
-    name: Keepkey Sim Builder
-    sim_work_cache:
-      folder: test/work/keepkey-firmware
-      << : *SIM_CACHE_FPR_TEMPLATE
-
-bitcoind_cache_template: &BITCOIND_CACHE_TEMPLATE
-  bitcoind_work_cache:
-    folder: test/work/bitcoin
-    fingerprint_script: echo $CIRRUS_BUILD_ID bitcoind
-
-dist_cache_template: &DIST_CACHE_TEMPLATE
-  dist_cache:
-    folder: dist
-    fingerprint_script: echo $CIRRUS_BUILD_ID dist
+    fetch_sim_script:
+      - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/Keepkey Sim Builder/sim/keepkey-firmware.tar.gz"
+      - tar -xvf "keepkey-firmware.tar.gz"
+      - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/bitcoind_builder/bitcoin/bitcoin.tar.gz"
+      - tar -xvf "bitcoin.tar.gz"
 
 lint_task:
   test_script:
@@ -162,34 +125,107 @@ wine_builder_task:
     - find dist -type f -exec sha256sum {} \;
 
 bitcoind_builder_task:
-  << : *BITCOIND_CACHE_TEMPLATE
   bitcoind_cache:
     folder: test/work/bitcoin
   ccache_cache:
     folder: /root/.ccache
   env:
     BUILD_BITCOIND: 1
-  build_script: cd test; ./setup_environment.sh --bitcoind; cd ..
+  build_script:
+    - cd test; ./setup_environment.sh --bitcoind; cd ..
+    - tar -czf bitcoin.tar.gz test/work/bitcoin
+  bitcoin_artifacts:
+    path: "bitcoin.tar.gz"
 
 task:
-  matrix:
-    << : *SIM_BUILD_MATRIX_TEMPLATE
-  build_script: cd test; ./setup_environment.sh $DEVICE; cd ..
+  env:
+    DEVICE: --trezor-1
+  name: Trezor 1 Sim Builder
+  sim_work_cache:
+    folder: test/work/trezor-firmware
+  build_script:
+    - cd test; ./setup_environment.sh $DEVICE; cd ..
+    - tar -czf trezor-firmware.tar.gz test/work/trezor-firmware
+  sim_artifacts:
+    path: "trezor-firmware.tar.gz"
+
+task:
+  env:
+    DEVICE: --trezor-t
+  name: Trezor T Sim Builder
+  sim_work_cache:
+    folder: test/work/trezor-firmware
+  build_script:
+    - cd test; ./setup_environment.sh $DEVICE; cd ..
+    - tar -czf trezor-firmware.tar.gz test/work/trezor-firmware
+  sim_artifacts:
+    path: "trezor-firmware.tar.gz"
+
+task:
+  env:
+    DEVICE: --coldcard
+  name: Coldcard Sim Builder
+  sim_work_cache:
+    folder: test/work/firmware
+  build_script:
+    - cd test; ./setup_environment.sh $DEVICE; cd ..
+    - tar -czf coldcard-mpy.tar.gz test/work/firmware/external/micropython/ports/unix/coldcard-mpy test/work/firmware/unix/coldcard-mpy test/work/firmware/unix/l-mpy test/work/firmware/unix/l-port
+  sim_artifacts:
+    path: "coldcard-mpy.tar.gz"
+
+task:
+  env:
+    DEVICE: --bitbox01
+  name: Bitbox01 Sim Builder
+  sim_work_cache:
+    folder: test/work/mcu
+  build_script:
+    - cd test; ./setup_environment.sh $DEVICE; cd ..
+    - tar -czf mcu.tar.gz test/work/mcu
+  sim_artifacts:
+    path: "mcu.tar.gz"
+
+task:
+  env:
+    DEVICE: --ledger
+  name: Ledger Sim Builder
+  sim_work_cache:
+    folder: test/work/speculos
+  build_script:
+    - cd test; ./setup_environment.sh $DEVICE; cd ..
+    - tar -czf speculos.tar.gz test/work/speculos
+  sim_artifacts:
+    path: "speculos.tar.gz"
+
+task:
+  env:
+    DEVICE: --keepkey
+  name: Keepkey Sim Builder
+  sim_work_cache:
+    folder: test/work/keepkey-firmware
+  build_script:
+    - cd test; ./setup_environment.sh $DEVICE; cd ..
+    - tar -czf keepkey-firmware.tar.gz test/work/keepkey-firmware/bin
+  sim_artifacts:
+    path: "keepkey-firmware.tar.gz"
+
 
 dist_builder_task:
   container:
     dockerfile: contrib/build.Dockerfile
-  << : *DIST_CACHE_TEMPLATE
   build_script:
     - contrib/build_bin.sh
     - contrib/build_dist.sh
     - find dist -type f -exec sha256sum {} \;
+  built_dist_artifacts:
+    path: "dist/*"
 
 task:
   matrix:
     << : *DEVICE_MATRIX_TEMPLATE
-  << : *DIST_CACHE_TEMPLATE
-  << : *BITCOIND_CACHE_TEMPLATE
+  fetch_dist_script:
+    - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/dist_builder/built_dist.zip"
+    - unzip built_dist.zip
   matrix:
     - name: $DEVICE Wheel
       install_script: pip install dist/*.whl
@@ -199,6 +235,7 @@ task:
       test_script: cd test; ./run_tests.py $DEVICE --interface=cli --device-only; cd ..
     - name: $DEVICE Bindist
       install_script: poetry install
+      untar_bindist_script: cd dist; tar -xvf hwi*linux*.tar.gz; cd ..
       test_script: cd test; poetry run ./run_tests.py $DEVICE --interface=bindist --device-only; cd ..
   on_failure:
     failed_script: tail -v -n +1 test/*.std*
@@ -206,7 +243,6 @@ task:
 task:
   matrix:
     << : *DEVICE_MATRIX_TEMPLATE
-  << : *BITCOIND_CACHE_TEMPLATE
   matrix:
     - env:
         INTERFACE: library

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -66,8 +66,8 @@ device_matrix_template: &DEVICE_MATRIX_TEMPLATE
       - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/bitcoind_builder/bitcoin/bitcoin.tar.gz"
       - tar -xvf "bitcoin.tar.gz"
     sim_install_script:
-      - poetry run pip install construct pyelftools mnemonic jsonschema
-      - pip install construct pyelftools mnemonic jsonschema
+      - poetry run pip install construct flask-restful jsonschema mnemonic pyelftools pillow requests
+      - pip install construct flask-restful jsonschema mnemonic pyelftools pillow requests
   - env:
       DEVICE: --keepkey
     depends_on:

--- a/ci/cirrus.Dockerfile
+++ b/ci/cirrus.Dockerfile
@@ -3,36 +3,36 @@ FROM python:3.6
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install -y \
-    build-essential \
     autotools-dev \
     automake \
-    cmake \
-    pkg-config \
     bsdmainutils \
-    libtool \
-    curl \
-    git \
+    build-essential \
     ccache \
-    qemu-user-static \
-    libsdl2-dev \
-    libsdl2-image-dev \
+    cmake \
+    curl \
+    cython3 \
     gcc-arm-none-eabi \
-    libnewlib-arm-none-eabi \
     gcc-arm-linux-gnueabihf \
-    libc6-dev-armhf-cross \
-    libudev-dev \
-    libusb-1.0-0-dev \
-    libssl-dev \
-    libevent-dev \
-    libdb-dev \
-    libdb++-dev \
+    git \
     libboost-system-dev \
     libboost-filesystem-dev \
     libboost-chrono-dev \
     libboost-test-dev \
     libboost-thread-dev \
+    libc6-dev-armhf-cross \
+    libdb-dev \
+    libdb++-dev \
+    libevent-dev \
+    libnewlib-arm-none-eabi \
+    libsdl2-dev \
+    libsdl2-image-dev \
+    libssl-dev \
+    libtool \
+    libudev-dev \
+    libusb-1.0-0-dev \
+    pkg-config \
     protobuf-compiler \
-    cython3
+    qemu-user-static
 
 RUN pip install poetry flake8
 

--- a/ci/cirrus.Dockerfile
+++ b/ci/cirrus.Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get install -y \
     bsdmainutils \
     build-essential \
     ccache \
+    clang \    
     cmake \
     curl \
     cython3 \
@@ -35,6 +36,9 @@ RUN apt-get install -y \
     qemu-user-static
 
 RUN pip install poetry flake8
+RUN wget https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init
+RUN chmod +x rustup-init && ./rustup-init -y
+ENV PATH="/root/.cargo/bin:$PATH"
 
 ####################
 # Local build/test steps

--- a/contrib/build_wine.sh
+++ b/contrib/build_wine.sh
@@ -22,7 +22,7 @@ wine 'wineboot'
 
 # Install Python
 # Get the PGP keys
-wget -N -c "https://www.python.org/static/files/pubkeys.txt"
+wget -O pubkeys.txt -N -c "https://keybase.io/stevedower/pgp_keys.asc?fingerprint=7ed10b6531d7c8e1bc296021fc624643487034e5"
 gpg --import pubkeys.txt
 rm pubkeys.txt
 

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -146,7 +146,7 @@ class KeepkeyClient(TrezorClient):
 
         As Keepkeys are clones of the Trezor 1, please refer to `TrezorClient` for documentation.
         """
-        super(KeepkeyClient, self).__init__(path, password, expert)
+        super(KeepkeyClient, self).__init__(path, password, expert, KEEPKEY_HID_IDS, KEEPKEY_WEBUSB_IDS, KEEPKEY_SIMULATOR_PATH)
         self.type = 'Keepkey'
         self.client.vendors = ("keepkey.com")
         self.client.minimum_versions = {"K1-14AM": (0, 0, 0)}

--- a/test/data/coldcard-libngu.patch
+++ b/test/data/coldcard-libngu.patch
@@ -1,0 +1,39 @@
+From ed46f9ae6048aed6e694fd040909a972be4595d1 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Fri, 27 Aug 2021 22:08:14 -0400
+Subject: [PATCH] Build fixes for libngu on linux
+
+---
+ ngu/hash.c   | 2 +-
+ ngu/random.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ngu/hash.c b/ngu/hash.c
+index 72a16d5..c8e0653 100644
+--- a/ngu/hash.c
++++ b/ngu/hash.c
+@@ -286,7 +286,7 @@ void ripemd160(const uint8_t *msg, int msglen, uint8_t digest[20])
+ #error "untested; suspect endian challenge here"
+ #endif
+ 
+-    if(((uint32_t)digest) & 0x3) {
++    if(((uintptr_t)digest) & 0x3) {
+         // unaligned case
+         uint32_t    ctx[5];
+ 
+diff --git a/ngu/random.c b/ngu/random.c
+index 4bd3d8d..deef1d2 100644
+--- a/ngu/random.c
++++ b/ngu/random.c
+@@ -32,7 +32,7 @@ extern uint32_t rng_get(void);
+ 
+ #ifdef UNIX
+ # define CHIP_TRNG_SETUP()      
+-# define CHIP_TRNG_32()         arc4random()
++# define CHIP_TRNG_32()         random()
+ #endif
+ 
+ #ifndef CHIP_TRNG_SETUP
+-- 
+2.33.0
+

--- a/test/data/coldcard-multisig.patch
+++ b/test/data/coldcard-multisig.patch
@@ -1,47 +1,46 @@
-From f91b0cf38f640a031de08e27081599da13be92fe Mon Sep 17 00:00:00 2001
+From d217046502825fb238cca49546e2b314ccafa8ad Mon Sep 17 00:00:00 2001
 From: Andrew Chow <achow101-github@achow101.com>
 Date: Tue, 27 Nov 2018 17:32:44 -0500
 Subject: [PATCH 1/3] Use linux unix socket address format
 
 ---
- unix/frozen-modules/pyb.py | 6 +++---
+ unix/variant/pyb.py | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
-diff --git a/unix/frozen-modules/pyb.py b/unix/frozen-modules/pyb.py
-index 5341be7..b9d32d0 100644
---- a/unix/frozen-modules/pyb.py
-+++ b/unix/frozen-modules/pyb.py
-@@ -26,10 +26,10 @@ class USB_HID:
-         fn = b'/tmp/ckcc-simulator.sock'
+diff --git a/unix/variant/pyb.py b/unix/variant/pyb.py
+index d22bb1b..fe8e7ca 100644
+--- a/unix/variant/pyb.py
++++ b/unix/variant/pyb.py
+@@ -36,10 +36,10 @@ class USB_HID:
+         import usocket as socket
          self.pipe = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
          # If on linux, try commenting the following line
--        addr = bytes([len(fn)+2, socket.AF_UNIX] + list(fn))
-+        # addr = bytes([len(fn)+2, socket.AF_UNIX] + list(fn))
+-        addr = bytes([len(self.fn)+2, socket.AF_UNIX] + list(self.fn))
++        # addr = bytes([len(self.fn)+2, socket.AF_UNIX] + list(self.fn))
          # If on linux, try uncommenting the following two lines
 -        #import struct
--        #addr = struct.pack('H108s', socket.AF_UNIX, fn)
+-        #addr = struct.pack('H108s', socket.AF_UNIX, self.fn)
 +        import struct
-+        addr = struct.pack('H108s', socket.AF_UNIX, fn)
++        addr = struct.pack('H108s', socket.AF_UNIX, self.fn)
          while 1:
              try:
                  self.pipe.bind(addr)
 -- 
-2.30.0
+2.33.0
 
-
-From 32d4235a79e8cde7ee1c9901e0c834c310a29725 Mon Sep 17 00:00:00 2001
+From ea0fbe4eb7ba4c68ed60c262af3c1cea993061cb Mon Sep 17 00:00:00 2001
 From: Andrew Chow <achow101-github@achow101.com>
 Date: Tue, 17 Dec 2019 17:56:05 -0500
 Subject: [PATCH 2/3] Change default simulator multisig
 
 ---
- unix/frozen-modules/sim_settings.py | 6 +++++-
+ unix/variant/sim_settings.py | 6 +++++-
  1 file changed, 5 insertions(+), 1 deletion(-)
 
-diff --git a/unix/frozen-modules/sim_settings.py b/unix/frozen-modules/sim_settings.py
-index 650f255..cf5bbd4 100644
---- a/unix/frozen-modules/sim_settings.py
-+++ b/unix/frozen-modules/sim_settings.py
+diff --git a/unix/variant/sim_settings.py b/unix/variant/sim_settings.py
+index 130f20c..4f0c46b 100644
+--- a/unix/variant/sim_settings.py
++++ b/unix/variant/sim_settings.py
 @@ -68,7 +68,11 @@ if '--ms' in sys.argv:
          sim_defaults['multisig'] = [["CC-2-of-4", [2, 4], [[1130956047, "tpubDF2rnouQaaYrUEy2JM1YD3RFzew4onawGM4X2Re67gguTf5CbHonBRiFGe3Xjz7DK88dxBFGf2i7K1hef3PM4cFKyUjcbJXddaY9F5tJBoP"], [3503269483, "tpubDFcrvj5n7gyatVbr8dHCUfHT4CGvL8hREBjtxc4ge7HZgqNuPhFimPRtVg6fRRwfXiQthV9EBjNbwbpgV2VoQeL1ZNXoAWXxP2L9vMtRjax"], [2389277556, "tpubDExj5FnaUnPAjjgzELoSiNRkuXJG8Cm1pbdiA4Hc5vkAZHphibeVcUp6mqH5LuNVKbtLVZxVSzyja5X26Cfmx6pzRH6gXBUJAH7MiqwNyuM"], [3190206587, "tpubDFiuHYSJhNbHaGtB5skiuDLg12tRboh2uVZ6KGXxr8WVr28pLcS7F3gv8SsHFa2tm1jtx3VAuw56YfgRkdo6DXyfp51oygTKY3nJFT5jBMt"]], {"pp": "48'/1'/0'/1'", "ch": "XTN", "ft": 26}]]
      else:
@@ -56,10 +55,9 @@ index 650f255..cf5bbd4 100644
  
  if '--xfp' in sys.argv:
 -- 
-2.30.0
+2.33.0
 
-
-From 8cf7883d84ca5e30638b4aff0cd12c7e9a01e643 Mon Sep 17 00:00:00 2001
+From 9c6a8f180bd2589c3e0700ea0c6724a2430ee713 Mon Sep 17 00:00:00 2001
 From: Andrew Chow <achow101-github@achow101.com>
 Date: Wed, 27 Jan 2021 21:50:22 -0500
 Subject: [PATCH 3/3] Allow multisigs to share master fingerprint
@@ -69,10 +67,10 @@ Subject: [PATCH 3/3] Allow multisigs to share master fingerprint
  1 file changed, 24 insertions(+), 14 deletions(-)
 
 diff --git a/shared/multisig.py b/shared/multisig.py
-index b7e4f44..e3b5807 100644
+index 4ce66e4..a655516 100644
 --- a/shared/multisig.py
 +++ b/shared/multisig.py
-@@ -141,9 +141,9 @@ class MultisigWallet:
+@@ -142,9 +142,9 @@ class MultisigWallet:
          # calc useful cache value: numeric xfp+subpath, with lookup
          self.xfp_paths = {}
          for xfp, deriv, _ in self.xpubs:
@@ -84,7 +82,7 @@ index b7e4f44..e3b5807 100644
  
      @classmethod
      def render_addr_fmt(cls, addr_fmt):
-@@ -244,7 +244,11 @@ class MultisigWallet:
+@@ -243,7 +243,11 @@ class MultisigWallet:
  
      def get_xfp_paths(self):
          # return list of lists [xfp, *deriv]
@@ -97,7 +95,7 @@ index b7e4f44..e3b5807 100644
  
      @classmethod
      def find_match(cls, M, N, xfp_paths, addr_fmt=None):
-@@ -282,17 +286,23 @@ class MultisigWallet:
+@@ -281,17 +285,23 @@ class MultisigWallet:
          for x in xfp_paths:
              if x[0] not in self.xfp_paths:
                  return False
@@ -133,5 +131,5 @@ index b7e4f44..e3b5807 100644
  
          return True
 -- 
-2.30.0
+2.33.0
 

--- a/test/data/keepkey-build.patch
+++ b/test/data/keepkey-build.patch
@@ -1,0 +1,38 @@
+From 5657d7a0465cea36e840853f350f907e9301a451 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Tue, 31 Aug 2021 17:29:07 -0400
+Subject: [PATCH] include stdio and remove extra __stack_chk_guard
+
+---
+ lib/board/keepkey_board.c | 2 +-
+ tools/emulator/main.cpp   | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/lib/board/keepkey_board.c b/lib/board/keepkey_board.c
+index cfc957a6..0e67623c 100644
+--- a/lib/board/keepkey_board.c
++++ b/lib/board/keepkey_board.c
+@@ -36,7 +36,7 @@
+ #include <stdlib.h>
+ 
+ /* Stack smashing protector (SSP) canary value storage */
+-uintptr_t __stack_chk_guard;
++// uintptr_t __stack_chk_guard;
+ 
+ #ifdef EMULATOR
+ /**
+diff --git a/tools/emulator/main.cpp b/tools/emulator/main.cpp
+index b6aa9ee6..7b3976f8 100644
+--- a/tools/emulator/main.cpp
++++ b/tools/emulator/main.cpp
+@@ -37,6 +37,7 @@ extern "C" {
+ #include <stdbool.h>
+ #include <stdint.h>
+ #include <signal.h>
++#include <stdio.h>
+ 
+ #define APP_VERSIONS                                    \
+   "VERSION" VERSION_STR(MAJOR_VERSION) "." VERSION_STR( \
+-- 
+2.33.0
+

--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -135,7 +135,11 @@ if [[ -n ${build_coldcard} ]]; then
     pip install -r requirements.txt
     cd unix
     if [ "$coldcard_setup_needed" == true ] ; then
+        pushd ../external/micropython/mpy-cross/
+        make
+        popd
         make setup
+        make ngu-setup
     fi
     make
     cd ../..

--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -225,8 +225,9 @@ if [[ -n ${build_keepkey} ]]; then
 fi
 
 if [[ -n ${build_ledger} ]]; then
-    poetry run pip install construct mnemonic pyelftools jsonschema
-    pip install construct mnemonic pyelftools jsonschema
+    speculos_packages="construct flask-restful jsonschema mnemonic pyelftools pillow requests"
+    poetry run pip install ${speculos_packages}
+    pip install ${speculos_packages}
     # Clone ledger simulator Speculos if it doesn't exist, or update it if it does
     if [ ! -d "speculos" ]; then
         git clone --recursive https://github.com/LedgerHQ/speculos.git

--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -130,6 +130,11 @@ if [[ -n ${build_coldcard} ]]; then
     # Apply patch to make simulator work in linux environments
     git am ../../data/coldcard-multisig.patch
 
+    # Apply patch to libngu to make it compile
+    pushd external/libngu
+    git am ../../../../data/coldcard-libngu.patch
+    popd
+
     # Build the simulator. This is cached, but it is also fast
     poetry run pip install -r requirements.txt
     pip install -r requirements.txt

--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -89,6 +89,7 @@ if [[ -n ${build_trezor_1} || -n ${build_trezor_t} ]]; then
     fi
 
     if [[ -n ${build_trezor_t} ]]; then
+        rustup update
         # Build trezor t emulator. This is pretty fast, so rebuilding every time is ok
         # But there should be some caching that makes this faster
         poetry install

--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -110,7 +110,7 @@ if [[ -n ${build_coldcard} ]]; then
         coldcard_setup_needed=true
     else
         cd firmware
-        git reset --hard HEAD~2 # Undo git-am for checking and updating
+        git reset --hard HEAD~3 # Undo git-am for checking and updating
         git fetch
 
         # Determine if we need to pull. From https://stackoverflow.com/a/3278427

--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -252,7 +252,7 @@ if [[ -n ${build_ledger} ]]; then
     # Build the simulator. This is cached, but it is also fast
     mkdir -p build
     cmake -Bbuild -H.
-    make -C build/ emu launcher
+    make -C build/ emu launcher copy-launcher
     cd ..
 fi
 

--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -181,6 +181,7 @@ if [[ -n ${build_keepkey} ]]; then
         keepkey_setup_needed=true
     else
         cd keepkey-firmware
+        git reset --hard HEAD~1 # Undo git-am for checking and updating
         git fetch
 
         # Determine if we need to pull. From https://stackoverflow.com/a/3278427
@@ -196,6 +197,8 @@ if [[ -n ${build_keepkey} ]]; then
             keepkey_setup_needed=true
         fi
     fi
+    # Apply patch to make simulator build
+    git am ../../data/keepkey-build.patch
 
     # Build the simulator. This is cached, but it is also fast
     if [ "$keepkey_setup_needed" == true ] ; then

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -35,7 +35,7 @@ class DeviceEmulator():
 
 def start_bitcoind(bitcoind_path):
     datadir = tempfile.mkdtemp()
-    bitcoind_proc = subprocess.Popen([bitcoind_path, '-regtest', '-datadir=' + datadir, '-noprinttoconsole', '-fallbackfee=0.0002'])
+    bitcoind_proc = subprocess.Popen([bitcoind_path, '-regtest', '-datadir=' + datadir, '-noprinttoconsole', '-fallbackfee=0.0002', '-keypool=1'])
 
     def cleanup_bitcoind():
         bitcoind_proc.kill()

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -103,13 +103,13 @@ class DeviceTestCase(unittest.TestCase):
             result = proc.communicate()
             return json.loads(result[0].decode())
         elif self.interface == 'bindist':
-            proc = subprocess.Popen(['../dist/hwi ' + ' '.join(cli_args)], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, shell=True)
+            proc = subprocess.Popen(['../dist/hwi ' + ' '.join(cli_args)], stdout=subprocess.PIPE, shell=True)
             result = proc.communicate()
             return json.loads(result[0].decode())
         elif self.interface == 'stdin':
             args = [f'"{arg}"' for arg in args]
             input_str = '\n'.join(args) + '\n'
-            proc = subprocess.Popen(['hwi', '--stdin'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+            proc = subprocess.Popen(['hwi', '--stdin'], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
             result = proc.communicate(input_str.encode())
             return json.loads(result[0].decode())
         else:

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -85,6 +85,9 @@ class KeepkeyEmulator(DeviceEmulator):
         if self.keepkey_log is not None:
             self.keepkey_log.close()
 
+        # Wait a second for everything to be cleaned up before going to the next test
+        time.sleep(1)
+
         atexit.unregister(self.stop)
 
 class KeepkeyTestCase(unittest.TestCase):

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -60,7 +60,7 @@ class KeepkeyEmulator(DeviceEmulator):
                 time.sleep(0.05)
 
         # Setup the emulator
-        wirelink = UdpTransport.enumerate()[0]
+        wirelink = UdpTransport.enumerate("127.0.0.1:11044")[0]
         client = TrezorClientDebugLink(wirelink)
         client.vendors = ("keepkey.com")
         client.minimum_versions = {"K1-14AM": (0, 0, 0)}

--- a/test/test_ledger.py
+++ b/test/test_ledger.py
@@ -29,7 +29,7 @@ class LedgerEmulator(DeviceEmulator):
 
         self.emulator_stderr = open('ledger-emulator.stderr', 'a')
         # Start the emulator
-        self.emulator_proc = subprocess.Popen(['python3', './' + os.path.basename(self.emulator_path), '--display', 'headless', '--automation', 'file:{}'.format(automation_path), '--log-level', 'automation:DEBUG', '--log-level', 'seproxyhal:DEBUG', './apps/btc.elf'], cwd=os.path.dirname(self.emulator_path), stderr=self.emulator_stderr, preexec_fn=os.setsid)
+        self.emulator_proc = subprocess.Popen(['python3', './' + os.path.basename(self.emulator_path), '--display', 'headless', '--automation', 'file:{}'.format(automation_path), '--log-level', 'automation:DEBUG', '--log-level', 'seproxyhal:DEBUG', '--api-port', '0', './apps/btc.elf'], cwd=os.path.dirname(self.emulator_path), stderr=self.emulator_stderr, preexec_fn=os.setsid)
         # Wait for simulator to be up
         while True:
             try:

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -87,6 +87,9 @@ class TrezorEmulator(DeviceEmulator):
             self.emulator_log.close()
             self.emulator_log = None
 
+        # Wait a second for everything to be cleaned up before going to the next test
+        time.sleep(1)
+
         atexit.unregister(self.stop)
 
 class TrezorTestCase(unittest.TestCase):


### PR DESCRIPTION
* Cleanup of `.cirrus.yml`
* Change to use artifacts rather than caching to get built things to test tasks. This should make it less likely to fail due to race conditions around the caching.
* Fix wine_builder to download the actual key. Python.org removed the keys file we used previously.
* Install rustup and clang in `cirrus.Dockerfile`. Trezor needs this now.
* Fix Coldcard simulator patches and build
* Fix Speculos simulator build
* Patch and fix Keepkey emulator builds
* Fix keepkey transport finding.