### PR TITLE
ci: run install_script before installing simulators

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -286,6 +286,7 @@ task:
         dockerfile: ci/py310.Dockerfile
       env:
         PYTHON: 3.10
+  install_script: poetry install
   matrix:
     << : *DEVICE_MATRIX_TEMPLATE
   matrix:
@@ -296,7 +297,6 @@ task:
     - env:
         INTERFACE: stdin
   name: Python $PYTHON $DEVICE $INTERFACE
-  install_script: poetry install
   test_script: cd test; poetry run ./run_tests.py $DEVICE --interface=$INTERFACE --device-only; cd ..
   on_failure:
     failed_script: tail -v -n +1 test/*.std*


### PR DESCRIPTION
This fixes the CI failures of Python 3.8 Ledger jobs. Apparently in 3.8, `poetry install` removes some of the dependencies we installed for speculos during the `sim_install` part of the job. By doing `poetry install` first, and then installing the simulator dependencies afterwards, we can avoid this problem.