### PR TITLE
trezor: Implement Taproot support

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -761,13 +761,15 @@ class TrezorClient(HardwareWalletClient):
     @trezor_exception
     def can_sign_taproot(self) -> bool:
         """
-        Trezor T supports Taproot in firmware versions greater than (not including) 2.4.2.
-        Trezor One supports Taproot in firmware versions greater than (not including) 1.10.3.
-        However HWI does not implement Taproot support for any Trezor devices yet.
+        Trezor T supports Taproot since firmware version 2.4.3.
+        Trezor One supports Taproot since firmware version 1.10.4.
 
         :returns: False, always.
         """
-        return False
+        self._prepare_device()
+        if self.client.features.model == "T":
+            return bool(self.client.version >= (2, 4, 3))
+        return bool(self.client.version >= (1, 10, 4))
 
 
 def enumerate(password: str = "") -> List[Dict[str, Any]]:

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -596,7 +596,9 @@ class TrezorClient(HardwareWalletClient):
         elif addr_type == AddressType.LEGACY:
             script_type = messages.InputScriptType.SPENDADDRESS
         elif addr_type == AddressType.TAP:
-            raise UnavailableActionError("Trezor does not support displaying Taproot addresses yet")
+            if not self.can_sign_taproot():
+                raise UnavailableActionError("This device does not support displaying Taproot addresses")
+            script_type = messages.InputScriptType.SPENDTAPROOT
         else:
             raise BadArgumentError("Unknown address type")
 

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -100,6 +100,16 @@ Use the numeric keypad to describe number positions. The layout is:
 
 Device = Union[hid.HidTransport, webusb.WebUsbTransport, udp.UdpTransport]
 
+ECDSA_SCRIPT_TYPES = [
+    messages.InputScriptType.SPENDADDRESS,
+    messages.InputScriptType.SPENDMULTISIG,
+    messages.InputScriptType.SPENDWITNESS,
+    messages.InputScriptType.SPENDP2SHWITNESS,
+]
+SCHNORR_SCRIPT_TYPES = [
+    messages.InputScriptType.SPENDTAPROOT,
+]
+
 
 # Only handles up to 15 of 15
 def parse_multisig(script: bytes, tx_xpubs: Dict[bytes, KeyOriginInfo], psbt_scope: Union[PartiallySignedInput, PartiallySignedOutput]) -> Tuple[bool, Optional[messages.MultisigRedeemScriptType]]:
@@ -381,13 +391,16 @@ class TrezorClient(HardwareWalletClient):
                     p2sh = True
 
                 # Check segwit
-                is_wit, _, _ = is_witness(scriptcode)
+                is_wit, wit_ver, _ = is_witness(scriptcode)
 
                 if is_wit:
-                    if p2sh:
-                        txinputtype.script_type = messages.InputScriptType.SPENDP2SHWITNESS
-                    else:
-                        txinputtype.script_type = messages.InputScriptType.SPENDWITNESS
+                    if wit_ver == 0:
+                        if p2sh:
+                            txinputtype.script_type = messages.InputScriptType.SPENDP2SHWITNESS
+                        else:
+                            txinputtype.script_type = messages.InputScriptType.SPENDWITNESS
+                    elif wit_ver == 1:
+                        txinputtype.script_type = messages.InputScriptType.SPENDTAPROOT
                 else:
                     txinputtype.script_type = messages.InputScriptType.SPENDADDRESS
                 txinputtype.amount = utxo.nValue
@@ -433,16 +446,28 @@ class TrezorClient(HardwareWalletClient):
                 found = False # Whether we have found a key to sign with
                 found_in_sigs = False # Whether we have found one of our keys in the signatures
                 our_keys = 0
-                for key in psbt_in.hd_keypaths.keys():
-                    keypath = psbt_in.hd_keypaths[key]
-                    if keypath.fingerprint == master_fp:
-                        if key in psbt_in.partial_sigs: # This key already has a signature
-                            found_in_sigs = True
-                            continue
-                        if not found: # This key does not have a signature and we don't have a key to sign with yet
-                            txinputtype.address_n = keypath.path
-                            found = True
-                        our_keys += 1
+                if txinputtype.script_type in ECDSA_SCRIPT_TYPES:
+                    for key in psbt_in.hd_keypaths.keys():
+                        keypath = psbt_in.hd_keypaths[key]
+                        if keypath.fingerprint == master_fp:
+                            if key in psbt_in.partial_sigs: # This key already has a signature
+                                found_in_sigs = True
+                                continue
+                            if not found: # This key does not have a signature and we don't have a key to sign with yet
+                                txinputtype.address_n = keypath.path
+                                found = True
+                            our_keys += 1
+                elif txinputtype.script_type in SCHNORR_SCRIPT_TYPES:
+                    if len(psbt_in.tap_key_sig) > 0:
+                        found_in_sigs = True
+                    else:
+                        for key, (leaf_hashes, origin) in psbt_in.tap_bip32_paths.items():
+                            # TODO: Support script path signing
+                            if key == psbt_in.tap_internal_key and origin.fingerprint == master_fp:
+                                txinputtype.address_n = origin.path
+                                found = True
+                                our_keys += 1
+                                break
 
                 # Determine if we need to do more passes to sign everything
                 if our_keys > passes:
@@ -568,6 +593,10 @@ class TrezorClient(HardwareWalletClient):
                     if fp == master_fp and pubkey not in psbt_in.partial_sigs:
                         psbt_in.partial_sigs[pubkey] = sig + b'\x01'
                         break
+                if len(psbt_in.tap_internal_key) > 0 and len(psbt_in.tap_key_sig) == 0:
+                    # Assume key path sig
+                    # TODO: Deal with script path sig
+                    psbt_in.tap_key_sig = sig
 
             p += 1
 

