### PR TITLE
WIP - jade: use non-blocking socket for the jade simulator

### DIFF
--- a/hwilib/devices/jadepy/README.md
+++ b/hwilib/devices/jadepy/README.md
@@ -7,4 +7,4 @@ This stripped down version was made from tag [0.1.32](https://github.com/Blockst
 ## Changes
 
 - Removed BLE module, reducing transitive dependencies
-
+- Have tcp connection (for simulator) respect passed timeout - backported from master

--- a/hwilib/devices/jadepy/jade.py
+++ b/hwilib/devices/jadepy/jade.py
@@ -509,7 +509,7 @@ class JadeInterface:
     @staticmethod
     def create_serial(device=None, baud=None, timeout=None):
         if device and JadeTCPImpl.isSupportedDevice(device):
-            impl = JadeTCPImpl(device)
+            impl = JadeTCPImpl(device, timeout or DEFAULT_SERIAL_TIMEOUT)
         else:
             impl = JadeSerialImpl(device or DEFAULT_SERIAL_DEVICE,
                                   baud or DEFAULT_BAUD_RATE,

--- a/hwilib/devices/jadepy/jade_tcp.py
+++ b/hwilib/devices/jadepy/jade_tcp.py
@@ -25,9 +25,10 @@ class JadeTCPImpl:
     def isSupportedDevice(cls, device):
         return device is not None and device.startswith(cls.PROTOCOL_PREFIX)
 
-    def __init__(self, device):
+    def __init__(self, device, timeout):
         assert self.isSupportedDevice(device)
         self.device = device
+        self.timeout = timeout
         self.tcp_sock = None
 
     def connect(self):
@@ -36,6 +37,7 @@ class JadeTCPImpl:
 
         logger.info('Connecting to {}'.format(self.device))
         self.tcp_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.tcp_sock.settimeout(self.timeout)
 
         url = self.device[len(self.PROTOCOL_PREFIX):].split(':')
         self.tcp_sock.connect((url[0], int(url[1])))


### PR DESCRIPTION
When enumerating and looking for the Jade simulator, set the socket to non-blocking mode, as some platforms (Windows?) will wait forever for a response if the simulator is not running.

For #630 