### PR TITLE
keepkey, trezor: Handle if ButtonRequest is sent during sendpin

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -737,7 +737,7 @@ class TrezorClient(HardwareWalletClient):
                     raise DeviceAlreadyUnlockedError('The PIN has already been sent to this device')
             return False
         elif isinstance(resp, messages.PassphraseRequest):
-            pass_resp = self.client.call_raw(messages.PassphraseAck(passphrase=self.client.ui.get_passphrase(available_on_device=False), on_device=False))
+            pass_resp = self.client.call(messages.PassphraseAck(passphrase=self.client.ui.get_passphrase(available_on_device=False), on_device=False), check_fw=False)
             if isinstance(pass_resp, messages.Deprecated_PassphraseStateRequest):
                 self.client.call_raw(messages.Deprecated_PassphraseStateAck())
         return True

--- a/hwilib/devices/trezorlib/client.py
+++ b/hwilib/devices/trezorlib/client.py
@@ -212,8 +212,9 @@ class TrezorClient:
         return self._raw_read()
 
     @tools.session
-    def call(self, msg):
-        self.check_firmware_version()
+    def call(self, msg, check_fw = True):
+        if check_fw:
+            self.check_firmware_version()
         resp = self.call_raw(msg)
         while True:
             if isinstance(resp, messages.PinMatrixRequest):

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -239,7 +239,7 @@ class TestKeepkeyManCommands(KeepkeyTestCase):
 
         # Set a PIN
         device.wipe(self.client)
-        load_device_by_mnemonic(client=self.client, mnemonic='alcohol woman abuse must during monitor noble actual mixed trade anger aisle', pin='1234', passphrase_protection=False, label='test')
+        load_device_by_mnemonic(client=self.client, mnemonic='alcohol woman abuse must during monitor noble actual mixed trade anger aisle', pin='1234', passphrase_protection=True, label='test')
         self.client.call(messages.LockDevice())
         result = self.do_command(self.dev_args + ['enumerate'])
         for dev in result:
@@ -272,7 +272,7 @@ class TestKeepkeyManCommands(KeepkeyTestCase):
         # Send the PIN
         self.client.open()
         pin = self.client.debug.encode_pin('1234')
-        result = self.do_command(self.dev_args + ['sendpin', pin])
+        result = self.do_command(self.dev_args + ["-p", "test", 'sendpin', pin])
         self.assertTrue(result['success'])
 
         result = self.do_command(self.dev_args + ['enumerate'])

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -289,7 +289,7 @@ class TestTrezorManCommands(TrezorTestCase):
         # Send the PIN
         self.client.open()
         pin = self.client.debug.encode_pin('1234')
-        result = self.do_command(self.dev_args + ['sendpin', pin])
+        result = self.do_command(self.dev_args + ["-p", "asdf", 'sendpin', pin])
         self.assertTrue(result['success'])
 
         result = self.do_command(self.dev_args + ['enumerate'])


### PR DESCRIPTION
Keepkey and Trezor may ask the user for confirmation of their passphrase after the PIN is sent. This could cause some issues as `ButtonRequests` were not being handled by `sendpin`. Additionally, `TrezorClient.call` would not work because it needs access to `TrezorClient.features`, which is not set for the `sendpin` command. In order to resolve this, `TrezorClient.call` is modified to optionally skip the firmware check that requires `TrezorClient.features`, and `sendpin` uses `TrezorClient.call` instead of `TrezorClient.call_raw`.

Fixes #526 
Fixes $539