### PR TITLE
trezor: Set p2sh multisig output script type correctly

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -576,6 +576,7 @@ class TrezorClient(HardwareWalletClient):
                         tx.xpub, psbt_out)
                     if is_ms:
                         txoutput.multisig = multisig
+                        txoutput.script_type = messages.OutputScriptType.PAYTOMULTISIG
 
                 # append to outputs
                 outputs.append(txoutput)


### PR DESCRIPTION
P2SH outputs that are multisigs that belong to the wallet should be PAYTOMULTISIG

Fixes  #624