### PR TITLE
ci: do git clean before setting up keepkey

### DIFF
--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -218,6 +218,7 @@ if [[ -n ${build_keepkey} ]]; then
 
     # Build the simulator. This is cached, but it is also fast
     if [ "$keepkey_setup_needed" == true ] ; then
+        git clean -ffdx
         git clone https://github.com/nanopb/nanopb.git -b nanopb-0.3.9.4
     fi
     cd nanopb/generator/proto


### PR DESCRIPTION
Need to make sure that nanopb does not exist before cloning. `git clean` takes care of this, as well as removing anything else that could potentially be problematic.