### PR TITLE
Add AddressType.TAP and be able to fetch Taproot descriptors from getdescriptors and getkeypool

### DIFF
--- a/hwilib/_base58.py
+++ b/hwilib/_base58.py
@@ -131,6 +131,19 @@ def xpub_to_pub_hex(xpub: str) -> str:
     pubkey = data[-37:-4]
     return hexlify(pubkey).decode()
 
+
+def xpub_to_xonly_pub_hex(xpub: str) -> str:
+    """
+    Get the public key as a string from the extended public key.
+
+    :param xpub: The extended pubkey
+    :return: The pubkey hex string
+    """
+    data = decode(xpub)
+    pubkey = data[-36:-4]
+    return hexlify(pubkey).decode()
+
+
 def xpub_main_2_test(xpub: str) -> str:
     """
     Convert an extended pubkey from mainnet version to testnet version.

--- a/hwilib/_bech32.py
+++ b/hwilib/_bech32.py
@@ -25,6 +25,7 @@ Bech32 Conversion Utilities
 Reference implementation for Bech32 and segwit addresses.
 """
 
+from enum import Enum
 from typing import (
     List,
     Optional,
@@ -34,6 +35,13 @@ from typing import (
 
 
 CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+BECH32_CONST = 1
+BECH32M_CONST = 0x2bc830a3
+
+class Encoding(Enum):
+    """Enumeration type to list the various supported encodings."""
+    BECH32 = 1
+    BECH32M = 2
 
 
 def bech32_polymod(values: List[int]) -> int:
@@ -53,40 +61,48 @@ def bech32_hrp_expand(hrp: str) -> List[int]:
     return [ord(x) >> 5 for x in hrp] + [0] + [ord(x) & 31 for x in hrp]
 
 
-def bech32_verify_checksum(hrp: str, data: List[int]) -> bool:
+def bech32_verify_checksum(hrp: str, data: List[int]) -> Optional[Encoding]:
     """Verify a checksum given HRP and converted data characters."""
-    return bech32_polymod(bech32_hrp_expand(hrp) + data) == 1
+    check = bech32_polymod(bech32_hrp_expand(hrp) + data)
+    if check == BECH32_CONST:
+        return Encoding.BECH32
+    elif check == BECH32M_CONST:
+        return Encoding.BECH32M
+    else:
+        return None
 
 
-def bech32_create_checksum(hrp: str, data: List[int]) -> List[int]:
+def bech32_create_checksum(encoding: Encoding, hrp: str, data: List[int]) -> List[int]:
     """Compute the checksum values given HRP and data."""
     values = bech32_hrp_expand(hrp) + data
-    polymod = bech32_polymod(values + [0, 0, 0, 0, 0, 0]) ^ 1
+    const = BECH32M_CONST if encoding == Encoding.BECH32M else BECH32_CONST
+    polymod = bech32_polymod(values + [0, 0, 0, 0, 0, 0]) ^ const
     return [(polymod >> 5 * (5 - i)) & 31 for i in range(6)]
 
 
-def bech32_encode(hrp: str, data: List[int]) -> str:
+def bech32_encode(encoding: Encoding, hrp: str, data: List[int]) -> str:
     """Compute a Bech32 string given HRP and data values."""
-    combined = data + bech32_create_checksum(hrp, data)
+    combined = data + bech32_create_checksum(encoding, hrp, data)
     return hrp + '1' + ''.join([CHARSET[d] for d in combined])
 
 
-def bech32_decode(bech: str) -> Tuple[Optional[str], Optional[List[int]]]:
+def bech32_decode(bech: str) -> Tuple[Optional[Encoding], Optional[str], Optional[List[int]]]:
     """Validate a Bech32 string, and determine HRP and data."""
     if ((any(ord(x) < 33 or ord(x) > 126 for x in bech)) or
             (bech.lower() != bech and bech.upper() != bech)):
-        return (None, None)
+        return (None, None, None)
     bech = bech.lower()
     pos = bech.rfind('1')
     if pos < 1 or pos + 7 > len(bech) or len(bech) > 90:
-        return (None, None)
+        return (None, None, None)
     if not all(x in CHARSET for x in bech[pos + 1:]):
-        return (None, None)
+        return (None, None, None)
     hrp = bech[:pos]
     data = [CHARSET.find(x) for x in bech[pos + 1:]]
-    if not bech32_verify_checksum(hrp, data):
-        return (None, None)
-    return (hrp, data[:-6])
+    encoding = bech32_verify_checksum(hrp, data)
+    if encoding is None:
+        return (None, None, None)
+    return (encoding, hrp, data[:-6])
 
 
 def convertbits(data: Union[bytes, List[int]], frombits: int, tobits: int, pad: bool = True) -> Optional[List[int]]:
@@ -114,7 +130,7 @@ def convertbits(data: Union[bytes, List[int]], frombits: int, tobits: int, pad: 
 
 def decode(hrp: str, addr: str) -> Tuple[Optional[int], Optional[List[int]]]:
     """Decode a segwit address."""
-    hrpgot, data = bech32_decode(addr)
+    encoding, hrpgot, data = bech32_decode(addr)
     if hrpgot != hrp or hrpgot is None or data is None:
         return (None, None)
     decoded = convertbits(data[1:], 5, 8, False)
@@ -124,15 +140,18 @@ def decode(hrp: str, addr: str) -> Tuple[Optional[int], Optional[List[int]]]:
         return (None, None)
     if data[0] == 0 and len(decoded) != 20 and len(decoded) != 32:
         return (None, None)
+    if (data[0] == 0 and encoding != Encoding.BECH32) or (data[0] != 0 and encoding != Encoding.BECH32M):
+        return (None, None)
     return (data[0], decoded)
 
 
 def encode(hrp: str, witver: int, witprog: bytes) -> Optional[str]:
     """Encode a segwit address."""
+    encoding = Encoding.BECH32 if witver == 0 else Encoding.BECH32M
     conv_bits = convertbits(witprog, 8, 5)
     if conv_bits is None:
         return None
-    ret = bech32_encode(hrp, [witver] + conv_bits)
+    ret = bech32_encode(encoding, hrp, [witver] + conv_bits)
     if decode(hrp, ret) == (None, None):
         return None
     return ret

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -464,7 +464,7 @@ def displayaddress(
                     addr_type = AddressType.WIT
                 return {"address": client.display_multisig_address(addr_type, descriptor)}
         is_wpkh = isinstance(descriptor, WPKHDescriptor)
-        if isinstance(descriptor, PKHDescriptor) or is_wpkh:
+        if isinstance(descriptor, PKHDescriptor) or is_wpkh or isinstance(descriptor, TRDescriptor):
             pubkey = descriptor.pubkeys[0]
             if pubkey.origin is None:
                 raise BadArgumentError(f"Descriptor missing origin info: {desc}")
@@ -477,6 +477,8 @@ def displayaddress(
                 addr_type = AddressType.SH_WIT
             elif not is_sh and is_wpkh:
                 addr_type = AddressType.WIT
+            elif isinstance(descriptor, TRDescriptor):
+                addr_type = AddressType.TAP
             return {"address": client.display_singlesig_address(pubkey.get_full_derivation_path(0), addr_type)}
     raise BadArgumentError("Missing both path and descriptor")
 

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -409,7 +409,7 @@ def getdescriptors(
 
     for internal in [False, True]:
         descriptors = []
-        for addr_type in (AddressType.LEGACY, AddressType.SH_WIT, AddressType.WIT):
+        for addr_type in list(AddressType):
             try:
                 desc = getdescriptor(client, master_fpr=master_fpr, internal=internal, addr_type=addr_type, account=account)
             except UnavailableActionError:

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -22,7 +22,7 @@ import importlib
 import logging
 import platform
 
-from ._base58 import xpub_to_pub_hex
+from ._base58 import xpub_to_pub_hex, xpub_to_xonly_pub_hex
 from .key import (
     get_bip44_purpose,
     get_bip44_chain,
@@ -471,7 +471,7 @@ def displayaddress(
             if pubkey.origin.fingerprint != client.get_master_fingerprint():
                 raise BadArgumentError(f"Descriptor fingerprint does not match device: {desc}")
             xpub = client.get_pubkey_at_path(pubkey.origin.get_derivation_path()).to_string()
-            if pubkey.pubkey != xpub and pubkey.pubkey != xpub_to_pub_hex(xpub):
+            if pubkey.pubkey != xpub and pubkey.pubkey != xpub_to_pub_hex(xpub) and pubkey.pubkey != xpub_to_xonly_pub_hex(xpub):
                 raise BadArgumentError(f"Key in descriptor does not match device: {desc}")
             if is_sh and is_wpkh:
                 addr_type = AddressType.SH_WIT

--- a/hwilib/common.py
+++ b/hwilib/common.py
@@ -40,6 +40,7 @@ class AddressType(Enum):
     LEGACY = 1 #: Legacy address type. P2PKH for single sig, P2SH for scripts.
     WIT = 2 #: Native segwit v0 address type. P2WPKH for single sig, P2WPSH for scripts.
     SH_WIT = 3 #: Nested segwit v0 address type. P2SH-P2WPKH for single sig, P2SH-P2WPSH for scripts.
+    TAP = 4 #: Segwit v1 Taproot address type. P2TR always.
 
     def __str__(self) -> str:
         return self.name.lower()

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -466,6 +466,8 @@ class Bitbox02Client(HardwareWalletClient):
             raise UnavailableActionError(
                 "The BitBox02 does not support legacy p2pkh addresses"
             )
+        elif addr_type == AddressType.TAP:
+            raise UnavailableActionError("BitBox02 does not support displaying Taproot addresses yet")
         else:
             raise BadArgumentError("Unknown address type")
         address = self.init().btc_address(

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -866,3 +866,11 @@ class Bitbox02Client(HardwareWalletClient):
 
         bb02.restore_from_mnemonic()
         return True
+
+    def can_sign_taproot(self) -> bool:
+        """
+        The BitBox02 does not support Taproot yet.
+
+        :returns: False, always
+        """
+        return False

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -241,6 +241,8 @@ class ColdcardClient(HardwareWalletClient):
             addr_fmt = AF_P2WPKH
         elif addr_type == AddressType.LEGACY:
             addr_fmt = AF_CLASSIC
+        elif addr_type == AddressType.TAP:
+            raise UnavailableActionError("Coldcard does not support displaying Taproot addresses yet")
         else:
             raise BadArgumentError("Unknown address type")
 

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -386,6 +386,15 @@ class ColdcardClient(HardwareWalletClient):
         """
         raise UnavailableActionError('The Coldcard does not support toggling passphrase from the host')
 
+    def can_sign_taproot(self) -> bool:
+        """
+        The Coldard does not support Taproot yet.
+
+        :returns: False, always
+        """
+        return False
+
+
 def enumerate(password: str = "") -> List[Dict[str, Any]]:
     results = []
     devices = hid.enumerate(COINKITE_VID, CKCC_PID)

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -669,6 +669,15 @@ class DigitalbitboxClient(HardwareWalletClient):
         """
         raise UnavailableActionError('The Digital Bitbox does not support toggling passphrase from the host')
 
+    def can_sign_taproot(self) -> bool:
+        """
+        The BitBox01 does not support Taproot as it is no longer supported by the manufacturer
+
+        :returns: False, always
+        """
+        return False
+
+
 def enumerate(password: str = "") -> List[Dict[str, Any]]:
     results = []
     devices = hid.enumerate(DBB_VENDOR_ID, DBB_DEVICE_ID)

--- a/hwilib/devices/jade.py
+++ b/hwilib/devices/jade.py
@@ -485,6 +485,16 @@ class JadeClient(HardwareWalletClient):
         """
         raise UnavailableActionError('Blockstream Jade does not support toggling passphrase from the host')
 
+    @jade_exception
+    def can_sign_taproot(self) -> bool:
+        """
+        Blockstream Jade does not currently support Taproot.
+
+        :returns: False, always
+        """
+        return False
+
+
 def enumerate(password: str = '') -> List[Dict[str, Any]]:
     results = []
 

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -155,6 +155,14 @@ class KeepkeyClient(TrezorClient):
         if self.simulator:
             self.client.debug.map_type_to_class_override[KeepkeyDebugLinkState.MESSAGE_WIRE_TYPE] = KeepkeyDebugLinkState
 
+    def can_sign_taproot(self) -> bool:
+        """
+        The KeepKey does not support Taproot yet.
+
+        :returns: False, always
+        """
+        return False
+
 
 def enumerate(password: str = "") -> List[Dict[str, Any]]:
     results = []

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -360,6 +360,8 @@ class LedgerClient(HardwareWalletClient):
             bech32 = True
         elif addr_type == AddressType.LEGACY:
             pass
+        elif addr_type == AddressType.TAP:
+            raise UnavailableActionError("Ledger does not support displaying Taproot addresses yet")
         else:
             raise BadArgumentError("Unknown address type")
         output = self.app.getWalletPublicKey(keypath[2:], True, p2sh_p2wpkh or bech32, bech32)

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -433,6 +433,17 @@ class LedgerClient(HardwareWalletClient):
         """
         raise UnavailableActionError('The Ledger Nano S and X do not support toggling passphrase from the host')
 
+    @ledger_exception
+    def can_sign_taproot(self) -> bool:
+        """
+        Ledgers support Taproot if the Bitcoin App version greater than 2.0.0.
+        However HWI does not implement Taproot support for the Ledger yet.
+
+        :returns: False, always
+        """
+        return False
+
+
 def enumerate(password: str = '') -> List[Dict[str, Any]]:
     results = []
     devices = []

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -352,8 +352,16 @@ class LedgerClient(HardwareWalletClient):
     ) -> str:
         if not check_keypath(keypath):
             raise BadArgumentError("Invalid keypath")
-        p2sh_p2wpkh = addr_type == AddressType.SH_WIT
-        bech32 = addr_type == AddressType.WIT
+        bech32 = False
+        p2sh_p2wpkh = False
+        if addr_type == AddressType.SH_WIT:
+            p2sh_p2wpkh = True
+        elif addr_type == AddressType.WIT:
+            bech32 = True
+        elif addr_type == AddressType.LEGACY:
+            pass
+        else:
+            raise BadArgumentError("Unknown address type")
         output = self.app.getWalletPublicKey(keypath[2:], True, p2sh_p2wpkh or bech32, bech32)
         assert isinstance(output["address"], str)
         return output['address'][12:-2] # HACK: A bug in getWalletPublicKey results in the address being returned as the string "bytearray(b'<address>')". This extracts the actual address to work around this.

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -754,6 +754,18 @@ class TrezorClient(HardwareWalletClient):
                 print(PIN_MATRIX_DESCRIPTION, file=sys.stderr)
         return True
 
+    @trezor_exception
+    def can_sign_taproot(self) -> bool:
+        """
+        Trezor T supports Taproot in firmware versions greater than (not including) 2.4.2.
+        Trezor One supports Taproot in firmware versions greater than (not including) 1.10.3.
+        However HWI does not implement Taproot support for any Trezor devices yet.
+
+        :returns: False, always.
+        """
+        return False
+
+
 def enumerate(password: str = "") -> List[Dict[str, Any]]:
     results = []
     devs = hid.HidTransport.enumerate()

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -593,6 +593,8 @@ class TrezorClient(HardwareWalletClient):
             script_type = messages.InputScriptType.SPENDWITNESS
         elif addr_type == AddressType.LEGACY:
             script_type = messages.InputScriptType.SPENDADDRESS
+        elif addr_type == AddressType.TAP:
+            raise UnavailableActionError("Trezor does not support displaying Taproot addresses yet")
         else:
             raise BadArgumentError("Unknown address type")
 

--- a/hwilib/hwwclient.py
+++ b/hwilib/hwwclient.py
@@ -228,3 +228,12 @@ class HardwareWalletClient(object):
         """
         raise NotImplementedError("The HardwareWalletClient base class "
                                   "does not implement this method")
+
+    def can_sign_taproot(self) -> bool:
+        """
+        Whether the device has a version that can sign for Taproot inputs
+
+        :return: Whether Taproot is supported
+        """
+        raise NotImplementedError("The HardwareWalletClient base class "
+                                  "does not implement this method")

--- a/hwilib/key.py
+++ b/hwilib/key.py
@@ -366,6 +366,8 @@ def get_bip44_purpose(addrtype: AddressType) -> int:
         return 49
     elif addrtype == AddressType.WIT:
         return 84
+    elif addrtype == AddressType.TAP:
+        return 86
     else:
         raise ValueError("Unknown address type")
 

--- a/test/test_bech32.py
+++ b/test/test_bech32.py
@@ -31,49 +31,107 @@ def segwit_scriptpubkey(witver, witprog):
     """Construct a Segwit scriptPubKey for a given witness program."""
     return bytes([witver + 0x50 if witver else 0, len(witprog)] + witprog)
 
-VALID_CHECKSUM = [
+VALID_BECH32 = [
     "A12UEL5L",
+    "a12uel5l",
     "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
     "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
     "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
     "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
+    "?1ezyfcl",
 ]
 
-INVALID_CHECKSUM = [
-    " 1nwldj5",
-    "\x7F" + "1axkwrx",
+VALID_BECH32M = [
+    "A1LQFN3A",
+    "a1lqfn3a",
+    "an83characterlonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11sg7hg6",
+    "abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx",
+    "11llllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllludsr8",
+    "split1checkupstagehandshakeupstreamerranterredcaperredlc445v",
+    "?1v759aa",
+]
+
+INVALID_BECH32 = [
+    " 1nwldj5",          # HRP character out of range
+    "\x7F" + "1axkwrx",  # HRP character out of range
+    "\x80" + "1eym55h",  # HRP character out of range
+    # overall max length exceeded
     "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
-    "pzry9x0s0muk",
-    "1pzry9x0s0muk",
-    "x1b4n0q5v",
-    "li1dgmt3",
-    "de1lg7wt\xff",
+    "pzry9x0s0muk",      # No separator character
+    "1pzry9x0s0muk",     # Empty HRP
+    "x1b4n0q5v",         # Invalid data character
+    "li1dgmt3",          # Too short checksum
+    "de1lg7wt" + "\xFF", # Invalid character in checksum
+    "A1G7SGD8",          # checksum calculated with uppercase form of HRP
+    "10a06t8",           # empty HRP
+    "1qzzfhee",          # empty HRP
+]
+
+INVALID_BECH32M = [
+    " 1xj0phk",          # HRP character out of range
+    "\x7F" + "1g6xzxy",  # HRP character out of range
+    "\x80" + "1vctc34",  # HRP character out of range
+    # overall max length exceeded
+    "an84characterslonghumanreadablepartthatcontainsthetheexcludedcharactersbioandnumber11d6pts4",
+    "qyrz8wqd2c9m",      # No separator character
+    "1qyrz8wqd2c9m",     # Empty HRP
+    "y1b0jsk6g",         # Invalid data character
+    "lt1igcx5c0",        # Invalid data character
+    "in1muywd",          # Too short checksum
+    "mm1crxm3i",         # Invalid character in checksum
+    "au1s5cgom",         # Invalid character in checksum
+    "M1VUXWEZ",          # Checksum calculated with uppercase form of HRP
+    "16plkw9",           # Empty HRP
+    "1p2gdwpf",          # Empty HRP
 ]
 
 VALID_ADDRESS = [
     ["BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4", "0014751e76e8199196d454941c45d1b3a323f1433bd6"],
     ["tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
      "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262"],
-    ["bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
+    ["bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kt5nd6y",
      "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6"],
-    ["BC1SW50QA3JX3S", "6002751e"],
-    ["bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj", "5210751e76e8199196d454941c45d1b3a323"],
+    ["BC1SW50QGDZ25J", "6002751e"],
+    ["bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs", "5210751e76e8199196d454941c45d1b3a323"],
     ["tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
      "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"],
+    ["tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c",
+     "5120000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"],
+    ["bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0",
+     "512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"],
 ]
 
 INVALID_ADDRESS = [
-    "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty",
-    "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5",
-    "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2",
-    "bc1rw5uspcuh",
-    "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90",
+    # Invalid HRP
+    "tc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq5zuyut",
+    # Invalid checksum algorithm (bech32 instead of bech32m)
+    "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqh2y7hd",
+    # Invalid checksum algorithm (bech32 instead of bech32m)
+    "tb1z0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqglt7rf",
+    # Invalid checksum algorithm (bech32 instead of bech32m)
+    "BC1S0XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ54WELL",
+    # Invalid checksum algorithm (bech32m instead of bech32)
+    "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kemeawh",
+    # Invalid checksum algorithm (bech32m instead of bech32)
+    "tb1q0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq24jc47",
+    # Invalid character in checksum
+    "bc1p38j9r5y49hruaue7wxjce0updqjuyyx0kh56v8s25huc6995vvpql3jow4",
+    # Invalid witness version
+    "BC130XLXVLHEMJA6C4DQV22UAPCTQUPFHLXM9H8Z3K2E72Q4K9HCZ7VQ7ZWS8R",
+    # Invalid program length (1 byte)
+    "bc1pw5dgrnzv",
+    # Invalid program length (41 bytes)
+    "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v8n0nx0muaewav253zgeav",
+    # Invalid program length for witness version 0 (per BIP141)
     "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P",
-    "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7",
-    "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du",
-    "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv",
+    # Mixed case
+    "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47Zagq",
+    # More than 4 padding bits
+    "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7v07qwwzcrf",
+    # Non-zero padding in 8-to-5 conversion
+    "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vpggkg4j",
+    # Empty data section
     "bc1gmk9yu",
-
 ]
 
 INVALID_ADDRESS_ENC = [
@@ -89,19 +147,23 @@ class TestSegwitAddress(unittest.TestCase):
 
     def test_valid_checksum(self):
         """Test checksum creation and validation."""
-        for test in VALID_CHECKSUM:
-            hrp, _ = segwit_addr.bech32_decode(test)
-            self.assertIsNotNone(hrp)
-            pos = test.rfind('1')
-            test = test[:pos + 1] + chr(ord(test[pos + 1]) ^ 1) + test[pos + 2:]
-            hrp, _ = segwit_addr.bech32_decode(test)
-            self.assertIsNone(hrp)
+        for encoding in segwit_addr.Encoding:
+            tests = VALID_BECH32 if encoding == segwit_addr.Encoding.BECH32 else VALID_BECH32M
+            for test in tests:
+                dencoding, hrp, _ = segwit_addr.bech32_decode(test)
+                self.assertTrue(hrp is not None and dencoding == encoding)
+                pos = test.rfind('1')
+                test = test[:pos + 1] + chr(ord(test[pos + 1]) ^ 1) + test[pos + 2:]
+                decoding, hrp, _ = segwit_addr.bech32_decode(test)
+                self.assertIsNone(hrp)
 
     def test_invalid_checksum(self):
         """Test validation of invalid checksums."""
-        for test in INVALID_CHECKSUM:
-            hrp, _ = segwit_addr.bech32_decode(test)
-            self.assertIsNone(hrp)
+        for encoding in segwit_addr.Encoding:
+            tests = INVALID_BECH32 if encoding == segwit_addr.Encoding.BECH32 else INVALID_BECH32M
+            for test in tests:
+                dencoding, hrp, _ = segwit_addr.bech32_decode(test)
+                self.assertTrue(hrp is None or dencoding != encoding)
 
     def test_valid_address(self):
         """Test whether valid addresses decode to the correct output."""
@@ -111,7 +173,7 @@ class TestSegwitAddress(unittest.TestCase):
             if witver is None:
                 hrp = "tb"
                 witver, witprog = segwit_addr.decode(hrp, address)
-            self.assertIsNotNone(witver)
+            self.assertIsNotNone(witver, address)
             scriptpubkey = segwit_scriptpubkey(witver, witprog)
             self.assertEqual(scriptpubkey, binascii.unhexlify(hexscript))
             addr = segwit_addr.encode(hrp, witver, witprog)

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -24,6 +24,7 @@ SUPPORTS_MIXED = {'coldcard', 'trezor_1', 'digitalbitbox', 'keepkey', 'trezor_t'
 SUPPORTS_MULTISIG = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t', 'jade'}
 SUPPORTS_EXTERNAL = {'ledger', 'trezor_1', 'digitalbitbox', 'keepkey', 'coldcard', 'trezor_t', 'jade'}
 SUPPORTS_OP_RETURN = {'ledger', 'digitalbitbox', 'trezor_1', 'trezor_t', 'keepkey', 'jade'}
+SUPPORTS_TAPROOT = {}
 
 # Class for emulator control
 class DeviceEmulator():
@@ -194,8 +195,9 @@ class TestGetKeypool(DeviceTestCase):
             ("legacy", 44, "legacy"),
             ("wit", 84, "bech32"),
             ("sh_wit", 49, "p2sh-segwit"),
-            ("tap", 86, "bech32m"),
         ]
+        if self.full_type in SUPPORTS_TAPROOT:
+            getkeypool_args.append(("tap", 86, "bech32m"))
 
         descs = []
         for arg in getkeypool_args:
@@ -254,8 +256,8 @@ class TestGetDescriptors(DeviceTestCase):
 
         self.assertIn('receive', descriptors)
         self.assertIn('internal', descriptors)
-        self.assertEqual(len(descriptors['receive']), 4)
-        self.assertEqual(len(descriptors['internal']), 4)
+        self.assertEqual(len(descriptors['receive']), 4 if self.full_type in SUPPORTS_TAPROOT else 3)
+        self.assertEqual(len(descriptors['internal']), 4 if self.full_type in SUPPORTS_TAPROOT else 3)
 
         for descriptor in descriptors['receive']:
             self.assertNotIn("'", descriptor)


### PR DESCRIPTION
Adds a `AddressType.TAP` which can be used as `tap` in `displayaddress` and anywhere else `--addr-type` is used. Implements the bech32m encoding scheme. Also adds `tr()` descriptors to `getdescriptors` and `getkeypool` output.

Depends on #545