### PR TITLE
ci: Use Ledger app build rather than speculos package app

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -69,6 +69,7 @@ device_matrix_template: &DEVICE_MATRIX_TEMPLATE
       DEVICE: --ledger
     depends_on:
       - Ledger Sim Builder
+      - Ledger App Builder
       - dist_builder
       - bitcoind_builder
     fetch_sim_script:
@@ -76,6 +77,9 @@ device_matrix_template: &DEVICE_MATRIX_TEMPLATE
       - tar -xvf "speculos.tar.gz"
       - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/bitcoind_builder/bitcoin/bitcoin.tar.gz"
       - tar -xvf "bitcoin.tar.gz"
+    fetch_ledger_app_script:
+      - wget -nv "https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/Ledger App Builder/built_ledger_app/app-bitcoin-new/bin/app.elf"
+      - mv app.elf test/work/speculos/apps/btc-test.elf
     sim_install_script:
       - poetry run pip install construct flask-restful jsonschema mnemonic pyelftools pillow requests
       - pip install construct flask-restful jsonschema mnemonic pyelftools pillow requests
@@ -257,6 +261,17 @@ dist_builder_task:
     - find dist -type f -exec sha256sum {} \;
   built_dist_artifacts:
     path: "dist/*"
+
+ledger_app_builder_task:
+  name: Ledger App Builder
+  container:
+    dockerfile: ci/ledger-app-builder.Dockerfile
+  build_script:
+    - git clone https://github.com/LedgerHQ/app-bitcoin-new.git
+    - cd app-bitcoin-new
+    - make DEBUG=1
+  built_ledger_app_artifacts:
+    path: app-bitcoin-new/bin/app.elf
 
 task:
   matrix:

--- a/ci/ledger-app-builder.Dockerfile
+++ b/ci/ledger-app-builder.Dockerfile
@@ -1,0 +1,80 @@
+# Copied from https://github.com/LedgerHQ/ledger-app-builder/blob/229b03cf20630e6bdc66d7f1ce33c70b2fd2b9e5/Dockerfile
+
+FROM ubuntu:20.04
+ENV LANG C.UTF-8
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ARG LLVM_VERSION=12
+
+RUN apt-get update && apt-get upgrade -qy && \
+    apt-get install -qy \
+        clang-$LLVM_VERSION \
+        clang-tools-$LLVM_VERSION \
+        clang-format-$LLVM_VERSION \
+        cmake \
+        curl \
+        doxygen \
+        git \
+        lcov \
+        libbsd-dev \
+        libcmocka0 \
+        libcmocka-dev \
+        lld-$LLVM_VERSION \
+        make \
+        protobuf-compiler \
+        python-is-python3 \
+        python3 \
+        python3-pip && \
+    apt-get autoclean -y && \
+    apt-get autoremove -y && \
+    apt-get clean
+
+# Create generic clang & lld symbolic links to their installed version
+RUN cd /usr/bin && \
+    find . -name "*-"$LLVM_VERSION | sed "s/^\(.*\)\(-"$LLVM_VERSION"\)$/ln -s \1\2 \1/" | sh
+
+# ARM Embedded Toolchain
+# Integrity is checked using the MD5 checksum provided by ARM at https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads
+RUN curl -sSfL -o arm-toolchain.tar.bz2 "https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2" && \
+    echo 2383e4eb4ea23f248d33adc70dc3227e arm-toolchain.tar.bz2 > /tmp/arm-toolchain.md5 && \
+    md5sum --check /tmp/arm-toolchain.md5 && rm /tmp/arm-toolchain.md5 && \
+    tar xf arm-toolchain.tar.bz2 -C /opt && \
+    rm arm-toolchain.tar.bz2
+
+# Adding GCC to PATH and defining rustup/cargo home directories
+ENV PATH=/opt/gcc-arm-none-eabi-10.3-2021.10/bin:$PATH \
+    RUSTUP_HOME=/opt/rustup \
+    CARGO_HOME=/opt/.cargo
+
+# Install rustup to manage rust toolchains
+RUN curl https://sh.rustup.rs -sSf | \
+    sh -s -- --default-toolchain stable -y
+
+# Adding cargo binaries to PATH
+ENV PATH=${CARGO_HOME}/bin:${PATH}
+
+# Adding ARMV6M target to the default toolchain
+RUN rustup target add thumbv6m-none-eabi
+
+# Python packages commonly used by apps
+RUN pip3 install ledgerblue pytest
+
+# Latest Nano S SDK
+ENV NANOS_SDK=/opt/nanos-secure-sdk
+RUN git clone --branch 2.1.0 --depth 1 https://github.com/LedgerHQ/nanos-secure-sdk.git "${NANOS_SDK}"
+
+# Latest Nano X SDK
+ENV NANOX_SDK=/opt/nanox-secure-sdk
+RUN git clone --branch 2.0.2-2 --depth 1 https://github.com/LedgerHQ/nanox-secure-sdk.git "${NANOX_SDK}"
+
+# Latest Nano S+ SDK
+ENV NANOSP_SDK=/opt/nanosplus-secure-sdk
+RUN git clone --branch 1.0.2 --depth 1 https://github.com/LedgerHQ/nanosplus-secure-sdk.git "${NANOSP_SDK}"
+
+# Default SDK
+ENV BOLOS_SDK=${NANOS_SDK}
+
+WORKDIR /app
+
+CMD ["/usr/bin/env", "bash"]


### PR DESCRIPTION
Most of our CI uses self builds of the latest emulated firmware for each device. However with Ledger we are using builds of the actual Ledger app which may be outdated as they come with speculos itself. In order to be aware of breaking changes that may be made by Ledger we should be using latest builds of the Ledger Bitcoin app itself rather than just Speculos and what it provides. So this PR adds a CI job to build the Ledger Bitcoin app from the current HEAD of the app repo and to use that app in Speculos when running the tests.