--- a/test/data/bitcoind_taproot_psbt.patch
+++ b/test/data/bitcoind_taproot_psbt.patch
@@ -1,0 +1,1322 @@
+From 7678dc295809e3e12469fdbc91014db126ea7f76 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Mon, 12 Jul 2021 15:31:12 -0400
+Subject: [PATCH 01/15] Move individual KeyOriginInfo de/ser to separate
+ function
+
+To make it easier to de/serialize individual KeyOriginInfo for PSBTs,
+separate the actual de/serialization of KeyOriginInfo to its own
+function.
+
+This is an additional separation where any length prefix is processed by
+the caller.
+---
+ src/psbt.h | 31 +++++++++++++++++++++++--------
+ 1 file changed, 23 insertions(+), 8 deletions(-)
+
+diff --git a/src/psbt.h b/src/psbt.h
+index 43b1b249c5..17ef61bdaf 100644
+--- a/src/psbt.h
++++ b/src/psbt.h
+@@ -98,22 +98,30 @@ void UnserializeFromVector(Stream& s, X&... args)
+     }
+ }
+ 
+-// Deserialize an individual HD keypath to a stream
++// Deserialize bytes of given length from the stream as a KeyOriginInfo
+ template<typename Stream>
+-void DeserializeHDKeypath(Stream& s, KeyOriginInfo& hd_keypath)
++KeyOriginInfo DeserializeKeyOrigin(Stream& s, uint64_t length)
+ {
+     // Read in key path
+-    uint64_t value_len = ReadCompactSize(s);
+-    if (value_len % 4 || value_len == 0) {
++    if (length % 4 || length == 0) {
+         throw std::ios_base::failure("Invalid length for HD key path");
+     }
+ 
++    KeyOriginInfo hd_keypath;
+     s >> hd_keypath.fingerprint;
+-    for (unsigned int i = 4; i < value_len; i += sizeof(uint32_t)) {
++    for (unsigned int i = 4; i < length; i += sizeof(uint32_t)) {
+         uint32_t index;
+         s >> index;
+         hd_keypath.path.push_back(index);
+     }
++    return hd_keypath;
++}
++
++// Deserialize a length prefixed KeyOriginInfo from a stream
++template<typename Stream>
++void DeserializeHDKeypath(Stream& s, KeyOriginInfo& hd_keypath)
++{
++    hd_keypath = DeserializeKeyOrigin(s, ReadCompactSize(s));
+ }
+ 
+ // Deserialize HD keypaths into a map
+@@ -140,17 +148,24 @@ void DeserializeHDKeypaths(Stream& s, const std::vector<unsigned char>& key, std
+     hd_keypaths.emplace(pubkey, std::move(keypath));
+ }
+ 
+-// Serialize an individual HD keypath to a stream
++// Serialize a KeyOriginInfo to a stream
+ template<typename Stream>
+-void SerializeHDKeypath(Stream& s, KeyOriginInfo hd_keypath)
++void SerializeKeyOrigin(Stream& s, KeyOriginInfo hd_keypath)
+ {
+-    WriteCompactSize(s, (hd_keypath.path.size() + 1) * sizeof(uint32_t));
+     s << hd_keypath.fingerprint;
+     for (const auto& path : hd_keypath.path) {
+         s << path;
+     }
+ }
+ 
++// Serialize a length prefixed KeyOriginInfo to a stream
++template<typename Stream>
++void SerializeHDKeypath(Stream& s, KeyOriginInfo hd_keypath)
++{
++    WriteCompactSize(s, (hd_keypath.path.size() + 1) * sizeof(uint32_t));
++    SerializeKeyOrigin(s, hd_keypath);
++}
++
+ // Serialize HD keypaths to a stream from a map
+ template<typename Stream>
+ void SerializeHDKeypaths(Stream& s, const std::map<CPubKey, KeyOriginInfo>& hd_keypaths, CompactSizeWriter type)
+-- 
+2.34.1
+
+
+From 13078c1a4a66fa9563a8730d4c8c011868ccac40 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Mon, 12 Jul 2021 17:04:46 -0400
+Subject: [PATCH 02/15] Add TaprootBuilder::GetTreeTuples
+
+GetTreeTuples returns the leaves in DFS order as tuples of depth, leaf
+version, and script. This is a representation of the tree that can be
+serialized.
+---
+ src/script/standard.cpp | 15 +++++++++++++++
+ src/script/standard.h   |  2 ++
+ 2 files changed, 17 insertions(+)
+
+diff --git a/src/script/standard.cpp b/src/script/standard.cpp
+index d9656c781d..ca27c175ee 100644
+--- a/src/script/standard.cpp
++++ b/src/script/standard.cpp
+@@ -621,3 +621,18 @@ std::optional<std::vector<std::tuple<int, CScript, int>>> InferTaprootTree(const
+ 
+     return ret;
+ }
++
++std::vector<std::tuple<uint8_t, uint8_t, CScript>> TaprootBuilder::GetTreeTuples() const
++{
++    assert(IsComplete());
++    std::vector<std::tuple<uint8_t, uint8_t, CScript>> tuples;
++    if (m_branch.size()) {
++        const auto& leaves = m_branch[0]->leaves;
++        for (const auto& leaf : leaves) {
++            uint8_t depth = (uint8_t)leaf.merkle_branch.size();
++            uint8_t leaf_ver = (uint8_t)leaf.leaf_version;
++            tuples.push_back(std::make_tuple(depth, leaf_ver, leaf.script));
++        }
++    }
++    return tuples;
++}
+diff --git a/src/script/standard.h b/src/script/standard.h
+index a8e57231bf..5740acf809 100644
+--- a/src/script/standard.h
++++ b/src/script/standard.h
+@@ -312,6 +312,8 @@ public:
+     static bool ValidDepths(const std::vector<int>& depths);
+     /** Compute spending data (after Finalize()). */
+     TaprootSpendData GetSpendData() const;
++    /** Returns a vector of tuples representing the depth, leaf version, and script */
++    std::vector<std::tuple<uint8_t, uint8_t, CScript>> GetTreeTuples() const;
+ };
+ 
+ /** Given a TaprootSpendData and the output key, reconstruct its script tree.
+-- 
+2.34.1
+
+
+From f6a139f5949ef54921235b9ccc09a0ef636c7640 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Mon, 12 Jul 2021 17:05:42 -0400
+Subject: [PATCH 03/15] Add TaprootBuilder::IsEmpty
+
+Helper function to know whether the tree has any data in it.
+---
+ src/script/standard.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/script/standard.h b/src/script/standard.h
+index 5740acf809..b6a2fae620 100644
+--- a/src/script/standard.h
++++ b/src/script/standard.h
+@@ -304,6 +304,8 @@ public:
+ 
+     /** Return true if so far all input was valid. */
+     bool IsValid() const { return m_valid; }
++    /** Return true if there are no leaves */
++    bool IsEmpty() const { return m_branch.size() == 0; }
+     /** Return whether there were either no leaves, or the leaves form a Huffman tree. */
+     bool IsComplete() const { return m_valid && (m_branch.size() == 0 || (m_branch.size() == 1 && m_branch[0].has_value())); }
+     /** Compute scriptPubKey (after Finalize()). */
+-- 
+2.34.1
+
+
+From e9e2d4e7b2901c13efea47e159ccbc9b198ae93a Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Mon, 12 Jul 2021 17:06:20 -0400
+Subject: [PATCH 04/15] Add serialization methods to XOnlyPubKey
+
+It is useful to have serialzation methods for XOnlyPubKey. These will
+serialize the internal uint256, so it is not prefixed with the length as
+CPubKey does.
+---
+ src/pubkey.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/pubkey.h b/src/pubkey.h
+index 204e96f49e..ce17bfe17c 100644
+--- a/src/pubkey.h
++++ b/src/pubkey.h
+@@ -286,6 +286,9 @@ public:
+     bool operator==(const XOnlyPubKey& other) const { return m_keydata == other.m_keydata; }
+     bool operator!=(const XOnlyPubKey& other) const { return m_keydata != other.m_keydata; }
+     bool operator<(const XOnlyPubKey& other) const { return m_keydata < other.m_keydata; }
++
++    //! Implement serialization without length prefixes since it is a fixed length
++    SERIALIZE_METHODS(XOnlyPubKey, obj) { READWRITE(obj.m_keydata); }
+ };
+ 
+ struct CExtPubKey {
+-- 
+2.34.1
+
+
+From d802c9990469362c46b05b3d43623928b404cb74 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Mon, 12 Jul 2021 17:07:08 -0400
+Subject: [PATCH 05/15] Implement de/ser of PSBT's Taproot fields
+
+---
+ src/psbt.h | 246 +++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 246 insertions(+)
+
+diff --git a/src/psbt.h b/src/psbt.h
+index 17ef61bdaf..f8660776b3 100644
+--- a/src/psbt.h
++++ b/src/psbt.h
+@@ -41,12 +41,21 @@ static constexpr uint8_t PSBT_IN_RIPEMD160 = 0x0A;
+ static constexpr uint8_t PSBT_IN_SHA256 = 0x0B;
+ static constexpr uint8_t PSBT_IN_HASH160 = 0x0C;
+ static constexpr uint8_t PSBT_IN_HASH256 = 0x0D;
++static constexpr uint8_t PSBT_IN_TAP_KEY_SIG = 0x13;
++static constexpr uint8_t PSBT_IN_TAP_SCRIPT_SIG = 0x14;
++static constexpr uint8_t PSBT_IN_TAP_LEAF_SCRIPT = 0x15;
++static constexpr uint8_t PSBT_IN_TAP_BIP32_DERIVATION = 0x16;
++static constexpr uint8_t PSBT_IN_TAP_INTERNAL_KEY = 0x17;
++static constexpr uint8_t PSBT_IN_TAP_MERKLE_ROOT = 0x18;
+ static constexpr uint8_t PSBT_IN_PROPRIETARY = 0xFC;
+ 
+ // Output types
+ static constexpr uint8_t PSBT_OUT_REDEEMSCRIPT = 0x00;
+ static constexpr uint8_t PSBT_OUT_WITNESSSCRIPT = 0x01;
+ static constexpr uint8_t PSBT_OUT_BIP32_DERIVATION = 0x02;
++static constexpr uint8_t PSBT_OUT_TAP_INTERNAL_KEY = 0x05;
++static constexpr uint8_t PSBT_OUT_TAP_TREE = 0x06;
++static constexpr uint8_t PSBT_OUT_TAP_BIP32_DERIVATION = 0x07;
+ static constexpr uint8_t PSBT_OUT_PROPRIETARY = 0xFC;
+ 
+ // The separator is 0x00. Reading this in means that the unserializer can interpret it
+@@ -194,6 +203,15 @@ struct PSBTInput
+     std::map<uint256, std::vector<unsigned char>> sha256_preimages;
+     std::map<uint160, std::vector<unsigned char>> hash160_preimages;
+     std::map<uint256, std::vector<unsigned char>> hash256_preimages;
++
++    // Taproot fields
++    std::vector<unsigned char> m_tap_key_sig;
++    std::map<std::pair<XOnlyPubKey, uint256>, std::vector<unsigned char>> m_tap_script_sigs;
++    std::map<std::pair<CScript, int>, std::set<std::vector<unsigned char>, ShortestVectorFirstComparator>> m_tap_scripts;
++    std::map<XOnlyPubKey, std::pair<std::set<uint256>, KeyOriginInfo>> m_tap_bip32_paths;
++    XOnlyPubKey m_tap_internal_key;
++    uint256 m_tap_merkle_root;
++
+     std::map<std::vector<unsigned char>, std::vector<unsigned char>> unknown;
+     std::set<PSBTProprietary> m_proprietary;
+     std::optional<int> sighash_type;
+@@ -268,6 +286,53 @@ struct PSBTInput
+                 SerializeToVector(s, CompactSizeWriter(PSBT_IN_HASH256), Span{hash});
+                 s << preimage;
+             }
++
++            // Write taproot key sig
++            if (!m_tap_key_sig.empty()) {
++                SerializeToVector(s, PSBT_IN_TAP_KEY_SIG);
++                s << m_tap_key_sig;
++            }
++
++            // Write taproot script sigs
++            for (const auto& [pubkey_leaf, sig] : m_tap_script_sigs) {
++                const auto& [xonly, leaf_hash] = pubkey_leaf;
++                SerializeToVector(s, PSBT_IN_TAP_SCRIPT_SIG, xonly, leaf_hash);
++                s << sig;
++            }
++
++            // Write taproot leaf scripts
++            for (const auto& [leaf, control_blocks] : m_tap_scripts) {
++                const auto& [script, leaf_ver] = leaf;
++                for (const auto& control_block : control_blocks) {
++                    SerializeToVector(s, PSBT_IN_TAP_LEAF_SCRIPT, Span{control_block});
++                    std::vector<unsigned char> value_v(script.begin(), script.end());
++                    value_v.push_back((uint8_t)leaf_ver);
++                    s << value_v;
++                }
++            }
++
++            // Write taproot bip32 keypaths
++            for (const auto& [xonly, leaf_origin] : m_tap_bip32_paths) {
++                const auto& [leaf_hashes, origin] = leaf_origin;
++                SerializeToVector(s, PSBT_IN_TAP_BIP32_DERIVATION, xonly);
++                std::vector<unsigned char> value;
++                CVectorWriter s_value(s.GetType(), s.GetVersion(), value, 0);
++                s_value << leaf_hashes;
++                SerializeKeyOrigin(s_value, origin);
++                s << value;
++            }
++
++            // Write taproot internal key
++            if (!m_tap_internal_key.IsNull()) {
++                SerializeToVector(s, PSBT_IN_TAP_INTERNAL_KEY);
++                s << ToByteVector(m_tap_internal_key);
++            }
++
++            // Write taproot merkle root
++            if (!m_tap_merkle_root.IsNull()) {
++                SerializeToVector(s, PSBT_IN_TAP_MERKLE_ROOT);
++                SerializeToVector(s, m_tap_merkle_root);
++            }
+         }
+ 
+         // Write script sig
+@@ -504,6 +569,101 @@ struct PSBTInput
+                     hash256_preimages.emplace(hash, std::move(preimage));
+                     break;
+                 }
++                case PSBT_IN_TAP_KEY_SIG:
++                {
++                    if (!key_lookup.emplace(key).second) {
++                        throw std::ios_base::failure("Duplicate Key, input Taproot key signature already provided");
++                    } else if (key.size() != 1) {
++                        throw std::ios_base::failure("Input Taproot key signature key is more than one byte type");
++                    }
++                    s >> m_tap_key_sig;
++                    if (m_tap_key_sig.size() < 64) {
++                        throw std::ios_base::failure("Input Taproot key path signature is shorter than 64 bytes");
++                    } else if (m_tap_key_sig.size() > 65) {
++                        throw std::ios_base::failure("Input Taproot key path signature is longer than 65 bytes");
++                    }
++                    break;
++                }
++                case PSBT_IN_TAP_SCRIPT_SIG:
++                {
++                    if (!key_lookup.emplace(key).second) {
++                        throw std::ios_base::failure("Duplicate Key, input Taproot script signature already provided");
++                    } else if (key.size() != 65) {
++                        throw std::ios_base::failure("Input Taproot script signature key is not 65 bytes");
++                    }
++                    SpanReader s_key(s.GetType(), s.GetVersion(), Span{key}.subspan(1));
++                    XOnlyPubKey xonly;
++                    uint256 hash;
++                    s_key >> xonly;
++                    s_key >> hash;
++                    std::vector<unsigned char> sig;
++                    s >> sig;
++                    if (sig.size() < 64) {
++                        throw std::ios_base::failure("Input Taproot script path signature is shorter than 64 bytes");
++                    } else if (sig.size() > 65) {
++                        throw std::ios_base::failure("Input Taproot script path signature is longer than 65 bytes");
++                    }
++                    m_tap_script_sigs.emplace(std::make_pair(xonly, hash), sig);
++                    break;
++                }
++                case PSBT_IN_TAP_LEAF_SCRIPT:
++                {
++                    if (!key_lookup.emplace(key).second) {
++                        throw std::ios_base::failure("Duplicate Key, input Taproot leaf script already provided");
++                    } else if (key.size() < 34) {
++                        throw std::ios_base::failure("Taproot leaf script key is not at least 34 bytes");
++                    } else if ((key.size() - 2) % 32 != 0) {
++                        throw std::ios_base::failure("Input Taproot leaf script key's control block size is not valid");
++                    }
++                    std::vector<unsigned char> script_v;
++                    s >> script_v;
++                    assert(!script_v.empty());
++                    uint8_t leaf_ver = script_v.back();
++                    script_v.pop_back();
++                    const auto leaf_script = std::make_pair(CScript(script_v.begin(), script_v.end()), (int)leaf_ver);
++                    m_tap_scripts[leaf_script].insert(std::vector<unsigned char>(key.begin() + 1, key.end()));
++                    break;
++                }
++                case PSBT_IN_TAP_BIP32_DERIVATION:
++                {
++                    if (!key_lookup.emplace(key).second) {
++                        throw std::ios_base::failure("Duplicate Key, input Taproot BIP32 keypath already provided");
++                    } else if (key.size() != 33) {
++                        throw std::ios_base::failure("Input Taproot BIP32 keypath key is not at 33 bytes");
++                    }
++                    SpanReader s_key(s.GetType(), s.GetVersion(), Span{key}.subspan(1));
++                    XOnlyPubKey xonly;
++                    s_key >> xonly;
++                    std::set<uint256> leaf_hashes;
++                    uint64_t value_len = ReadCompactSize(s);
++                    size_t before_hashes = s.size();
++                    s >> leaf_hashes;
++                    size_t after_hashes = s.size();
++                    size_t hashes_len = before_hashes - after_hashes;
++                    size_t origin_len = value_len - hashes_len;
++                    m_tap_bip32_paths.emplace(xonly, std::make_pair(leaf_hashes, DeserializeKeyOrigin(s, origin_len)));
++                    break;
++                }
++                case PSBT_IN_TAP_INTERNAL_KEY:
++                {
++                    if (!key_lookup.emplace(key).second) {
++                        throw std::ios_base::failure("Duplicate Key, input Taproot internal key already provided");
++                    } else if (key.size() != 1) {
++                        throw std::ios_base::failure("Input Taproot internal key key is more than one byte type");
++                    }
++                    UnserializeFromVector(s, m_tap_internal_key);
++                    break;
++                }
++                case PSBT_IN_TAP_MERKLE_ROOT:
++                {
++                    if (!key_lookup.emplace(key).second) {
++                        throw std::ios_base::failure("Duplicate Key, input Taproot merkle root already provided");
++                    } else if (key.size() != 1) {
++                        throw std::ios_base::failure("Input Taproot merkle root key is more than one byte type");
++                    }
++                    UnserializeFromVector(s, m_tap_merkle_root);
++                    break;
++                }
+                 case PSBT_IN_PROPRIETARY:
+                 {
+                     PSBTProprietary this_prop;
+@@ -548,6 +708,9 @@ struct PSBTOutput
+     CScript redeem_script;
+     CScript witness_script;
+     std::map<CPubKey, KeyOriginInfo> hd_keypaths;
++    XOnlyPubKey m_tap_internal_key;
++    TaprootBuilder m_tap_tree;
++    std::map<XOnlyPubKey, std::pair<std::set<uint256>, KeyOriginInfo>> m_tap_bip32_paths;
+     std::map<std::vector<unsigned char>, std::vector<unsigned char>> unknown;
+     std::set<PSBTProprietary> m_proprietary;
+ 
+@@ -580,6 +743,40 @@ struct PSBTOutput
+             s << entry.value;
+         }
+ 
++        // Write taproot internal key
++        if (!m_tap_internal_key.IsNull()) {
++            SerializeToVector(s, PSBT_OUT_TAP_INTERNAL_KEY);
++            s << ToByteVector(m_tap_internal_key);
++        }
++
++        // Write taproot tree
++        if (!m_tap_tree.IsEmpty()) {
++            SerializeToVector(s, PSBT_OUT_TAP_TREE);
++            std::vector<unsigned char> value;
++            CVectorWriter s_value(s.GetType(), s.GetVersion(), value, 0);
++            const auto& tuples = m_tap_tree.GetTreeTuples();
++            for (const auto& tuple : tuples) {
++                uint8_t depth = std::get<0>(tuple);
++                uint8_t leaf_ver = std::get<1>(tuple);
++                CScript script = std::get<2>(tuple);
++                s_value << depth;
++                s_value << leaf_ver;
++                s_value << script;
++            }
++            s << value;
++        }
++
++        // Write taproot bip32 keypaths
++        for (const auto& [xonly, leaf] : m_tap_bip32_paths) {
++            const auto& [leaf_hashes, origin] = leaf;
++            SerializeToVector(s, PSBT_OUT_TAP_BIP32_DERIVATION, xonly);
++            std::vector<unsigned char> value;
++            CVectorWriter s_value(s.GetType(), s.GetVersion(), value, 0);
++            s_value << leaf_hashes;
++            SerializeKeyOrigin(s_value, origin);
++            s << value;
++        }
++
+         // Write unknown things
+         for (auto& entry : unknown) {
+             s << entry.first;
+@@ -640,6 +837,55 @@ struct PSBTOutput
+                     DeserializeHDKeypaths(s, key, hd_keypaths);
+                     break;
+                 }
++                case PSBT_OUT_TAP_INTERNAL_KEY:
++                {
++                    if (!key_lookup.emplace(key).second) {
++                        throw std::ios_base::failure("Duplicate Key, output Taproot internal key already provided");
++                    } else if (key.size() != 1) {
++                        throw std::ios_base::failure("Output Taproot internal key key is more than one byte type");
++                    }
++                    UnserializeFromVector(s, m_tap_internal_key);
++                    break;
++                }
++                case PSBT_OUT_TAP_TREE:
++                {
++                    if (!key_lookup.emplace(key).second) {
++                        throw std::ios_base::failure("Duplicate Key, output Taproot tree already provided");
++                    } else if (key.size() != 1) {
++                        throw std::ios_base::failure("Output Taproot tree key is more than one byte type");
++                    }
++                    std::vector<unsigned char> tree_v;
++                    s >> tree_v;
++                    SpanReader s_tree(s.GetType(), s.GetVersion(), tree_v);
++                    while (!s_tree.empty()) {
++                        uint8_t depth;
++                        uint8_t leaf_ver;
++                        CScript script;
++                        s_tree >> depth;
++                        s_tree >> leaf_ver;
++                        s_tree >> script;
++                        m_tap_tree.Add((int)depth, script, (int)leaf_ver, true /* track */);
++                    }
++                    break;
++                }
++                case PSBT_OUT_TAP_BIP32_DERIVATION:
++                {
++                    if (!key_lookup.emplace(key).second) {
++                        throw std::ios_base::failure("Duplicate Key, output Taproot BIP32 keypath already provided");
++                    } else if (key.size() != 33) {
++                        throw std::ios_base::failure("Output Taproot BIP32 keypath key is not at 33 bytes");
++                    }
++                    XOnlyPubKey xonly(uint256({key.begin() + 1, key.begin() + 33}));
++                    std::set<uint256> leaf_hashes;
++                    uint64_t value_len = ReadCompactSize(s);
++                    size_t before_hashes = s.size();
++                    s >> leaf_hashes;
++                    size_t after_hashes = s.size();
++                    size_t hashes_len = before_hashes - after_hashes;
++                    size_t origin_len = value_len - hashes_len;
++                    m_tap_bip32_paths.emplace(xonly, std::make_pair(leaf_hashes, DeserializeKeyOrigin(s, origin_len)));
++                    break;
++                }
+                 case PSBT_OUT_PROPRIETARY:
+                 {
+                     PSBTProprietary this_prop;
+-- 
+2.34.1
+
+
+From f4aa7f3eb3d24a185fe7617318f09ee3b96ea894 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Mon, 19 Jul 2021 15:29:29 -0400
+Subject: [PATCH 06/15] Fill PSBT Taproot input data to/from SignatureData
+
+---
+ src/psbt.cpp      | 36 ++++++++++++++++++++++++++++++++++++
+ src/script/sign.h |  1 +
+ 2 files changed, 37 insertions(+)
+
+diff --git a/src/psbt.cpp b/src/psbt.cpp
+index 203e0a0bd3..0f375e4394 100644
+--- a/src/psbt.cpp
++++ b/src/psbt.cpp
+@@ -113,6 +113,24 @@ void PSBTInput::FillSignatureData(SignatureData& sigdata) const
+     for (const auto& key_pair : hd_keypaths) {
+         sigdata.misc_pubkeys.emplace(key_pair.first.GetID(), key_pair);
+     }
++    if (!m_tap_key_sig.empty()) {
++        sigdata.taproot_key_path_sig = m_tap_key_sig;
++    }
++    for (const auto& [pubkey_leaf, sig] : m_tap_script_sigs) {
++        sigdata.taproot_script_sigs.emplace(pubkey_leaf, sig);
++    }
++    if (!m_tap_internal_key.IsNull()) {
++        sigdata.tr_spenddata.internal_key = m_tap_internal_key;
++    }
++    if (!m_tap_merkle_root.IsNull()) {
++        sigdata.tr_spenddata.merkle_root = m_tap_merkle_root;
++    }
++    for (const auto& [leaf_script, control_block] : m_tap_scripts) {
++        sigdata.tr_spenddata.scripts.emplace(leaf_script, control_block);
++    }
++    for (const auto& [pubkey, leaf_origin] : m_tap_bip32_paths) {
++        sigdata.taproot_misc_pubkeys.emplace(pubkey, leaf_origin);
++    }
+ }
+ 
+ void PSBTInput::FromSignatureData(const SignatureData& sigdata)
+@@ -142,6 +160,24 @@ void PSBTInput::FromSignatureData(const SignatureData& sigdata)
+     for (const auto& entry : sigdata.misc_pubkeys) {
+         hd_keypaths.emplace(entry.second);
+     }
++    if (!sigdata.taproot_key_path_sig.empty()) {
++        m_tap_key_sig = sigdata.taproot_key_path_sig;
++    }
++    for (const auto& [pubkey_leaf, sig] : sigdata.taproot_script_sigs) {
++        m_tap_script_sigs.emplace(pubkey_leaf, sig);
++    }
++    if (!sigdata.tr_spenddata.internal_key.IsNull()) {
++        m_tap_internal_key = sigdata.tr_spenddata.internal_key;
++    }
++    if (!sigdata.tr_spenddata.merkle_root.IsNull()) {
++        m_tap_merkle_root = sigdata.tr_spenddata.merkle_root;
++    }
++    for (const auto& [leaf_script, control_block] : sigdata.tr_spenddata.scripts) {
++        m_tap_scripts.emplace(leaf_script, control_block);
++    }
++    for (const auto& [pubkey, leaf_origin] : sigdata.taproot_misc_pubkeys) {
++        m_tap_bip32_paths.emplace(pubkey, leaf_origin);
++    }
+ }
+ 
+ void PSBTInput::Merge(const PSBTInput& input)
+diff --git a/src/script/sign.h b/src/script/sign.h
+index 7e3d5e80e4..d97756eba9 100644
+--- a/src/script/sign.h
++++ b/src/script/sign.h
+@@ -72,6 +72,7 @@ struct SignatureData {
+     std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>> misc_pubkeys;
+     std::vector<unsigned char> taproot_key_path_sig; /// Schnorr signature for key path spending
+     std::map<std::pair<XOnlyPubKey, uint256>, std::vector<unsigned char>> taproot_script_sigs; ///< (Partial) schnorr signatures, indexed by XOnlyPubKey and leaf_hash.
++    std::map<XOnlyPubKey, std::pair<std::set<uint256>, KeyOriginInfo>> taproot_misc_pubkeys; ///< Miscellaneous Taproot pubkeys involved in this input along with their leaf script hashes and key origin data. Also includes the Taproot internal key (may have no leaf script hashes).
+     std::vector<CKeyID> missing_pubkeys; ///< KeyIDs of pubkeys which could not be found
+     std::vector<CKeyID> missing_sigs; ///< KeyIDs of pubkeys for signatures which could not be found
+     uint160 missing_redeem_script; ///< ScriptID of the missing redeemScript (if any)
+-- 
+2.34.1
+
+
+From 4810ce3f667af32570e23c6732f44002f2d66364 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Mon, 19 Jul 2021 15:29:55 -0400
+Subject: [PATCH 07/15] Fetch key origins for Taproot keys
+
+---
+ src/script/sign.cpp | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/src/script/sign.cpp b/src/script/sign.cpp
+index d33c847d98..7898b79d16 100644
+--- a/src/script/sign.cpp
++++ b/src/script/sign.cpp
+@@ -169,6 +169,17 @@ static bool SignTaprootScript(const SigningProvider& provider, const BaseSignatu
+     // <xonly pubkey> OP_CHECKSIG
+     if (script.size() == 34 && script[33] == OP_CHECKSIG && script[0] == 0x20) {
+         XOnlyPubKey pubkey{Span{script}.subspan(1, 32)};
++
++        KeyOriginInfo info;
++        if (provider.GetKeyOriginByXOnly(pubkey, info)) {
++            auto it = sigdata.taproot_misc_pubkeys.find(pubkey);
++            if (it == sigdata.taproot_misc_pubkeys.end()) {
++                sigdata.taproot_misc_pubkeys.emplace(pubkey, std::make_pair(std::set<uint256>({leaf_hash}), info));
++            } else {
++                it->second.first.insert(leaf_hash);
++            }
++        }
++
+         std::vector<unsigned char> sig;
+         if (CreateTaprootScriptSig(creator, sigdata, provider, sig, pubkey, leaf_hash, sigversion)) {
+             result = Vector(std::move(sig));
+@@ -190,6 +201,14 @@ static bool SignTaproot(const SigningProvider& provider, const BaseSignatureCrea
+ 
+     // Try key path spending.
+     {
++        KeyOriginInfo info;
++        if (provider.GetKeyOriginByXOnly(spenddata.internal_key, info)) {
++            auto it = sigdata.taproot_misc_pubkeys.find(spenddata.internal_key);
++            if (it == sigdata.taproot_misc_pubkeys.end()) {
++                sigdata.taproot_misc_pubkeys.emplace(spenddata.internal_key, std::make_pair(std::set<uint256>(), info));
++            }
++        }
++
+         std::vector<unsigned char> sig;
+         if (sigdata.taproot_key_path_sig.size() == 0) {
+             if (creator.CreateSchnorrSig(provider, sig, spenddata.internal_key, nullptr, &spenddata.merkle_root, SigVersion::TAPROOT)) {
+-- 
+2.34.1
+
+
+From 724310fd955d77a303244186a295e4b4769fcfc3 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Mon, 19 Jul 2021 16:01:12 -0400
+Subject: [PATCH 08/15] Store TaprootBuilder in SigningProviders instead of
+ TaprootSpendData
+
+TaprootSpendData can be gotten from TaprootBuilder, however for PSBT, we
+also need TaprootBuilders directly (for the outputs). So we store the
+TaprootBuilder in the FlatSigningProvider and when the TaprootSpendData
+is needed, we generate it on the fly using the stored builder.
+---
+ src/script/descriptor.cpp      |  2 +-
+ src/script/signingprovider.cpp | 21 ++++++++++++++++-----
+ src/script/signingprovider.h   |  5 ++++-
+ 3 files changed, 21 insertions(+), 7 deletions(-)
+
+diff --git a/src/script/descriptor.cpp b/src/script/descriptor.cpp
+index 30f929664f..6c9c47c18e 100644
+--- a/src/script/descriptor.cpp
++++ b/src/script/descriptor.cpp
+@@ -850,7 +850,7 @@ protected:
+         if (!xpk.IsFullyValid()) return {};
+         builder.Finalize(xpk);
+         WitnessV1Taproot output = builder.GetOutput();
+-        out.tr_spenddata[output].Merge(builder.GetSpendData());
++        out.tr_trees[output] = builder;
+         out.pubkeys.emplace(keys[0].GetID(), keys[0]);
+         return Vector(GetScriptForDestination(output));
+     }
+diff --git a/src/script/signingprovider.cpp b/src/script/signingprovider.cpp
+index 17f97fa30c..fb14b3a5f5 100644
+--- a/src/script/signingprovider.cpp
++++ b/src/script/signingprovider.cpp
+@@ -48,6 +48,10 @@ bool HidingSigningProvider::GetTaprootSpendData(const XOnlyPubKey& output_key, T
+ {
+     return m_provider->GetTaprootSpendData(output_key, spenddata);
+ }
++bool HidingSigningProvider::GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const
++{
++    return m_provider->GetTaprootBuilder(output_key, builder);
++}
+ 
+ bool FlatSigningProvider::GetCScript(const CScriptID& scriptid, CScript& script) const { return LookupHelper(scripts, scriptid, script); }
+ bool FlatSigningProvider::GetPubKey(const CKeyID& keyid, CPubKey& pubkey) const { return LookupHelper(pubkeys, keyid, pubkey); }
+@@ -61,7 +65,16 @@ bool FlatSigningProvider::GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info)
+ bool FlatSigningProvider::GetKey(const CKeyID& keyid, CKey& key) const { return LookupHelper(keys, keyid, key); }
+ bool FlatSigningProvider::GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const
+ {
+-    return LookupHelper(tr_spenddata, output_key, spenddata);
++    TaprootBuilder builder;
++    if (LookupHelper(tr_trees, output_key, builder)) {
++        spenddata = builder.GetSpendData();
++        return true;
++    }
++    return false;
++}
++bool FlatSigningProvider::GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const
++{
++    return LookupHelper(tr_trees, output_key, builder);
+ }
+ 
+ FlatSigningProvider Merge(const FlatSigningProvider& a, const FlatSigningProvider& b)
+@@ -75,10 +88,8 @@ FlatSigningProvider Merge(const FlatSigningProvider& a, const FlatSigningProvide
+     ret.keys.insert(b.keys.begin(), b.keys.end());
+     ret.origins = a.origins;
+     ret.origins.insert(b.origins.begin(), b.origins.end());
+-    ret.tr_spenddata = a.tr_spenddata;
+-    for (const auto& [output_key, spenddata] : b.tr_spenddata) {
+-        ret.tr_spenddata[output_key].Merge(spenddata);
+-    }
++    ret.tr_trees = a.tr_trees;
++    ret.tr_trees.insert(b.tr_trees.begin(), b.tr_trees.end());
+     return ret;
+ }
+ 
+diff --git a/src/script/signingprovider.h b/src/script/signingprovider.h
+index b8b3e03dd3..27f74084c3 100644
+--- a/src/script/signingprovider.h
++++ b/src/script/signingprovider.h
+@@ -25,6 +25,7 @@ public:
+     virtual bool HaveKey(const CKeyID &address) const { return false; }
+     virtual bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const { return false; }
+     virtual bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const { return false; }
++    virtual bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const { return false; }
+ 
+     bool GetKeyByXOnly(const XOnlyPubKey& pubkey, CKey& key) const
+     {
+@@ -67,6 +68,7 @@ public:
+     bool GetKey(const CKeyID& keyid, CKey& key) const override;
+     bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
+     bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
++    bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
+ };
+ 
+ struct FlatSigningProvider final : public SigningProvider
+@@ -75,13 +77,14 @@ struct FlatSigningProvider final : public SigningProvider
+     std::map<CKeyID, CPubKey> pubkeys;
+     std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>> origins;
+     std::map<CKeyID, CKey> keys;
+-    std::map<XOnlyPubKey, TaprootSpendData> tr_spenddata; /** Map from output key to spend data. */
++    std::map<XOnlyPubKey, TaprootBuilder> tr_trees; /** Map from output key to Taproot tree (which can then make the TaprootSpendData */
+ 
+     bool GetCScript(const CScriptID& scriptid, CScript& script) const override;
+     bool GetPubKey(const CKeyID& keyid, CPubKey& pubkey) const override;
+     bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
+     bool GetKey(const CKeyID& keyid, CKey& key) const override;
+     bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
++    bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
+ };
+ 
+ FlatSigningProvider Merge(const FlatSigningProvider& a, const FlatSigningProvider& b);
+-- 
+2.34.1
+
+
+From ba372efd5fe907b58b73719c8b0d247a539f0191 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Mon, 19 Jul 2021 16:02:36 -0400
+Subject: [PATCH 09/15] Fill PSBT Taproot output data to/from SignatureData
+
+---
+ src/psbt.cpp        | 19 +++++++++++++++++++
+ src/script/sign.cpp |  4 ++++
+ src/script/sign.h   |  1 +
+ 3 files changed, 24 insertions(+)
+
+diff --git a/src/psbt.cpp b/src/psbt.cpp
+index 0f375e4394..679fbac562 100644
+--- a/src/psbt.cpp
++++ b/src/psbt.cpp
+@@ -213,6 +213,16 @@ void PSBTOutput::FillSignatureData(SignatureData& sigdata) const
+     for (const auto& key_pair : hd_keypaths) {
+         sigdata.misc_pubkeys.emplace(key_pair.first.GetID(), key_pair);
+     }
++    if (!m_tap_internal_key.IsNull()) {
++        sigdata.tr_spenddata.internal_key = m_tap_internal_key;
++    }
++    if (!m_tap_tree.IsEmpty()) {
++        TaprootSpendData spenddata = m_tap_tree.GetSpendData();
++        sigdata.tr_spenddata.Merge(spenddata);
++    }
++    for (const auto& [pubkey, leaf_origin] : m_tap_bip32_paths) {
++        sigdata.taproot_misc_pubkeys.emplace(pubkey, leaf_origin);
++    }
+ }
+ 
+ void PSBTOutput::FromSignatureData(const SignatureData& sigdata)
+@@ -226,6 +236,15 @@ void PSBTOutput::FromSignatureData(const SignatureData& sigdata)
+     for (const auto& entry : sigdata.misc_pubkeys) {
+         hd_keypaths.emplace(entry.second);
+     }
++    if (!sigdata.tr_spenddata.internal_key.IsNull()) {
++        m_tap_internal_key = sigdata.tr_spenddata.internal_key;
++    }
++    if (!sigdata.tr_builder.IsEmpty()) {
++        m_tap_tree = sigdata.tr_builder;
++    }
++    for (const auto& [pubkey, leaf_origin] : sigdata.taproot_misc_pubkeys) {
++        m_tap_bip32_paths.emplace(pubkey, leaf_origin);
++    }
+ }
+ 
+ bool PSBTOutput::IsNull() const
+diff --git a/src/script/sign.cpp b/src/script/sign.cpp
+index 7898b79d16..05413cbe63 100644
+--- a/src/script/sign.cpp
++++ b/src/script/sign.cpp
+@@ -193,11 +193,15 @@ static bool SignTaprootScript(const SigningProvider& provider, const BaseSignatu
+ static bool SignTaproot(const SigningProvider& provider, const BaseSignatureCreator& creator, const WitnessV1Taproot& output, SignatureData& sigdata, std::vector<valtype>& result)
+ {
+     TaprootSpendData spenddata;
++    TaprootBuilder builder;
+ 
+     // Gather information about this output.
+     if (provider.GetTaprootSpendData(output, spenddata)) {
+         sigdata.tr_spenddata.Merge(spenddata);
+     }
++    if (provider.GetTaprootBuilder(output, builder)) {
++        sigdata.tr_builder = builder;
++    }
+ 
+     // Try key path spending.
+     {
+diff --git a/src/script/sign.h b/src/script/sign.h
+index d97756eba9..e9bd5d8e74 100644
+--- a/src/script/sign.h
++++ b/src/script/sign.h
+@@ -68,6 +68,7 @@ struct SignatureData {
+     CScript witness_script; ///< The witnessScript (if any) for the input. witnessScripts are used in P2WSH outputs.
+     CScriptWitness scriptWitness; ///< The scriptWitness of an input. Contains complete signatures or the traditional partial signatures format. scriptWitness is part of a transaction input per BIP 144.
+     TaprootSpendData tr_spenddata; ///< Taproot spending data.
++    TaprootBuilder tr_builder; ///< Taproot tree used to build tr_spenddata.
+     std::map<CKeyID, SigPair> signatures; ///< BIP 174 style partial signatures for the input. May contain all signatures necessary for producing a final scriptSig or scriptWitness.
+     std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>> misc_pubkeys;
+     std::vector<unsigned char> taproot_key_path_sig; /// Schnorr signature for key path spending
+-- 
+2.34.1
+
+
+From 2935b71f22625bdc3e1e630059226ec4ae3b5a50 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Mon, 19 Jul 2021 16:54:16 -0400
+Subject: [PATCH 10/15] Implement decodepsbt for Taproot fields
+
+---
+ src/rpc/rawtransaction.cpp | 169 ++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 168 insertions(+), 1 deletion(-)
+
+diff --git a/src/rpc/rawtransaction.cpp b/src/rpc/rawtransaction.cpp
+index f2e8104e14..0300c9b274 100644
+--- a/src/rpc/rawtransaction.cpp
++++ b/src/rpc/rawtransaction.cpp
+@@ -1170,6 +1170,43 @@ static RPCHelpMan decodepsbt()
+                                 {
+                                     {RPCResult::Type::STR, "hash", "The hash and preimage that corresponds to it."},
+                                 }},
++                                {RPCResult::Type::STR_HEX, "taproot_key_path_sig", /*optional=*/ true, "hex-encoded signature for the Taproot key path spend"},
++                                {RPCResult::Type::ARR, "taproot_script_path_sigs", /*optional=*/ true, "",
++                                {
++                                    {RPCResult::Type::OBJ, "signature", /*optional=*/ true, "The signature for the pubkey and leaf hash combination",
++                                    {
++                                        {RPCResult::Type::STR, "pubkey", "The x-only pubkey for this signature"},
++                                        {RPCResult::Type::STR, "leaf_hash", "The leaf hash for this signature"},
++                                        {RPCResult::Type::STR, "sig", "The signature itself"},
++                                    }},
++                                }},
++                                {RPCResult::Type::ARR, "taproot_scripts", /*optional=*/ true, "",
++                                {
++                                    {RPCResult::Type::OBJ, "", "",
++                                    {
++                                        {RPCResult::Type::STR_HEX, "script", "A leaf script"},
++                                        {RPCResult::Type::NUM, "leaf_ver", "The version number for the leaf script"},
++                                        {RPCResult::Type::ARR, "control_blocks", "The control blocks for this script",
++                                        {
++                                            {RPCResult::Type::STR_HEX, "control_block", "A hex-encoded control block for this script"},
++                                        }},
++                                    }},
++                                }},
++                                {RPCResult::Type::ARR, "taproot_bip32_derivs", /*optional=*/ true, "",
++                                {
++                                    {RPCResult::Type::OBJ, "", "",
++                                    {
++                                        {RPCResult::Type::STR, "pubkey", "The x-only public key this path corresponds to"},
++                                        {RPCResult::Type::STR, "master_fingerprint", "The fingerprint of the master key"},
++                                        {RPCResult::Type::STR, "path", "The path"},
++                                        {RPCResult::Type::ARR, "leaf_hashes", "The hashes of the leaves this pubkey appears in",
++                                        {
++                                            {RPCResult::Type::STR_HEX, "hash", "The hash of a leaf this pubkey appears in"},
++                                        }},
++                                    }},
++                                }},
++                                {RPCResult::Type::STR_HEX, "taproot_internal_key", /*optional=*/ true, "The hex-encoded Taproot x-only internal key"},
++                                {RPCResult::Type::STR_HEX, "taproot_merkle_root", /*optional=*/ true, "The hex-encoded Taproot merkle root"},
+                                 {RPCResult::Type::OBJ_DYN, "unknown", /*optional=*/ true, "The unknown input fields",
+                                 {
+                                     {RPCResult::Type::STR_HEX, "key", "(key-value pair) An unknown key-value pair"},
+@@ -1211,7 +1248,30 @@ static RPCHelpMan decodepsbt()
+                                         {RPCResult::Type::STR, "path", "The path"},
+                                     }},
+                                 }},
+-                                {RPCResult::Type::OBJ_DYN, "unknown", /*optional=*/true, "The unknown global fields",
++                                {RPCResult::Type::STR_HEX, "taproot_internal_key", /*optional=*/ true, "The hex-encoded Taproot x-only internal key"},
++                                {RPCResult::Type::ARR, "taproot_tree", /*optional=*/ true, "The tuples that make up the Taproot tree, in depth first search order",
++                                {
++                                    {RPCResult::Type::OBJ, "tuple", /*optional=*/ true, "A single leaf script in the taproot tree",
++                                    {
++                                        {RPCResult::Type::NUM, "depth", "The depth of this element in the tree"},
++                                        {RPCResult::Type::NUM, "leaf_ver", "The version of this leaf"},
++                                        {RPCResult::Type::STR, "script", "The hex-encoded script itself"},
++                                    }},
++                                }},
++                                {RPCResult::Type::ARR, "taproot_bip32_derivs", /*optional=*/ true, "",
++                                {
++                                    {RPCResult::Type::OBJ, "", "",
++                                    {
++                                        {RPCResult::Type::STR, "pubkey", "The x-only public key this path corresponds to"},
++                                        {RPCResult::Type::STR, "master_fingerprint", "The fingerprint of the master key"},
++                                        {RPCResult::Type::STR, "path", "The path"},
++                                        {RPCResult::Type::ARR, "leaf_hashes", "The hashes of the leaves this pubkey appears in",
++                                        {
++                                            {RPCResult::Type::STR_HEX, "hash", "The hash of a leaf this pubkey appears in"},
++                                        }},
++                                    }},
++                                }},
++                                {RPCResult::Type::OBJ_DYN, "unknown", /*optional=*/true, "The unknown output fields",
+                                 {
+                                     {RPCResult::Type::STR_HEX, "key", "(key-value pair) An unknown key-value pair"},
+                                 }},
+@@ -1425,6 +1485,72 @@ static RPCHelpMan decodepsbt()
+             in.pushKV("hash256_preimages", hash256_preimages);
+         }
+ 
++        // Taproot key path signature
++        if (!input.m_tap_key_sig.empty()) {
++            in.pushKV("taproot_key_path_sig", HexStr(input.m_tap_key_sig));
++        }
++
++        // Taproot script path signatures
++        if (!input.m_tap_script_sigs.empty()) {
++            UniValue script_sigs(UniValue::VARR);
++            for (const auto& [pubkey_leaf, sig] : input.m_tap_script_sigs) {
++                const auto& [xonly, leaf_hash] = pubkey_leaf;
++                UniValue sigobj(UniValue::VOBJ);
++                sigobj.pushKV("pubkey", HexStr(xonly));
++                sigobj.pushKV("leaf_hash", HexStr(leaf_hash));
++                sigobj.pushKV("sig", HexStr(sig));
++                script_sigs.push_back(sigobj);
++            }
++            in.pushKV("taproot_script_path_sigs", script_sigs);
++        }
++
++        // Taproot leaf scripts
++        if (!input.m_tap_scripts.empty()) {
++            UniValue tap_scripts(UniValue::VARR);
++            for (const auto& [leaf, control_blocks] : input.m_tap_scripts) {
++                const auto& [script, leaf_ver] = leaf;
++                UniValue script_info(UniValue::VOBJ);
++                script_info.pushKV("script", HexStr(script));
++                script_info.pushKV("leaf_ver", leaf_ver);
++                UniValue control_blocks_univ(UniValue::VARR);
++                for (const auto& control_block : control_blocks) {
++                    control_blocks_univ.push_back(HexStr(control_block));
++                }
++                script_info.pushKV("control_blocks", control_blocks_univ);
++                tap_scripts.push_back(script_info);
++            }
++            in.pushKV("taproot_scripts", tap_scripts);
++        }
++
++        // Taproot bip32 keypaths
++        if (!input.m_tap_bip32_paths.empty()) {
++            UniValue keypaths(UniValue::VARR);
++            for (const auto& [xonly, leaf_origin] : input.m_tap_bip32_paths) {
++                const auto& [leaf_hashes, origin] = leaf_origin;
++                UniValue path_obj(UniValue::VOBJ);
++                path_obj.pushKV("pubkey", HexStr(xonly));
++                path_obj.pushKV("master_fingerprint", strprintf("%08x", ReadBE32(origin.fingerprint)));
++                path_obj.pushKV("path", WriteHDKeypath(origin.path));
++                UniValue leaf_hashes_arr(UniValue::VARR);
++                for (const auto& leaf_hash : leaf_hashes) {
++                    leaf_hashes_arr.push_back(HexStr(leaf_hash));
++                }
++                path_obj.pushKV("leaf_hashes", leaf_hashes_arr);
++                keypaths.push_back(path_obj);
++            }
++            in.pushKV("taproot_bip32_derivs", keypaths);
++        }
++
++        // Taproot internal key
++        if (!input.m_tap_internal_key.IsNull()) {
++            in.pushKV("taproot_internal_key", HexStr(input.m_tap_internal_key));
++        }
++
++        // Write taproot merkle root
++        if (!input.m_tap_merkle_root.IsNull()) {
++            in.pushKV("taproot_merkle_root", HexStr(input.m_tap_merkle_root));
++        }
++
+         // Proprietary
+         if (!input.m_proprietary.empty()) {
+             UniValue proprietary(UniValue::VARR);
+@@ -1483,6 +1609,47 @@ static RPCHelpMan decodepsbt()
+             out.pushKV("bip32_derivs", keypaths);
+         }
+ 
++        // Taproot internal key
++        if (!output.m_tap_internal_key.IsNull()) {
++            out.pushKV("taproot_internal_key", HexStr(output.m_tap_internal_key));
++        }
++
++        // Taproot tree
++        if (!output.m_tap_tree.IsEmpty()) {
++            UniValue tree(UniValue::VARR);
++            const auto& tuples = output.m_tap_tree.GetTreeTuples();
++            for (const auto& tuple : tuples) {
++                uint8_t depth = std::get<0>(tuple);
++                uint8_t leaf_ver = std::get<1>(tuple);
++                CScript script = std::get<2>(tuple);
++                UniValue elem(UniValue::VOBJ);
++                elem.pushKV("depth", (int)depth);
++                elem.pushKV("leaf_ver", (int)leaf_ver);
++                elem.pushKV("script", HexStr(script));
++                tree.push_back(elem);
++            }
++            out.pushKV("taproot_tree", tree);
++        }
++
++        // Taproot bip32 keypaths
++        if (!output.m_tap_bip32_paths.empty()) {
++            UniValue keypaths(UniValue::VARR);
++            for (const auto& [xonly, leaf_origin] : output.m_tap_bip32_paths) {
++                const auto& [leaf_hashes, origin] = leaf_origin;
++                UniValue path_obj(UniValue::VOBJ);
++                path_obj.pushKV("pubkey", HexStr(xonly));
++                path_obj.pushKV("master_fingerprint", strprintf("%08x", ReadBE32(origin.fingerprint)));
++                path_obj.pushKV("path", WriteHDKeypath(origin.path));
++                UniValue leaf_hashes_arr(UniValue::VARR);
++                for (const auto& leaf_hash : leaf_hashes) {
++                    leaf_hashes_arr.push_back(HexStr(leaf_hash));
++                }
++                path_obj.pushKV("leaf_hashes", leaf_hashes_arr);
++                keypaths.push_back(path_obj);
++            }
++            out.pushKV("taproot_bip32_derivs", keypaths);
++        }
++
+         // Proprietary
+         if (!output.m_proprietary.empty()) {
+             UniValue proprietary(UniValue::VARR);
+-- 
+2.34.1
+
+
+From 8b6a8ec3c951b7385770873daff21b9081c54aec Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Tue, 20 Jul 2021 20:04:33 -0400
+Subject: [PATCH 11/15] psbt: Remove non_witness_utxo for segwit v1+
+
+If all inputs are segwit v1+, the non_witness_utxos can be removed.
+---
+ src/psbt.cpp          |  6 +++---
+ src/wallet/wallet.cpp | 29 +++++++++++++++++++++++++++++
+ 2 files changed, 32 insertions(+), 3 deletions(-)
+
+diff --git a/src/psbt.cpp b/src/psbt.cpp
+index 679fbac562..53185475fd 100644
+--- a/src/psbt.cpp
++++ b/src/psbt.cpp
+@@ -184,7 +184,6 @@ void PSBTInput::Merge(const PSBTInput& input)
+ {
+     if (!non_witness_utxo && input.non_witness_utxo) non_witness_utxo = input.non_witness_utxo;
+     if (witness_utxo.IsNull() && !input.witness_utxo.IsNull()) {
+-        // TODO: For segwit v1, we will want to clear out the non-witness utxo when setting a witness one. For v0 and non-segwit, this is not safe
+         witness_utxo = input.witness_utxo;
+     }
+ 
+@@ -368,10 +367,11 @@ bool SignPSBTInput(const SigningProvider& provider, PartiallySignedTransaction&
+     input.FromSignatureData(sigdata);
+ 
+     // If we have a witness signature, put a witness UTXO.
+-    // TODO: For segwit v1, we should remove the non_witness_utxo
+     if (sigdata.witness) {
+         input.witness_utxo = utxo;
+-        // input.non_witness_utxo = nullptr;
++        // We can remove the non_witness_utxo if and only if there are no non-segwit or segwit v0
++        // inputs in this transaction. Since this requires inspecting the entire transaction, this
++        // is something for the caller to deal with (i.e. FillPSBT).
+     }
+ 
+     // Fill in the missing info
+diff --git a/src/wallet/wallet.cpp b/src/wallet/wallet.cpp
+index c79e917c69..8038abea21 100644
+--- a/src/wallet/wallet.cpp
++++ b/src/wallet/wallet.cpp
+@@ -1907,6 +1907,35 @@ TransactionError CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bool& comp
+         }
+     }
+ 
++    // Only drop non_witness_utxos if sighash_type != SIGHASH_ANYONECANPAY
++    if ((sighash_type & 0x80) != SIGHASH_ANYONECANPAY) {
++        // Figure out if any non_witness_utxos should be dropped
++        std::vector<unsigned int> to_drop;
++        for (unsigned int i = 0; i < psbtx.inputs.size(); ++i) {
++            const auto& input = psbtx.inputs.at(i);
++            int wit_ver;
++            std::vector<unsigned char> wit_prog;
++            if (input.witness_utxo.IsNull() || !input.witness_utxo.scriptPubKey.IsWitnessProgram(wit_ver, wit_prog)) {
++                // There's a non-segwit input or Segwit v0, so we cannot drop any witness_utxos
++                to_drop.clear();
++                break;
++            }
++            if (wit_ver == 0) {
++                // Segwit v0, so we cannot drop any non_witness_utxos
++                to_drop.clear();
++                break;
++            }
++            if (input.non_witness_utxo) {
++                to_drop.push_back(i);
++            }
++        }
++
++        // Drop the non_witness_utxos that we can drop
++        for (unsigned int i : to_drop) {
++            psbtx.inputs.at(i).non_witness_utxo = nullptr;
++        }
++    }
++
+     // Complete if every input is now signed
+     complete = true;
+     for (const auto& input : psbtx.inputs) {
+-- 
+2.34.1
+
+
+From dddd953e38e93592c745f022b1e0fb00fb77a82d Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Fri, 23 Jul 2021 18:50:54 -0400
+Subject: [PATCH 12/15] tests: Test taproot fields for PSBT
+
+---
+ test/functional/data/rpc_psbt.json | 21 +++++++++++++++++++--
+ 1 file changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/test/functional/data/rpc_psbt.json b/test/functional/data/rpc_psbt.json
+index 8672400a92..430a1802a8 100644
+--- a/test/functional/data/rpc_psbt.json
++++ b/test/functional/data/rpc_psbt.json
+@@ -27,7 +27,18 @@
+         "cHNidP8BADMBAAAAAREREREREREREREREREREREREfrK3hERERERERERERERfwAAAAD/////AAAAAAAAAQQAAQQBagA=",
+         "cHNidP8BADMBAAAAAREREREREREREREREREREREREfrK3hERERERERERERERfwAAAAD/////AAAAAAAAAQEJAOH1BQAAAAAAAQUAAQUBUQA=",
+         "cHNidP8BADMBAAAAAREREREREREREREREREREREREfrK3hERERERERERERERfwAAAAD/////AAAAAAAAAQcAAQcBUQA=",
+-        "cHNidP8BADMBAAAAAREREREREREREREREREREREREfrK3hERERERERERERERfwAAAAD/////AAAAAAAAAQEJAOH1BQAAAAAAAQgBAAEIAwEBUQA="
++        "cHNidP8BADMBAAAAAREREREREREREREREREREREREfrK3hERERERERERERERfwAAAAD/////AAAAAAAAAQEJAOH1BQAAAAAAAQgBAAEIAwEBUQA=",
++        "cHNidP8BAHECAAAAASd0Srq/MCf+DWzyOpbu4u+xiO9SMBlUWFiD5ptmJLJCAAAAAAD/////Anh8AQAAAAAAFgAUg6fjS9mf8DpJYu+KGhAbspVGHs5gawQqAQAAABYAFHrDad8bIOAz1hFmI5V7CsSfPFLoAAAAAAABASsA8gUqAQAAACJRIFosLPW1LPMfg60ujaY/8DGD7Nj2CcdRCuikjgORCgdXARchAv40kGTJjW4qhT+jybEr2LMEoZwZXGDvp+4jkwRtP6IyAAAA",
++        "cHNidP8BAHECAAAAASd0Srq/MCf+DWzyOpbu4u+xiO9SMBlUWFiD5ptmJLJCAAAAAAD/////Anh8AQAAAAAAFgAUg6fjS9mf8DpJYu+KGhAbspVGHs5gawQqAQAAABYAFHrDad8bIOAz1hFmI5V7CsSfPFLoAAAAAAABASsA8gUqAQAAACJRIFosLPW1LPMfg60ujaY/8DGD7Nj2CcdRCuikjgORCgdXARM/Fzuz02wHSvtxb+xjB6BpouRQuZXzyCeFlFq43w4kJg3NcDsMvzTeOZGEqUgawrNYbbZgHwJqd/fkk4SBvDR1AAAA",
++        "cHNidP8BAHECAAAAASd0Srq/MCf+DWzyOpbu4u+xiO9SMBlUWFiD5ptmJLJCAAAAAAD/////Anh8AQAAAAAAFgAUg6fjS9mf8DpJYu+KGhAbspVGHs5gawQqAQAAABYAFHrDad8bIOAz1hFmI5V7CsSfPFLoAAAAAAABASsA8gUqAQAAACJRIFosLPW1LPMfg60ujaY/8DGD7Nj2CcdRCuikjgORCgdXARNCFzuz02wHSvtxb+xjB6BpouRQuZXzyCeFlFq43w4kJg3NcDsMvzTeOZGEqUgawrNYbbZgHwJqd/fkk4SBvDR1FwGqAAAA",
++        "cHNidP8BAHECAAAAASd0Srq/MCf+DWzyOpbu4u+xiO9SMBlUWFiD5ptmJLJCAAAAAAD/////Anh8AQAAAAAAFgAUg6fjS9mf8DpJYu+KGhAbspVGHs5gawQqAQAAABYAFHrDad8bIOAz1hFmI5V7CsSfPFLoAAAAAAABASsA8gUqAQAAACJRIFosLPW1LPMfg60ujaY/8DGD7Nj2CcdRCuikjgORCgdXIhYC/jSQZMmNbiqFP6PJsSvYswShnBlcYO+n7iOTBG0/ojIZAHcrLadWAACAAQAAgAAAAIABAAAAAAAAAAAAAA==",
++        "cHNidP8BAH0CAAAAASd0Srq/MCf+DWzyOpbu4u+xiO9SMBlUWFiD5ptmJLJCAAAAAAD/////Aoh7AQAAAAAAFgAUI4KHHH6EIaAAk/dU2RKB5nWHS59gawQqAQAAACJRIFosLPW1LPMfg60ujaY/8DGD7Nj2CcdRCuikjgORCgdXAAAAAAABASsA8gUqAQAAACJRIFosLPW1LPMfg60ujaY/8DGD7Nj2CcdRCuikjgORCgdXAAABBSEC/jSQZMmNbiqFP6PJsSvYswShnBlcYO+n7iOTBG0/ojIA",
++        "cHNidP8BAH0CAAAAASd0Srq/MCf+DWzyOpbu4u+xiO9SMBlUWFiD5ptmJLJCAAAAAAD/////Aoh7AQAAAAAAFgAUI4KHHH6EIaAAk/dU2RKB5nWHS59gawQqAQAAACJRIFosLPW1LPMfg60ujaY/8DGD7Nj2CcdRCuikjgORCgdXAAAAAAABASsA8gUqAQAAACJRIFosLPW1LPMfg60ujaY/8DGD7Nj2CcdRCuikjgORCgdXAAAiBwL+NJBkyY1uKoU/o8mxK9izBKGcGVxg76fuI5MEbT+iMhkAdystp1YAAIABAACAAAAAgAEAAAAAAAAAAA==",
++        "cHNidP8BAF4CAAAAAZvUh2UjC/mnLmYgAflyVW5U8Mb5f+tWvLVgDYF/aZUmAQAAAAD/////AUjmBSoBAAAAIlEgAw2k/OT32yjCyylRYx4ANxOFZZf+ljiCy1AOaBEsymMAAAAAAAEBKwDyBSoBAAAAIlEgwiR++/2SrEf29AuNQtFpF1oZ+p+hDkol1/NetN2FtpJCFAIssTrGgkjegGqmo2Wc88A+toIdCcgRSk6Gj+vehlu20s2XDhX1P8DIL5UP1WD/qRm3YXK+AXNoqJkTrwdPQAsJQIl1aqNznMxonsD886NgvjLMC1mxbpOh6LtGBXJrLKej/3BsQXZkljKyzGjh+RK4pXjjcZzncQiFx6lm9JvNQ8sAAA==",
++        "cHNidP8BAF4CAAAAAZvUh2UjC/mnLmYgAflyVW5U8Mb5f+tWvLVgDYF/aZUmAQAAAAD/////AUjmBSoBAAAAIlEgAw2k/OT32yjCyylRYx4ANxOFZZf+ljiCy1AOaBEsymMAAAAAAAEBKwDyBSoBAAAAIlEgwiR++/2SrEf29AuNQtFpF1oZ+p+hDkol1/NetN2FtpJBFCyxOsaCSN6AaqajZZzzwD62gh0JyBFKToaP696GW7bSzZcOFfU/wMgvlQ/VYP+pGbdhcr4Bc2iomROvB09ACwlCiXVqo3OczGiewPzzo2C+MswLWbFuk6Hou0YFcmssp6P/cGxBdmSWMrLMaOH5ErileONxnOdxCIXHqWb0m81DywEBAAA=",
++        "cHNidP8BAF4CAAAAAZvUh2UjC/mnLmYgAflyVW5U8Mb5f+tWvLVgDYF/aZUmAQAAAAD/////AUjmBSoBAAAAIlEgAw2k/OT32yjCyylRYx4ANxOFZZf+ljiCy1AOaBEsymMAAAAAAAEBKwDyBSoBAAAAIlEgwiR++/2SrEf29AuNQtFpF1oZ+p+hDkol1/NetN2FtpJBFCyxOsaCSN6AaqajZZzzwD62gh0JyBFKToaP696GW7bSzZcOFfU/wMgvlQ/VYP+pGbdhcr4Bc2iomROvB09ACwk5iXVqo3OczGiewPzzo2C+MswLWbFuk6Hou0YFcmssp6P/cGxBdmSWMrLMaOH5ErileONxnOdxCIXHqWb0m81DywAA",
++        "cHNidP8BAF4CAAAAAZvUh2UjC/mnLmYgAflyVW5U8Mb5f+tWvLVgDYF/aZUmAQAAAAD/////AUjmBSoBAAAAIlEgAw2k/OT32yjCyylRYx4ANxOFZZf+ljiCy1AOaBEsymMAAAAAAAEBKwDyBSoBAAAAIlEgwiR++/2SrEf29AuNQtFpF1oZ+p+hDkol1/NetN2FtpJjFcFQkpt0waBJVLeLS2A16XpeB4paDyjsltVHv+6azoA6wG99YgWelJehpKJnVp2YdtpgEBr/OONSm5uTnOf5GulwEV8uSQr3zEXE94UR82BXzlxaXFYyWin7RN/CA/NW4fgAIyAssTrGgkjegGqmo2Wc88A+toIdCcgRSk6Gj+vehlu20qzAAAA=",
++        "cHNidP8BAF4CAAAAAZvUh2UjC/mnLmYgAflyVW5U8Mb5f+tWvLVgDYF/aZUmAQAAAAD/////AUjmBSoBAAAAIlEgAw2k/OT32yjCyylRYx4ANxOFZZf+ljiCy1AOaBEsymMAAAAAAAEBKwDyBSoBAAAAIlEgwiR++/2SrEf29AuNQtFpF1oZ+p+hDkol1/NetN2FtpJhFcFQkpt0waBJVLeLS2A16XpeB4paDyjsltVHv+6azoA6wG99YgWelJehpKJnVp2YdtpgEBr/OONSm5uTnOf5GulwEV8uSQr3zEXE94UR82BXzlxaXFYyWin7RN/CA/NW4SMgLLE6xoJI3oBqpqNlnPPAPraCHQnIEUpOho/r3oZbttKswAAA"
+     ],
+     "valid" : [
+         "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAAAAA",
+@@ -43,7 +54,13 @@
+         "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAFQoYn3yLGjhv/o7tkbODDHp7zR53jAIBAhUK8pG6UBXfNIyAhT+luw95RvXJ4bMBAQAAAA==",
+         "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAIQtL9RIvNEVUxTveLruM0rfj0WAK1jHDhaXXzOI8d4VFmgEBIQuhKHH+4hD7hhkpHq6hlFgcvSUx5LI3WdIl9oBpI/YyIgIBAgAAAA==",
+         "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAFQwVzEnhkcvFINkZRGAKXLd69qoykQIBAhUMxRtmvO1eRJEAG9cCZpdw3M9ECYIBAQAAAA==",
+-        "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAIQ12pWrO2RXSUT3NhMLDeLLoqlzWMrW3HKLyrFsOOmSb2wIBAiENnBLP3ATHRYTXh6w9I3chMsGFJLx6so3sQhm4/FtCX3ABAQAAAA=="
++        "cHNidP8BAHUCAAAAASaBcTce3/KF6Tet7qSze3gADAVmy7OtZGQXE8pCFxv2AAAAAAD+////AtPf9QUAAAAAGXapFNDFmQPFusKGh2DpD9UhpGZap2UgiKwA4fUFAAAAABepFDVF5uM7gyxHBQ8k0+65PJwDlIvHh7MuEwAAAQD9pQEBAAAAAAECiaPHHqtNIOA3G7ukzGmPopXJRjr6Ljl/hTPMti+VZ+UBAAAAFxYAFL4Y0VKpsBIDna89p95PUzSe7LmF/////4b4qkOnHf8USIk6UwpyN+9rRgi7st0tAXHmOuxqSJC0AQAAABcWABT+Pp7xp0XpdNkCxDVZQ6vLNL1TU/////8CAMLrCwAAAAAZdqkUhc/xCX/Z4Ai7NK9wnGIZeziXikiIrHL++E4sAAAAF6kUM5cluiHv1irHU6m80GfWx6ajnQWHAkcwRAIgJxK+IuAnDzlPVoMR3HyppolwuAJf3TskAinwf4pfOiQCIAGLONfc0xTnNMkna9b7QPZzMlvEuqFEyADS8vAtsnZcASED0uFWdJQbrUqZY3LLh+GFbTZSYG2YVi/jnF6efkE/IQUCSDBFAiEA0SuFLYXc2WHS9fSrZgZU327tzHlMDDPOXMMJ/7X85Y0CIGczio4OFyXBl/saiK9Z9R5E5CVbIBZ8hoQDHAXR8lkqASECI7cr7vCWXRC+B3jv7NYfysb3mk6haTkzgHNEZPhPKrMAAAAAIQ12pWrO2RXSUT3NhMLDeLLoqlzWMrW3HKLyrFsOOmSb2wIBAiENnBLP3ATHRYTXh6w9I3chMsGFJLx6so3sQhm4/FtCX3ABAQAAAA==",
++        "cHNidP8BAFICAAAAASd0Srq/MCf+DWzyOpbu4u+xiO9SMBlUWFiD5ptmJLJCAAAAAAD/////AUjmBSoBAAAAFgAUdo4e60z0IIZgM/gKzv8PlyB0SWkAAAAAAAEBKwDyBSoBAAAAIlEgWiws9bUs8x+DrS6Npj/wMYPs2PYJx1EK6KSOA5EKB1chFv40kGTJjW4qhT+jybEr2LMEoZwZXGDvp+4jkwRtP6IyGQB3Ky2nVgAAgAEAAIAAAACAAQAAAAAAAAABFyD+NJBkyY1uKoU/o8mxK9izBKGcGVxg76fuI5MEbT+iMgAiAgNrdyptt02HU8mKgnlY3mx4qzMSEJ830+AwRIQkLs5z2Bh3Ky2nVAAAgAEAAIAAAACAAAAAAAAAAAAA",
++        "cHNidP8BAFICAAAAASd0Srq/MCf+DWzyOpbu4u+xiO9SMBlUWFiD5ptmJLJCAAAAAAD/////AUjmBSoBAAAAFgAUdo4e60z0IIZgM/gKzv8PlyB0SWkAAAAAAAEBKwDyBSoBAAAAIlEgWiws9bUs8x+DrS6Npj/wMYPs2PYJx1EK6KSOA5EKB1cBE0C7U+yRe62dkGrxuocYHEi4as5aritTYFpyXKdGJWMUdvxvW67a9PLuD0d/NvWPOXDVuCc7fkl7l68uPxJcl680IRb+NJBkyY1uKoU/o8mxK9izBKGcGVxg76fuI5MEbT+iMhkAdystp1YAAIABAACAAAAAgAEAAAAAAAAAARcg/jSQZMmNbiqFP6PJsSvYswShnBlcYO+n7iOTBG0/ojIAIgIDa3cqbbdNh1PJioJ5WN5seKszEhCfN9PgMESEJC7Oc9gYdystp1QAAIABAACAAAAAgAAAAAAAAAAAAA==",
++        "cHNidP8BAF4CAAAAASd0Srq/MCf+DWzyOpbu4u+xiO9SMBlUWFiD5ptmJLJCAAAAAAD/////AUjmBSoBAAAAIlEgg2mORYxmZOFZXXXaJZfeHiLul9eY5wbEwKS1qYI810MAAAAAAAEBKwDyBSoBAAAAIlEgWiws9bUs8x+DrS6Npj/wMYPs2PYJx1EK6KSOA5EKB1chFv40kGTJjW4qhT+jybEr2LMEoZwZXGDvp+4jkwRtP6IyGQB3Ky2nVgAAgAEAAIAAAACAAQAAAAAAAAABFyD+NJBkyY1uKoU/o8mxK9izBKGcGVxg76fuI5MEbT+iMgABBSARJNp67JLM0GyVRWJkf0N7E4uVchqEvivyJ2u92rPmcSEHESTaeuySzNBslUViZH9DexOLlXIahL4r8idrvdqz5nEZAHcrLadWAACAAQAAgAAAAIAAAAAABQAAAAA=",
++        "cHNidP8BAF4CAAAAAZvUh2UjC/mnLmYgAflyVW5U8Mb5f+tWvLVgDYF/aZUmAQAAAAD/////AUjmBSoBAAAAIlEgg2mORYxmZOFZXXXaJZfeHiLul9eY5wbEwKS1qYI810MAAAAAAAEBKwDyBSoBAAAAIlEgwiR++/2SrEf29AuNQtFpF1oZ+p+hDkol1/NetN2FtpJiFcFQkpt0waBJVLeLS2A16XpeB4paDyjsltVHv+6azoA6wG99YgWelJehpKJnVp2YdtpgEBr/OONSm5uTnOf5GulwEV8uSQr3zEXE94UR82BXzlxaXFYyWin7RN/CA/NW4fgjICyxOsaCSN6AaqajZZzzwD62gh0JyBFKToaP696GW7bSrMBCFcFQkpt0waBJVLeLS2A16XpeB4paDyjsltVHv+6azoA6wJfG5v6l/3FP9XJEmZkIEOQG6YqhD1v35fZ4S8HQqabOIyBDILC/FvARtT6nvmFZJKp/J+XSmtIOoRVdhIZ2w7rRsqzAYhXBUJKbdMGgSVS3i0tgNel6XgeKWg8o7JbVR7/ums6AOsDNlw4V9T/AyC+VD9Vg/6kZt2FyvgFzaKiZE68HT0ALCRFfLkkK98xFxPeFEfNgV85cWlxWMlop+0TfwgPzVuH4IyD6D3o87zsdDAps59JuF62gsuXJLRnvrUi0GFnLikUcqazAIRYssTrGgkjegGqmo2Wc88A+toIdCcgRSk6Gj+vehlu20jkBzZcOFfU/wMgvlQ/VYP+pGbdhcr4Bc2iomROvB09ACwl3Ky2nVgAAgAEAAIACAACAAAAAAAAAAAAhFkMgsL8W8BG1Pqe+YVkkqn8n5dKa0g6hFV2EhnbDutGyOQERXy5JCvfMRcT3hRHzYFfOXFpcVjJaKftE38ID81bh+HcrLadWAACAAQAAgAEAAIAAAAAAAAAAACEWUJKbdMGgSVS3i0tgNel6XgeKWg8o7JbVR7/ums6AOsAFAHxGHl0hFvoPejzvOx0MCmzn0m4XraCy5cktGe+tSLQYWcuKRRypOQFvfWIFnpSXoaSiZ1admHbaYBAa/zjjUpubk5zn+RrpcHcrLadWAACAAQAAgAMAAIAAAAAAAAAAAAEXIFCSm3TBoElUt4tLYDXpel4HiloPKOyW1Ue/7prOgDrAARgg8DYuL3Wm9CClvePrIh2WrmcgzyX4GJDJWx13WstRXmUAAQUgESTaeuySzNBslUViZH9DexOLlXIahL4r8idrvdqz5nEhBxEk2nrskszQbJVFYmR/Q3sTi5VyGoS+K/Ina73as+ZxGQB3Ky2nVgAAgAEAAIAAAACAAAAAAAUAAAAA",
++        "cHNidP8BAF4CAAAAASd0Srq/MCf+DWzyOpbu4u+xiO9SMBlUWFiD5ptmJLJCAAAAAAD/////AUjmBSoBAAAAIlEgCoy9yG3hzhwPnK6yLW33ztNoP+Qj4F0eQCqHk0HW9vUAAAAAAAEBKwDyBSoBAAAAIlEgWiws9bUs8x+DrS6Npj/wMYPs2PYJx1EK6KSOA5EKB1chFv40kGTJjW4qhT+jybEr2LMEoZwZXGDvp+4jkwRtP6IyGQB3Ky2nVgAAgAEAAIAAAACAAQAAAAAAAAABFyD+NJBkyY1uKoU/o8mxK9izBKGcGVxg76fuI5MEbT+iMgABBSBQkpt0waBJVLeLS2A16XpeB4paDyjsltVHv+6azoA6wAEGbwLAIiBzblcpAP4SUliaIUPI88efcaBBLSNTr3VelwHHgmlKAqwCwCIgYxxfO1gyuPvev7GXBM7rMjwh9A96JPQ9aO8MwmsSWWmsAcAiIET6pJoDON5IjI3//s37bzKfOAvVZu8gyN9tgT6rHEJzrCEHRPqkmgM43kiMjf/+zftvMp84C9Vm7yDI322BPqscQnM5AfBreYuSoQ7ZqdC7/Trxc6U7FhfaOkFZygCCFs2Fay4Odystp1YAAIABAACAAQAAgAAAAAADAAAAIQdQkpt0waBJVLeLS2A16XpeB4paDyjsltVHv+6azoA6wAUAfEYeXSEHYxxfO1gyuPvev7GXBM7rMjwh9A96JPQ9aO8MwmsSWWk5ARis5AmIl4Xg6nDO67jhyokqenjq7eDy4pbPQ1lhqPTKdystp1YAAIABAACAAgAAgAAAAAADAAAAIQdzblcpAP4SUliaIUPI88efcaBBLSNTr3VelwHHgmlKAjkBKaW0kVCQFi11mv0/4Pk/ozJgVtC0CIy5M8rngmy42Cx3Ky2nVgAAgAEAAIADAACAAAAAAAMAAAAA",
++        "cHNidP8BAF4CAAAAAZvUh2UjC/mnLmYgAflyVW5U8Mb5f+tWvLVgDYF/aZUmAQAAAAD/////AUjmBSoBAAAAIlEgg2mORYxmZOFZXXXaJZfeHiLul9eY5wbEwKS1qYI810MAAAAAAAEBKwDyBSoBAAAAIlEgwiR++/2SrEf29AuNQtFpF1oZ+p+hDkol1/NetN2FtpJBFCyxOsaCSN6AaqajZZzzwD62gh0JyBFKToaP696GW7bSzZcOFfU/wMgvlQ/VYP+pGbdhcr4Bc2iomROvB09ACwlAv4GNl1fW/+tTi6BX+0wfxOD17xhudlvrVkeR4Cr1/T1eJVHU404z2G8na4LJnHmu0/A5Wgge/NLMLGXdfmk9eUEUQyCwvxbwEbU+p75hWSSqfyfl0prSDqEVXYSGdsO60bIRXy5JCvfMRcT3hRHzYFfOXFpcVjJaKftE38ID81bh+EDh8atvq/omsjbyGDNxncHUKKt2jYD5H5mI2KvvR7+4Y7sfKlKfdowV8AzjTsKDzcB+iPhCi+KPbvZAQ8MpEYEaQRT6D3o87zsdDAps59JuF62gsuXJLRnvrUi0GFnLikUcqW99YgWelJehpKJnVp2YdtpgEBr/OONSm5uTnOf5GulwQOwfA3kgZGHIM0IoVCMyZwirAx8NpKJT7kWq+luMkgNNi2BUkPjNE+APmJmJuX4hX6o28S3uNpPS2szzeBwXV/ZiFcFQkpt0waBJVLeLS2A16XpeB4paDyjsltVHv+6azoA6wG99YgWelJehpKJnVp2YdtpgEBr/OONSm5uTnOf5GulwEV8uSQr3zEXE94UR82BXzlxaXFYyWin7RN/CA/NW4fgjICyxOsaCSN6AaqajZZzzwD62gh0JyBFKToaP696GW7bSrMBCFcFQkpt0waBJVLeLS2A16XpeB4paDyjsltVHv+6azoA6wJfG5v6l/3FP9XJEmZkIEOQG6YqhD1v35fZ4S8HQqabOIyBDILC/FvARtT6nvmFZJKp/J+XSmtIOoRVdhIZ2w7rRsqzAYhXBUJKbdMGgSVS3i0tgNel6XgeKWg8o7JbVR7/ums6AOsDNlw4V9T/AyC+VD9Vg/6kZt2FyvgFzaKiZE68HT0ALCRFfLkkK98xFxPeFEfNgV85cWlxWMlop+0TfwgPzVuH4IyD6D3o87zsdDAps59JuF62gsuXJLRnvrUi0GFnLikUcqazAIRYssTrGgkjegGqmo2Wc88A+toIdCcgRSk6Gj+vehlu20jkBzZcOFfU/wMgvlQ/VYP+pGbdhcr4Bc2iomROvB09ACwl3Ky2nVgAAgAEAAIACAACAAAAAAAAAAAAhFkMgsL8W8BG1Pqe+YVkkqn8n5dKa0g6hFV2EhnbDutGyOQERXy5JCvfMRcT3hRHzYFfOXFpcVjJaKftE38ID81bh+HcrLadWAACAAQAAgAEAAIAAAAAAAAAAACEWUJKbdMGgSVS3i0tgNel6XgeKWg8o7JbVR7/ums6AOsAFAHxGHl0hFvoPejzvOx0MCmzn0m4XraCy5cktGe+tSLQYWcuKRRypOQFvfWIFnpSXoaSiZ1admHbaYBAa/zjjUpubk5zn+RrpcHcrLadWAACAAQAAgAMAAIAAAAAAAAAAAAEXIFCSm3TBoElUt4tLYDXpel4HiloPKOyW1Ue/7prOgDrAARgg8DYuL3Wm9CClvePrIh2WrmcgzyX4GJDJWx13WstRXmUAAQUgESTaeuySzNBslUViZH9DexOLlXIahL4r8idrvdqz5nEhBxEk2nrskszQbJVFYmR/Q3sTi5VyGoS+K/Ina73as+ZxGQB3Ky2nVgAAgAEAAIAAAACAAAAAAAUAAAAA"
+     ],
+     "creator" : [
+         {
+-- 
+2.34.1
+
+
+From 70a52ce178e6a5f79ac757599482cea18e50086b Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Mon, 26 Jul 2021 16:23:50 -0400
+Subject: [PATCH 13/15] taproot: Use pre-existing signatures if available
+
+Actually use pre-existing signatures in CreateTaprootScriptSig if a
+signature is found for the given key and leaf hash.
+---
+ src/script/sign.cpp               | 1 +
+ test/functional/wallet_taproot.py | 3 +--
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/script/sign.cpp b/src/script/sign.cpp
+index 05413cbe63..8d70f6650e 100644
+--- a/src/script/sign.cpp
++++ b/src/script/sign.cpp
+@@ -150,6 +150,7 @@ static bool CreateTaprootScriptSig(const BaseSignatureCreator& creator, Signatur
+     auto it = sigdata.taproot_script_sigs.find(lookup_key);
+     if (it != sigdata.taproot_script_sigs.end()) {
+         sig_out = it->second;
++        return true;
+     }
+     if (creator.CreateSchnorrSig(provider, sig_out, pubkey, &leaf_hash, nullptr, sigversion)) {
+         sigdata.taproot_script_sigs[lookup_key] = sig_out;
+diff --git a/test/functional/wallet_taproot.py b/test/functional/wallet_taproot.py
+index 17eab25457..2a2a99414e 100755
+--- a/test/functional/wallet_taproot.py
++++ b/test/functional/wallet_taproot.py
+@@ -416,8 +416,7 @@ class WalletTaprootTest(BitcoinTestFramework):
+         assert(self.rpc_online.gettransaction(txid)["confirmations"] > 0)
+ 
+         psbt = self.psbt_online.walletcreatefundedpsbt([], [{self.boring.getnewaddress(): self.psbt_online.getbalance()}], None, {"subtractFeeFromOutputs": [0]})['psbt']
+-        res = self.psbt_offline.walletprocesspsbt(psbt)
+-        assert(res['complete'])
++        res = self.psbt_offline.walletprocesspsbt(psbt=psbt, finalize=False)
+         rawtx = self.nodes[0].finalizepsbt(res['psbt'])['hex']
+         txid = self.nodes[0].sendrawtransaction(rawtx)
+         self.generatetoaddress(self.nodes[0], 1, self.boring.getnewaddress(), sync_fun=self.no_op)
+-- 
+2.34.1
+
+
+From 242244a59c2bf49339f8e7f029c138fd27f4b231 Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Mon, 26 Jul 2021 16:25:42 -0400
+Subject: [PATCH 14/15] psbt, test: Check for taproot fields in taproot psbt
+ test
+
+---
+ test/functional/wallet_taproot.py | 16 ++++++++++++++--
+ 1 file changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/test/functional/wallet_taproot.py b/test/functional/wallet_taproot.py
+index 2a2a99414e..cb5443172f 100755
+--- a/test/functional/wallet_taproot.py
++++ b/test/functional/wallet_taproot.py
+@@ -307,8 +307,20 @@ class WalletTaprootTest(BitcoinTestFramework):
+             test_balance = int(self.psbt_online.getbalance() * 100000000)
+             ret_amnt = random.randrange(100000, test_balance)
+             psbt = self.psbt_online.walletcreatefundedpsbt([], [{self.boring.getnewaddress(): Decimal(ret_amnt) / 100000000}], None, {"subtractFeeFromOutputs":[0]})['psbt']
+-            res = self.psbt_offline.walletprocesspsbt(psbt)
+-            assert(res['complete'])
++            res = self.psbt_offline.walletprocesspsbt(psbt=psbt, finalize=False)
++
++            decoded = self.psbt_offline.decodepsbt(res["psbt"])
++            if pattern.startswith("tr("):
++                for psbtin in decoded["inputs"]:
++                    assert "non_witness_utxo" not in psbtin
++                    assert "witness_utxo" in psbtin
++                    assert "taproot_internal_key" in psbtin
++                    assert "taproot_bip32_derivs" in psbtin
++                    assert "taproot_key_path_sig" in psbtin or "taproot_script_path_sigs" in psbtin
++                    if "taproot_script_path_sigs" in psbtin:
++                        assert "taproot_merkle_root" in psbtin
++                        assert "taproot_scripts" in psbtin
++
+             rawtx = self.nodes[0].finalizepsbt(res['psbt'])['hex']
+             txid = self.nodes[0].sendrawtransaction(rawtx)
+             self.generatetoaddress(self.nodes[0], 1, self.boring.getnewaddress(), sync_fun=self.no_op)
+-- 
+2.34.1
+
+
+From de7441b0b625bd7a83b33c19eaa306b57bd3210f Mon Sep 17 00:00:00 2001
+From: Andrew Chow <achow101-github@achow101.com>
+Date: Wed, 24 Nov 2021 22:50:10 -0500
+Subject: [PATCH 15/15] psbt: Implement merge for Taproot fields
+
+---
+ src/psbt.cpp | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/psbt.cpp b/src/psbt.cpp
+index 53185475fd..0e7a3d8485 100644
+--- a/src/psbt.cpp
++++ b/src/psbt.cpp
+@@ -194,11 +194,17 @@ void PSBTInput::Merge(const PSBTInput& input)
+     hash256_preimages.insert(input.hash256_preimages.begin(), input.hash256_preimages.end());
+     hd_keypaths.insert(input.hd_keypaths.begin(), input.hd_keypaths.end());
+     unknown.insert(input.unknown.begin(), input.unknown.end());
++    m_tap_script_sigs.insert(input.m_tap_script_sigs.begin(), input.m_tap_script_sigs.end());
++    m_tap_scripts.insert(input.m_tap_scripts.begin(), input.m_tap_scripts.end());
++    m_tap_bip32_paths.insert(input.m_tap_bip32_paths.begin(), input.m_tap_bip32_paths.end());
+ 
+     if (redeem_script.empty() && !input.redeem_script.empty()) redeem_script = input.redeem_script;
+     if (witness_script.empty() && !input.witness_script.empty()) witness_script = input.witness_script;
+     if (final_script_sig.empty() && !input.final_script_sig.empty()) final_script_sig = input.final_script_sig;
+     if (final_script_witness.IsNull() && !input.final_script_witness.IsNull()) final_script_witness = input.final_script_witness;
++    if (m_tap_key_sig.empty() && !input.m_tap_key_sig.empty()) m_tap_key_sig = input.m_tap_key_sig;
++    if (m_tap_internal_key.IsNull() && !input.m_tap_internal_key.IsNull()) m_tap_internal_key = input.m_tap_internal_key;
++    if (m_tap_merkle_root.IsNull() && !input.m_tap_merkle_root.IsNull()) m_tap_merkle_root = input.m_tap_merkle_root;
+ }
+ 
+ void PSBTOutput::FillSignatureData(SignatureData& sigdata) const
+@@ -255,9 +261,12 @@ void PSBTOutput::Merge(const PSBTOutput& output)
+ {
+     hd_keypaths.insert(output.hd_keypaths.begin(), output.hd_keypaths.end());
+     unknown.insert(output.unknown.begin(), output.unknown.end());
++    m_tap_bip32_paths.insert(output.m_tap_bip32_paths.begin(), output.m_tap_bip32_paths.end());
+ 
+     if (redeem_script.empty() && !output.redeem_script.empty()) redeem_script = output.redeem_script;
+     if (witness_script.empty() && !output.witness_script.empty()) witness_script = output.witness_script;
++    if (m_tap_internal_key.IsNull() && !output.m_tap_internal_key.IsNull()) m_tap_internal_key = output.m_tap_internal_key;
++    if (m_tap_tree.IsEmpty() && !output.m_tap_tree.IsEmpty()) m_tap_tree = output.m_tap_tree;
+ }
+ bool PSBTInputSigned(const PSBTInput& input)
+ {
+-- 
+2.34.1
+

--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -368,6 +368,7 @@ if [[ -n ${build_bitcoind} ]]; then
         bitcoind_setup_needed=true
     else
         cd bitcoin
+        git reset --hard origin/master
         git fetch
 
         # Determine if we need to pull. From https://stackoverflow.com/a/3278427
@@ -388,6 +389,11 @@ if [[ -n ${build_bitcoind} ]]; then
     pushd depends
     make NO_QT=1 NO_QR=1 NO_ZMQ=1 NO_UPNP=1 NO_NATPMP=1
     popd
+
+    # Apply Taproot PSBT fields patch
+    git am ../../data/bitcoind_taproot_psbt.patch
+
+    # Do the build
     ./autogen.sh
     CONFIG_SITE=$PWD/depends/x86_64-pc-linux-gnu/share/config.site ./configure --with-incompatible-bdb --with-miniupnpc=no --without-gui --disable-zmq --disable-tests --disable-bench --with-libs=no --with-utils=no
     make src/bitcoind

--- a/test/test_coldcard.py
+++ b/test/test_coldcard.py
@@ -98,17 +98,27 @@ def coldcard_test_suite(simulator, rpc, userpass, interface):
             self.assertEqual(result['chaincode'], '806b26507824f73bc331494afe122f428ef30dde80b2c1ce025d2d03aff411e7')
             self.assertEqual(result['pubkey'], '0368000bdff5e0b71421c37b8514de8acd4d98ba9908d183d9da56d02ca4fcfd08')
 
+    dev_type = "coldcard"
+    sim_path = "/tmp/ckcc-simulator.sock"
+    fpr = "0f056943"
+    xpub = "tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd"
+    signtx_cases = [
+        (["legacy"], True, True, False),
+        (["segwit"], True, True, False),
+        (["legacy", "segwit"], True, True, False),
+    ]
+
     # Generic device tests
     suite = unittest.TestSuite()
-    suite.addTest(DeviceTestCase.parameterize(TestColdcardManCommands, rpc, userpass, 'coldcard', 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', '', interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestColdcardGetXpub, rpc, userpass, 'coldcard', 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd', interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'coldcard', 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd', interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'coldcard_simulator', 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd', interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestGetDescriptors, rpc, userpass, 'coldcard', 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd', interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, 'coldcard', 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd', interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, 'coldcard', 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd', interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestSignMessage, rpc, userpass, 'coldcard', 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd', interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, 'coldcard', 'coldcard', '/tmp/ckcc-simulator.sock', '0f056943', 'tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd', interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestColdcardManCommands, rpc, userpass, dev_type, dev_type, sim_path, fpr, '', interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestColdcardGetXpub, rpc, userpass, dev_type, dev_type, sim_path, fpr, xpub, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, dev_type, dev_type, sim_path, fpr, xpub, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'coldcard_simulator', dev_type, sim_path, fpr, xpub, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestGetDescriptors, rpc, userpass, dev_type, dev_type, sim_path, fpr, xpub, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, dev_type, dev_type, sim_path, fpr, xpub, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, dev_type, dev_type, sim_path, fpr, xpub, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestSignMessage, rpc, userpass, dev_type, dev_type, sim_path, fpr, xpub, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, dev_type, dev_type, sim_path, fpr, xpub, interface=interface, signtx_cases=signtx_cases))
 
     result = unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)
     cleanup_simulator()

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -20,10 +20,6 @@ from hwilib.psbt import PSBT
 SUPPORTS_MS_DISPLAY = {'trezor_1', 'keepkey', 'coldcard', 'trezor_t'}
 SUPPORTS_XPUB_MS_DISPLAY = {'trezor_1', 'trezor_t'}
 SUPPORTS_UNSORTED_MS = {"trezor_1", "trezor_t"}
-SUPPORTS_MIXED = {'coldcard', 'trezor_1', 'digitalbitbox', 'keepkey', 'trezor_t', 'jade'}
-SUPPORTS_MULTISIG = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t', 'jade'}
-SUPPORTS_EXTERNAL = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t', 'jade'}
-SUPPORTS_OP_RETURN = {'ledger', 'digitalbitbox', 'trezor_1', 'trezor_t', 'keepkey', 'jade'}
 SUPPORTS_TAPROOT = {"trezor_1", "trezor_t"}
 
 # Class for emulator control
@@ -67,7 +63,7 @@ def start_bitcoind(bitcoind_path):
     return (rpc, userpass)
 
 class DeviceTestCase(unittest.TestCase):
-    def __init__(self, rpc, rpc_userpass, type, full_type, path, fingerprint, master_xpub, password='', emulator=None, interface='library', methodName='runTest'):
+    def __init__(self, rpc, rpc_userpass, type, full_type, path, fingerprint, master_xpub, password='', emulator=None, interface='library', signtx_cases=None, methodName='runTest'):
         super(DeviceTestCase, self).__init__(methodName)
         self.rpc = rpc
         self.rpc_userpass = rpc_userpass
@@ -85,14 +81,15 @@ class DeviceTestCase(unittest.TestCase):
         if password:
             self.dev_args.extend(['-p', password])
         self.interface = interface
+        self.signtx_cases = signtx_cases
 
     @staticmethod
-    def parameterize(testclass, rpc, rpc_userpass, type, full_type, path, fingerprint, master_xpub, password='', interface='library', emulator=None):
+    def parameterize(testclass, rpc, rpc_userpass, type, full_type, path, fingerprint, master_xpub, password='', interface='library', emulator=None, signtx_cases=None):
         testloader = unittest.TestLoader()
         testnames = testloader.getTestCaseNames(testclass)
         suite = unittest.TestSuite()
         for name in testnames:
-            suite.addTest(testclass(rpc, rpc_userpass, type, full_type, path, fingerprint, master_xpub, password, emulator, interface, name))
+            suite.addTest(testclass(rpc, rpc_userpass, type, full_type, path, fingerprint, master_xpub, password, emulator, interface, signtx_cases, name))
         return suite
 
     def do_command(self, args):
@@ -275,6 +272,7 @@ class TestSignTx(DeviceTestCase):
     def setUp(self):
         super().setUp()
         self.setup_wallets()
+        assert self.signtx_cases is not None
 
     def _generate_and_finalize(self, unknown_inputs, psbt):
         if not unknown_inputs:
@@ -369,7 +367,7 @@ class TestSignTx(DeviceTestCase):
 
         return sh_desc, sh_ms_info["address"], sh_wsh_desc, sh_wsh_ms_info["address"], wsh_desc, wsh_ms_info["address"]
 
-    def _test_signtx(self, input_type, multisig, external, op_return: bool):
+    def _test_signtx(self, input_types, multisig, external, op_return: bool):
         # Import some keys to the watch only wallet and send coins to them
         keypool_desc = self.do_command(self.dev_args + ['getkeypool', '--all', '30', '50'])
         import_result = self.wrpc.importdescriptors(keypool_desc)
@@ -378,7 +376,7 @@ class TestSignTx(DeviceTestCase):
         wpkh_addr = self.wrpc.getnewaddress('', 'bech32')
         pkh_addr = self.wrpc.getnewaddress('', 'legacy')
         tr_addr = None
-        if self.full_type in SUPPORTS_TAPROOT:
+        if "tap" in input_types:
             tr_addr = self.wrpc.getnewaddress("", "bech32m")
 
         sh_multi_desc, sh_multi_addr, sh_wsh_multi_desc, sh_wsh_multi_addr, wsh_multi_desc, wsh_multi_addr = self._make_multisigs()
@@ -395,23 +393,23 @@ class TestSignTx(DeviceTestCase):
         out_amt = in_amt // 3 * 0.9
         number_inputs = 0
         # Single-sig
-        if input_type == 'segwit' or input_type == 'all':
+        if "segwit" in input_types:
             self.wpk_rpc.sendtoaddress(sh_wpkh_addr, in_amt)
             self.wpk_rpc.sendtoaddress(wpkh_addr, in_amt)
             number_inputs += 2
-        if input_type == 'legacy' or input_type == 'all':
+        if "legacy" in input_types:
             self.wpk_rpc.sendtoaddress(pkh_addr, in_amt)
             number_inputs += 1
-        if input_type == "tap" or input_type == "all":
+        if "tap" in input_types:
             assert tr_addr is not None
             self.wpk_rpc.sendtoaddress(tr_addr, in_amt)
             number_inputs += 1
         # Now do segwit/legacy multisig
         if multisig:
-            if input_type == 'legacy' or input_type == 'all':
+            if "legacy" in input_types:
                 self.wpk_rpc.sendtoaddress(sh_multi_addr, in_amt)
                 number_inputs += 1
-            if input_type == 'segwit' or input_type == 'all':
+            if "segwit" in input_types:
                 self.wpk_rpc.sendtoaddress(wsh_multi_addr, in_amt)
                 self.wpk_rpc.sendtoaddress(sh_wsh_multi_addr, in_amt)
                 number_inputs += 2
@@ -446,22 +444,10 @@ class TestSignTx(DeviceTestCase):
 
     # Test wrapper to avoid mixed-inputs signing for Ledger
     def test_signtx(self):
-        multisig = self.full_type in SUPPORTS_MULTISIG
-        external = self.full_type in SUPPORTS_EXTERNAL
-        op_return = self.full_type in SUPPORTS_OP_RETURN
-        with self.subTest(addrtype="legacy", multisig=multisig, external=external):
-            self._test_signtx("legacy", multisig, external, op_return)
-        with self.subTest(addrtype="segwit", multisig=multisig, external=external):
-            self._test_signtx("segwit", multisig, external, op_return)
-        if self.full_type in SUPPORTS_TAPROOT:
-            with self.subTest(addrtype="tap", multisig=False, external=external):
-                self._test_signtx("tap", False, external, op_return)
-        if self.full_type in SUPPORTS_MIXED:
-            if "trezor" in self.full_type:
-                # Trezors cannot do external mixed with Taproot
-                external = False
-            with self.subTest(addrtype="all", multisig=multisig, external=external):
-                self._test_signtx("all", multisig, external, op_return)
+
+        for addrtypes, multisig, external, op_return in self.signtx_cases:
+            with self.subTest(addrtypes=addrtypes, multisig=multisig, external=external, op_return=op_return):
+                self._test_signtx(addrtypes, multisig, external, op_return)
 
     # Make a huge transaction which might cause some problems with different interfaces
     def test_big_tx(self):

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -457,6 +457,9 @@ class TestSignTx(DeviceTestCase):
             with self.subTest(addrtype="tap", multisig=False, external=external):
                 self._test_signtx("tap", False, external, op_return)
         if self.full_type in SUPPORTS_MIXED:
+            if "trezor" in self.full_type:
+                # Trezors cannot do external mixed with Taproot
+                external = False
             with self.subTest(addrtype="all", multisig=multisig, external=external):
                 self._test_signtx("all", multisig, external, op_return)
 

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -24,7 +24,7 @@ SUPPORTS_MIXED = {'coldcard', 'trezor_1', 'digitalbitbox', 'keepkey', 'trezor_t'
 SUPPORTS_MULTISIG = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t', 'jade'}
 SUPPORTS_EXTERNAL = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t', 'jade'}
 SUPPORTS_OP_RETURN = {'ledger', 'digitalbitbox', 'trezor_1', 'trezor_t', 'keepkey', 'jade'}
-SUPPORTS_TAPROOT = {}
+SUPPORTS_TAPROOT = {"trezor_1", "trezor_t"}
 
 # Class for emulator control
 class DeviceEmulator():

--- a/test/test_digitalbitbox.py
+++ b/test/test_digitalbitbox.py
@@ -148,6 +148,12 @@ def digitalbitbox_test_suite(simulator, rpc, userpass, interface):
             self.assertEqual(result['chaincode'], '7062818c752f878bf96ca668f77630452c3fa033b7415eed3ff568e04ada8104')
             self.assertEqual(result['pubkey'], '029078c9ad8421afd958d7bc054a0952874923e2586fc9375604f0479a354ea193')
 
+    signtx_cases = [
+        (["legacy"], True, True, True),
+        (["segwit"], True, True, True),
+        (["legacy", "segwit"], True, True, True),
+    ]
+
     # Generic Device tests
     suite = unittest.TestSuite()
     suite.addTest(DeviceTestCase.parameterize(TestDBBManCommands, rpc, userpass, type, full_type, path, fingerprint, master_xpub, '0000', interface=interface))
@@ -156,7 +162,7 @@ def digitalbitbox_test_suite(simulator, rpc, userpass, interface):
     suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'digitalbitbox_01_simulator', full_type, path, fingerprint, master_xpub, '0000', interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestGetDescriptors, rpc, userpass, type, full_type, path, fingerprint, master_xpub, '0000', interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, type, full_type, path, fingerprint, master_xpub, '0000', interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, type, full_type, path, fingerprint, master_xpub, '0000', interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, type, full_type, path, fingerprint, master_xpub, '0000', interface=interface, signtx_cases=signtx_cases))
 
     result = unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)
     cleanup_simulator()

--- a/test/test_jade.py
+++ b/test/test_jade.py
@@ -179,6 +179,12 @@ def jade_test_suite(emulator, rpc, userpass, interface):
     dev_emulator.start()
     atexit.register(dev_emulator.stop)
 
+    signtx_cases = [
+        (["legacy"], True, True, True),
+        (["segwit"], True, True, True),
+        (["legacy", "segwit"], True, True, True),
+    ]
+
     # Generic Device tests
     suite = unittest.TestSuite()
     suite.addTest(DeviceTestCase.parameterize(TestJadeDisabledCommands, rpc, userpass, device_model, full_type, path, fingerprint, master_xpub, interface=interface))
@@ -189,7 +195,7 @@ def jade_test_suite(emulator, rpc, userpass, interface):
     suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, device_model, full_type, path, fingerprint, master_xpub, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestJadeGetMultisigAddresses, rpc, userpass, device_model, full_type, path, fingerprint, master_xpub, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestSignMessage, rpc, userpass, device_model, full_type, path, fingerprint, master_xpub, interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, device_model, full_type, path, fingerprint, master_xpub, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, device_model, full_type, path, fingerprint, master_xpub, interface=interface, signtx_cases=signtx_cases))
 
     result = unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)
     dev_emulator.stop()

--- a/test/test_keepkey.py
+++ b/test/test_keepkey.py
@@ -373,13 +373,19 @@ def keepkey_test_suite(emulator, rpc, userpass, interface):
     master_xpub = 'xpub6D1weXBcFAo8CqBbpP4TbH5sxQH8ZkqC5pDEvJ95rNNBZC9zrKmZP2fXMuve7ZRBe18pWQQsGg68jkq24mZchHwYENd8cCiSb71u3KD4AFH'
     dev_emulator = KeepkeyEmulator(emulator)
 
+    signtx_cases = [
+        (["legacy"], True, True, True),
+        (["segwit"], True, True, True),
+        (["legacy", "segwit"], True, True, True),
+    ]
+
     # Generic Device tests
     suite = unittest.TestSuite()
     suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, 'keepkey_simulator', full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestGetDescriptors, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface, signtx_cases=signtx_cases))
     suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestSignMessage, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(KeepkeyTestCase.parameterize(TestKeepkeyGetxpub, emulator=dev_emulator, interface=interface))

--- a/test/test_ledger.py
+++ b/test/test_ledger.py
@@ -124,6 +124,11 @@ def ledger_test_suite(emulator, rpc, userpass, interface):
     dev_emulator.start()
     atexit.register(dev_emulator.stop)
 
+    signtx_cases = [
+        (["legacy"], True, True, True),
+        (["segwit"], True, True, True),
+    ]
+
     # Generic Device tests
     suite = unittest.TestSuite()
     suite.addTest(DeviceTestCase.parameterize(TestLedgerDisabledCommands, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
@@ -133,7 +138,7 @@ def ledger_test_suite(emulator, rpc, userpass, interface):
     suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestSignMessage, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, device_model, 'ledger', path, fingerprint, master_xpub, interface=interface, signtx_cases=signtx_cases))
 
     result = unittest.TextTestRunner(stream=sys.stdout, verbosity=2).run(suite)
     dev_emulator.stop()

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -396,12 +396,20 @@ def trezor_test_suite(emulator, rpc, userpass, interface, model):
     dev_emulator = TrezorEmulator(emulator, model)
     full_type = 'trezor_{}'.format(model)
 
+    signtx_cases = [
+        (["legacy"], True, True, True),
+        (["segwit"], True, True, True),
+        (["tap"], False, False, True),
+        (["legacy", "segwit"], True, True, True),
+        (["legacy", "segwit", "tap"], True, False, True),
+    ]
+
     # Generic Device tests
     suite = unittest.TestSuite()
     suite.addTest(DeviceTestCase.parameterize(TestDeviceConnect, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestGetDescriptors, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestGetKeypool, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
-    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
+    suite.addTest(DeviceTestCase.parameterize(TestSignTx, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface, signtx_cases=signtx_cases))
     suite.addTest(DeviceTestCase.parameterize(TestDisplayAddress, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     suite.addTest(DeviceTestCase.parameterize(TestSignMessage, rpc, userpass, type, full_type, path, fingerprint, master_xpub, emulator=dev_emulator, interface=interface))
     if model != 't':


### PR DESCRIPTION
Implements Taproot support for Trezor devices.

Depends on #545, #546, #547, and #548

No tests yet as they would need https://github.com/bitcoin/bitcoin/pull/22558 merged into Bitcoin Core.