### PR TITLE
tests, trezor: Assert scriptPubKey failure for Trezor in test_big_tx

### DIFF
--- a/test/test_device.py
+++ b/test/test_device.py
@@ -535,6 +535,10 @@ class TestSignTx(DeviceTestCase):
                 self.fail('Big tx did not cause CLI to error')
             if self.emulator.type == 'coldcard':
                 self.assertEqual(result['code'], -7)
+            elif self.emulator.type in ('trezor_1', 'trezor_t'):
+                # Trezor rejects to sign as inputs do not correspond to the wallet's private keys
+                self.assertEqual(result['code'], -13)
+                self.assertIn('Input does not match scriptPubKey', result['error'])
             else:
                 self.assertNotIn('code', result)
                 self.assertNotIn('error', result)


### PR DESCRIPTION
Soon there will be a security tightening in `Trezor` making sure that device will refuse to sign a transaction trying to spend inputs that do not belong to the wallet (the `scriptPubKey` of the input does not correspond to private keys in the wallet).

Connected PR, that will (most probably) merge these changes into `master` - https://github.com/trezor/trezor-firmware/pull/2081.

Making appropriate changes in `test_big_tx` testcase, that is generating inputs that are not spendable by Trezor's private keys. (Seems that could be the same case as with `coldcard`?) 

To still test Trezor's capability of signing big transaction, we might create inputs corresponding to [slip-14](https://github.com/satoshilabs/slips/blob/master/slip-0014.md) standard, which the wallet (inputted with `all all all...` seed) will be able to sign. That is up to discussion (we could supply the test vectors from our tests).