### PR TITLE
test setup: Always build bitcoind depends and configure

### DIFF
--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -284,12 +284,10 @@ if [[ -n ${build_bitcoind} ]]; then
     fi
 
     # Build bitcoind. This is super slow, but it is cached so it runs fairly quickly.
-    if [ "$bitcoind_setup_needed" == true ] ; then
-        pushd depends
-        make NO_QT=1 NO_QR=1 NO_ZMQ=1 NO_UPNP=1 NO_NATPMP=1
-        popd
-        ./autogen.sh
-        CONFIG_SITE=$PWD/depends/x86_64-pc-linux-gnu/share/config.site ./configure --with-incompatible-bdb --with-miniupnpc=no --without-gui --disable-zmq --disable-tests --disable-bench --with-libs=no --with-utils=no
-    fi
+    pushd depends
+    make NO_QT=1 NO_QR=1 NO_ZMQ=1 NO_UPNP=1 NO_NATPMP=1
+    popd
+    ./autogen.sh
+    CONFIG_SITE=$PWD/depends/x86_64-pc-linux-gnu/share/config.site ./configure --with-incompatible-bdb --with-miniupnpc=no --without-gui --disable-zmq --disable-tests --disable-bench --with-libs=no --with-utils=no
     make src/bitcoind
 fi


### PR DESCRIPTION
CI seems to be having some linker problems, probably because this isn't being done every time bitcoind is being built.