### PR TITLE
setup: fix install, remove messages module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from setuptools import setup
 packages = \
 ['hwilib',
  'hwilib.devices',
- 'hwilib.devices.btchip',
  'hwilib.devices.ckcc',
  'hwilib.devices.trezorlib',
  'hwilib.devices.trezorlib.transport']

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ packages = \
  'hwilib.devices.btchip',
  'hwilib.devices.ckcc',
  'hwilib.devices.trezorlib',
- 'hwilib.devices.trezorlib.messages',
  'hwilib.devices.trezorlib.transport']
 
 package_data = \


### PR DESCRIPTION
I'm tripping up on this when trying to package the latest master for nixpkgs. There is no messages module so it fails when trying to copy this as a directory during installation. not sure if this installation logic is just a nixpkgs python thing, but I think this change makes logical sense regardless.

error:
```
building '/nix/store/d6qgmvwv78gbxasj9xfd0lwr39qwakpr-python3.9-hwi-2.0.2.drv'...
error: builder for '/nix/store/d6qgmvwv78gbxasj9xfd0lwr39qwakpr-python3.9-hwi-2.0.2.drv' failed with exit code 1;
       last 10 log lines:
       > copying hwilib/devices/trezorlib/client.py -> build/lib/hwilib/devices/trezorlib
       > copying hwilib/devices/trezorlib/log.py -> build/lib/hwilib/devices/trezorlib
       > copying hwilib/devices/trezorlib/firmware.py -> build/lib/hwilib/devices/trezorlib
       > copying hwilib/devices/trezorlib/__init__.py -> build/lib/hwilib/devices/trezorlib
       > copying hwilib/devices/trezorlib/models.py -> build/lib/hwilib/devices/trezorlib
       > copying hwilib/devices/trezorlib/btc.py -> build/lib/hwilib/devices/trezorlib
       > copying hwilib/devices/trezorlib/exceptions.py -> build/lib/hwilib/devices/trezorlib
       > copying hwilib/devices/trezorlib/device.py -> build/lib/hwilib/devices/trezorlib
       > copying hwilib/devices/trezorlib/tools.py -> build/lib/hwilib/devices/trezorlib
       > error: package directory 'hwilib/devices/trezorlib/messages' does not exist
 ```