### PR TITLE
Improve support for the coming Ledger app 2.1.0

### DIFF
--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -194,7 +194,7 @@ class LedgerClient(HardwareWalletClient):
 
         For application versions 2.1.x and above:
 
-        - Only keys derived with standard BIP 44, 49, 84, and 86 derivation paths are supported.
+        - Only keys derived with standard BIP 44, 49, 84, and 86 derivation paths are supported for single signature addresses.
         """
         master_fp = self.get_master_fingerprint()
 

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -194,10 +194,7 @@ class LedgerClient(HardwareWalletClient):
 
         For application versions 2.1.x and above:
 
-        - Transactions containing OP_RETURN outputs are not supported.
-        - Transactions containing multisig inputs involving the device more than once and also have Taproot outputs are currently not supported.
         - Only keys derived with standard BIP 44, 49, 84, and 86 derivation paths are supported.
-        - Multisigs must only contain this device a single time. This is a limitation of the firmware.
         """
         master_fp = self.get_master_fingerprint()
 
@@ -293,16 +290,8 @@ class LedgerClient(HardwareWalletClient):
                         else:
                             # No xpub, Ledger will not accept this multisig
                             ok = False
-                    else:
-                        # No origin info, Ledger will not accept this multisig
-                        ok = False
 
                 if not ok:
-                    retry_legacy = True
-                    continue
-
-                if our_keys != 1:
-                    # Ledger does not allow having more than one key per multisig
                     retry_legacy = True
                     continue
 

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -378,28 +378,7 @@ class LedgerClient(HardwareWalletClient):
 
     @ledger_exception
     def sign_message(self, message: Union[str, bytes], keypath: str) -> str:
-        app = btchip(DongleAdaptor(self.transport_client))
-
-        if not check_keypath(keypath):
-            raise BadArgumentError("Invalid keypath")
-        if isinstance(message, str):
-            message = bytearray(message, 'utf-8')
-        else:
-            message = bytearray(message)
-        keypath = keypath[2:]
-        # First display on screen what address you're signing for
-        app.getWalletPublicKey(keypath, True)
-        app.signMessagePrepare(keypath, message)
-        signature = app.signMessageSign()
-
-        # Make signature into standard bitcoin format
-        rLength = signature[3]
-        r = int.from_bytes(signature[4: 4 + rLength], byteorder="big", signed=True)
-        s = int.from_bytes(signature[4 + rLength + 2:], byteorder="big", signed=True)
-
-        sig = bytearray(chr(27 + 4 + (signature[0] & 0x01)), 'utf8') + r.to_bytes(32, byteorder="big", signed=False) + s.to_bytes(32, byteorder="big", signed=False)
-
-        return base64.b64encode(sig).decode('utf-8')
+        return self.client.sign_message(message, keypath)
 
     def _get_singlesig_default_wallet_policy(self, addr_type: AddressType, account: int) -> WalletPolicy:
         if addr_type == AddressType.LEGACY:

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -442,7 +442,7 @@ class LedgerClient(HardwareWalletClient):
 
     def setup_device(self, label: str = "", passphrase: str = "") -> bool:
         """
-        The Coldcard does not support setup via software.
+        Ledgers do not support setup via software.
 
         :raises UnavailableActionError: Always, this function is unavailable
         """
@@ -450,7 +450,7 @@ class LedgerClient(HardwareWalletClient):
 
     def wipe_device(self) -> bool:
         """
-        The Coldcard does not support wiping via software.
+        Ledgers do not support wiping via software.
 
         :raises UnavailableActionError: Always, this function is unavailable
         """
@@ -458,7 +458,7 @@ class LedgerClient(HardwareWalletClient):
 
     def restore_device(self, label: str = "", word_count: int = 24) -> bool:
         """
-        The Coldcard does not support restoring via software.
+        Ledgers do not support restoring via software.
 
         :raises UnavailableActionError: Always, this function is unavailable
         """
@@ -466,7 +466,7 @@ class LedgerClient(HardwareWalletClient):
 
     def backup_device(self, label: str = "", passphrase: str = "") -> bool:
         """
-        The Coldcard does not support backing up via software.
+        Ledgers do not support backing up via software.
 
         :raises UnavailableActionError: Always, this function is unavailable
         """
@@ -477,7 +477,7 @@ class LedgerClient(HardwareWalletClient):
 
     def prompt_pin(self) -> bool:
         """
-        The Coldcard does not need a PIN sent from the host.
+        Ledgers do not need a PIN sent from the host.
 
         :raises UnavailableActionError: Always, this function is unavailable
         """
@@ -485,7 +485,7 @@ class LedgerClient(HardwareWalletClient):
 
     def send_pin(self, pin: str) -> bool:
         """
-        The Coldcard does not need a PIN sent from the host.
+        Ledgers do not need a PIN sent from the host.
 
         :raises UnavailableActionError: Always, this function is unavailable
         """
@@ -493,7 +493,7 @@ class LedgerClient(HardwareWalletClient):
 
     def toggle_passphrase(self) -> bool:
         """
-        The Coldcard does not support toggling passphrase from the host.
+        Ledgers do not support toggling passphrase from the host.
 
         :raises UnavailableActionError: Always, this function is unavailable
         """

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -39,16 +39,13 @@ from .ledger_bitcoin.client import (
     LegacyClient,
     TransportClient,
 )
-from .ledger_bitcoin.client_legacy import DongleAdaptor
 from .ledger_bitcoin.exception import NotSupportedError
 from .ledger_bitcoin.wallet import (
     MultisigWallet,
     WalletPolicy,
 )
 from .ledger_bitcoin.btchip.btchipException import BTChipException
-from .ledger_bitcoin.btchip.btchip import btchip
 
-import base64
 import builtins
 import copy
 import hid
@@ -63,10 +60,7 @@ from ..key import (
     parse_path,
 )
 from .._script import (
-    is_opreturn,
-    is_p2pkh,
     is_p2sh,
-    is_p2wpkh,
     is_p2wsh,
     is_witness,
     parse_multisig,

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -346,8 +346,6 @@ class LedgerClient(HardwareWalletClient):
                 if psbt_in.witness_utxo:
                     utxo = psbt_in.witness_utxo
                 if psbt_in.non_witness_utxo:
-                    if psbt_in.prev_txid != psbt_in.non_witness_utxo.hash:
-                        raise BadArgumentError(f"Input {input_num} has a non_witness_utxo with the wrong hash")
                     assert psbt_in.prev_out is not None
                     utxo = psbt_in.non_witness_utxo.vout[psbt_in.prev_out]
                 assert utxo is not None

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -370,6 +370,12 @@ class LedgerClient(HardwareWalletClient):
 
     @ledger_exception
     def sign_message(self, message: Union[str, bytes], keypath: str) -> str:
+        if not check_keypath(keypath):
+            raise ValueError("Invalid keypath")
+
+        # Ledger requires the character "'" for hardened derivations since version 2.0.0
+        keypath = keypath.replace("h", "'")
+
         return self.client.sign_message(message, keypath)
 
     def _get_singlesig_default_wallet_policy(self, addr_type: AddressType, account: int) -> WalletPolicy:

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -528,9 +528,9 @@ class LedgerClient(HardwareWalletClient):
     @ledger_exception
     def can_sign_taproot(self) -> bool:
         """
-        Ledgers support Taproot if the Bitcoin App version greater than 2.0.0.
+        Ledgers support Taproot if the Bitcoin App version greater than 2.0.0; support here is for versions 2.1.0 and above.
 
-        :returns: True if Bitcoin App version is greater than or equal to 2.0.0. False otherwise.
+        :returns: True if Bitcoin App version is greater than or equal to 2.1.0, and not the "Legacy" release. False otherwise.
         """
         return isinstance(self.client, NewClient)
 

--- a/hwilib/devices/ledger_bitcoin/__init__.py
+++ b/hwilib/devices/ledger_bitcoin/__init__.py
@@ -5,6 +5,6 @@ from .client_base import Client, TransportClient
 from .client import createClient
 from ...common import Chain
 
-from .wallet import AddressType, Wallet, MultisigWallet, PolicyMapWallet
+from .wallet import AddressType, WalletPolicy, MultisigWallet
 
-__all__ = ["Client", "TransportClient", "createClient", "Chain", "AddressType", "Wallet", "MultisigWallet", "PolicyMapWallet"]
+__all__ = ["Client", "TransportClient", "createClient", "Chain", "AddressType", "WalletPolicy", "MultisigWallet"]

--- a/hwilib/devices/ledger_bitcoin/client.py
+++ b/hwilib/devices/ledger_bitcoin/client.py
@@ -218,10 +218,18 @@ def createClient(comm_client: Optional[TransportClient] = None, chain: Chain = C
     base_client = Client(comm_client, chain)
     app_name, app_version, _ = base_client.get_version()
 
-    if app_name not in ["Bitcoin", "Bitcoin Test", "app"]:
+    if app_name not in ["Bitcoin", "Bitcoin Test", "Bitcoin Legacy", "Bitcoin Test Legacy", "app"]:
         raise NotSupportedError(0x6A82, None, "Ledger is not in either the Bitcoin or Bitcoin Testnet app")
 
-    if app_version >= "2":
-        return NewClient(comm_client, chain)
-    else:
+    app_version_major, app_version_minor, _ = app_version.split(".", 2)
+
+    # App versions using the legacy protocol:
+    # - any 1.*.* version
+    # - any 2.0.* version
+    # - any version if the app name is "Bitcoin Legacy" or "Bitcoin Test Legacy"
+    is_legacy = int(app_version_major) <= 1 or (int(app_version_major) == 2 and int(app_version_minor) == 0) or "Legacy" in app_name
+
+    if is_legacy:
         return LegacyClient(comm_client, chain)
+    else:
+        return NewClient(comm_client, chain)

--- a/hwilib/devices/ledger_bitcoin/client.py
+++ b/hwilib/devices/ledger_bitcoin/client.py
@@ -9,7 +9,7 @@ from .client_base import Client, TransportClient
 from .client_legacy import LegacyClient
 from .exception import DeviceException, NotSupportedError
 from .merkle import get_merkleized_map_commitment
-from .wallet import Wallet, WalletType, PolicyMapWallet
+from .wallet import WalletPolicy, WalletType
 from ...psbt import PSBT
 from ..._serialize import deser_string
 
@@ -30,6 +30,37 @@ def parse_stream_to_map(f: BufferedReader) -> Mapping[bytes, bytes]:
 
         result[key] = value
     return result
+
+
+def read_uint(buf: BytesIO,
+              bit_len: int,
+              byteorder: str = 'little') -> int:
+    assert byteorder in ['little', 'big']
+
+    size: int = bit_len // 8
+    b: bytes = buf.read(size)
+
+    if len(b) < size:
+        raise ValueError(f"Can't read u{bit_len} in buffer!")
+
+    return int.from_bytes(b, byteorder)
+
+
+def read_varint(buf: BytesIO,
+                prefix: Optional[bytes] = None) -> int:
+    b: bytes = prefix if prefix else buf.read(1)
+
+    if not b:
+        raise ValueError(f"Can't read prefix: '{b}'!")
+
+    n: int = {b"\xfd": 2, b"\xfe": 4, b"\xff": 8}.get(b, 1)  # default to 1
+
+    b = buf.read(n) if n > 1 else b
+
+    if len(b) != n:
+        raise ValueError("Can't read varint!")
+
+    return int.from_bytes(b, byteorder="little")
 
 
 class NewClient(Client):
@@ -65,13 +96,16 @@ class NewClient(Client):
 
         return response.decode()
 
-    def register_wallet(self, wallet: Wallet) -> Tuple[bytes, bytes]:
-        if wallet.type != WalletType.POLICYMAP:
-            raise ValueError("wallet type must be POLICYMAP")
+    def register_wallet(self, wallet: WalletPolicy) -> Tuple[bytes, bytes]:
+        if wallet.version not in [WalletType.WALLET_POLICY_V1, WalletType.WALLET_POLICY_V2]:
+            raise ValueError("invalid wallet policy version")
 
         client_intepreter = ClientCommandInterpreter()
         client_intepreter.add_known_preimage(wallet.serialize())
         client_intepreter.add_known_list([k.encode() for k in wallet.keys_info])
+
+        # necessary for version 1 of the protocol (available since version 2.1.0 of the app)
+        client_intepreter.add_known_preimage(wallet.descriptor_template.encode())
 
         sw, response = self._make_request(
             self.builder.register_wallet(wallet), client_intepreter
@@ -90,17 +124,15 @@ class NewClient(Client):
 
     def get_wallet_address(
         self,
-        wallet: Wallet,
+        wallet: WalletPolicy,
         wallet_hmac: Optional[bytes],
         change: int,
         address_index: int,
         display: bool,
     ) -> str:
 
-        if wallet.type != WalletType.POLICYMAP or not isinstance(
-            wallet, PolicyMapWallet
-        ):
-            raise ValueError("wallet type must be POLICYMAP")
+        if not isinstance(wallet, WalletPolicy) or wallet.version not in [WalletType.WALLET_POLICY_V1, WalletType.WALLET_POLICY_V2]:
+            raise ValueError("wallet type must be WalletPolicy, with version either WALLET_POLICY_V1 or WALLET_POLICY_V2")
 
         if change != 0 and change != 1:
             raise ValueError("Invalid change")
@@ -108,6 +140,9 @@ class NewClient(Client):
         client_intepreter = ClientCommandInterpreter()
         client_intepreter.add_known_list([k.encode() for k in wallet.keys_info])
         client_intepreter.add_known_preimage(wallet.serialize())
+
+        # necessary for version 1 of the protocol (available since version 2.1.0 of the app)
+        client_intepreter.add_known_preimage(wallet.descriptor_template.encode())
 
         sw, response = self._make_request(
             self.builder.get_wallet_address(
@@ -121,7 +156,7 @@ class NewClient(Client):
 
         return response.decode()
 
-    def sign_psbt(self, psbt: PSBT, wallet: Wallet, wallet_hmac: Optional[bytes]) -> Mapping[int, bytes]:
+    def sign_psbt(self, psbt: PSBT, wallet: WalletPolicy, wallet_hmac: Optional[bytes]) -> List[Tuple[int, bytes, bytes]]:
         """Signs a PSBT using a registered wallet (or a standard wallet that does not need registration).
 
         Signature requires explicit approval from the user.
@@ -132,9 +167,9 @@ class NewClient(Client):
             A PSBT of version 0 or 2, with all the necessary information to sign the inputs already filled in; what the
             required fields changes depending on the type of input.
             The non-witness UTXO must be present for both legacy and SegWit inputs, or the hardware wallet will reject
-            signing (this will change for Taproot inputs).
+            signing. This is not required for Taproot inputs.
 
-        wallet : Wallet
+        wallet : WalletPolicy
             The registered wallet policy, or a standard wallet policy.
 
         wallet_hmac: Optional[bytes]
@@ -142,8 +177,11 @@ class NewClient(Client):
 
         Returns
         -------
-        Mapping[int, bytes]
-            A mapping that has as keys the indexes of inputs that the Hardware Wallet signed, and the corresponding signatures as values.
+        List[Tuple[int, bytes, bytes]]
+            A list of tuples returned by the hardware wallets, where each element is a tuple of:
+            - an integer, the index of the input being signed;
+            - a `bytes` array of length 33 (compressed ecdsa pubkey) or 32 (x-only BIP-0340 pubkey), the corresponding pubkey for this signature;
+            - a `bytes` array with the signature.
         """
         assert psbt.version == 2
         psbt_v2 = psbt
@@ -160,6 +198,9 @@ class NewClient(Client):
         client_intepreter = ClientCommandInterpreter()
         client_intepreter.add_known_list([k.encode() for k in wallet.keys_info])
         client_intepreter.add_known_preimage(wallet.serialize())
+
+        # necessary for version 1 of the protocol (available since version 2.1.0 of the app)
+        client_intepreter.add_known_preimage(wallet.descriptor_template.encode())
 
         global_map: Mapping[bytes, bytes] = parse_stream_to_map(f)
         client_intepreter.add_known_mapping(global_map)
@@ -199,7 +240,19 @@ class NewClient(Client):
         if any(len(x) <= 1 for x in results):
             raise RuntimeError("Invalid response")
 
-        return {int(res[0]): res[1:] for res in results}
+        results_list: List[Tuple[int, bytes, bytes]] = []
+        for res in results:
+            res_buffer = BytesIO(res)
+            input_index = read_varint(res_buffer)
+
+            pubkey_len = read_uint(res_buffer, 8)
+            pubkey = res_buffer.read(pubkey_len)
+
+            signature = res_buffer.read()
+
+            results_list.append((input_index, pubkey, signature))
+
+        return results_list
 
     def get_master_fingerprint(self) -> bytes:
 

--- a/hwilib/devices/ledger_bitcoin/client_base.py
+++ b/hwilib/devices/ledger_bitcoin/client_base.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Mapping, Optional, Union
+from typing import Tuple, Optional, Union, List
 from io import BytesIO
 
 from .ledgercomm import Transport
@@ -8,7 +8,7 @@ from ...common import Chain
 from .command_builder import DefaultInsType
 from .exception import DeviceException
 
-from .wallet import Wallet
+from .wallet import WalletPolicy
 from ...psbt import PSBT
 from ..._serialize import deser_string
 
@@ -130,13 +130,13 @@ class Client:
 
         raise NotImplementedError
 
-    def register_wallet(self, wallet: Wallet) -> Tuple[bytes, bytes]:
+    def register_wallet(self, wallet: WalletPolicy) -> Tuple[bytes, bytes]:
         """Registers a wallet policy with the user. After approval returns the wallet id and hmac to be stored on the client.
 
         Parameters
         ----------
-        wallet : Wallet
-            The Wallet policy to register on the device.
+        wallet : WalletPolicy
+            The wallet policy to register on the device.
 
         Returns
         -------
@@ -149,7 +149,7 @@ class Client:
 
     def get_wallet_address(
         self,
-        wallet: Wallet,
+        wallet: WalletPolicy,
         wallet_hmac: Optional[bytes],
         change: int,
         address_index: int,
@@ -160,7 +160,7 @@ class Client:
 
         Parameters
         ----------
-        wallet : Wallet
+        wallet : WalletPolicy
             The registered wallet policy, or a standard wallet policy.
 
         wallet_hmac: Optional[bytes]
@@ -183,7 +183,7 @@ class Client:
 
         raise NotImplementedError
 
-    def sign_psbt(self, psbt: PSBT, wallet: Wallet, wallet_hmac: Optional[bytes]) -> Mapping[int, bytes]:
+    def sign_psbt(self, psbt: PSBT, wallet: WalletPolicy, wallet_hmac: Optional[bytes]) -> List[Tuple[int, bytes, bytes]]:
         """Signs a PSBT using a registered wallet (or a standard wallet that does not need registration).
 
         Signature requires explicit approval from the user.
@@ -196,7 +196,7 @@ class Client:
             The non-witness UTXO must be present for both legacy and SegWit inputs, or the hardware wallet will reject
             signing (this will change for Taproot inputs).
 
-        wallet : Wallet
+        wallet : WalletPolicy
             The registered wallet policy, or a standard wallet policy.
 
         wallet_hmac: Optional[bytes]
@@ -204,8 +204,11 @@ class Client:
 
         Returns
         -------
-        Mapping[int, bytes]
-            A mapping that has as keys the indexes of inputs that the Hardware Wallet signed, and the corresponding signatures as values.
+        List[Tuple[int, bytes, bytes]]
+            A list of tuples returned by the hardware wallets, where each element is a tuple of:
+            - an integer, the index of the input being signed;
+            - a `bytes` array of length 33 (compressed ecdsa pubkey) or 32 (x-only BIP-0340 pubkey), the corresponding pubkey for this signature;
+            - a `bytes` array with the signature.
         """
 
         raise NotImplementedError

--- a/hwilib/devices/ledger_bitcoin/client_legacy.py
+++ b/hwilib/devices/ledger_bitcoin/client_legacy.py
@@ -12,12 +12,12 @@ import base64
 
 from .client import Client, TransportClient
 
-from typing import List, Tuple, Mapping, Optional, Union
+from typing import List, Tuple, Optional, Union
 
 from ...common import AddressType, Chain, hash160
 from ...key import ExtendedKey, parse_path
 from ...psbt import PSBT
-from .wallet import Wallet, PolicyMapWallet
+from .wallet import WalletPolicy
 
 from ..._script import is_p2sh, is_witness, is_p2wpkh, is_p2wsh
 
@@ -26,12 +26,12 @@ from .btchip.btchipUtils import compress_public_key
 from .btchip.bitcoinTransaction import bitcoinTransaction
 
 
-def get_address_type_for_policy(policy: PolicyMapWallet) -> AddressType:
-    if policy.policy_map == "pkh(@0)":
+def get_address_type_for_policy(policy: WalletPolicy) -> AddressType:
+    if policy.descriptor_template == "pkh(@0/**)":
         return AddressType.LEGACY
-    elif policy.policy_map == "wpkh(@0)":
+    elif policy.descriptor_template == "wpkh(@0/**)":
         return AddressType.WIT
-    elif policy.policy_map == "sh(wpkh(@0))":
+    elif policy.descriptor_template == "sh(wpkh(@0/**))":
         return AddressType.SH_WIT
     else:
         raise ValueError("Invalid or unsupported policy")
@@ -113,12 +113,12 @@ class LegacyClient(Client):
         )
         return xpub.to_string()
 
-    def register_wallet(self, wallet: Wallet) -> Tuple[bytes, bytes]:
+    def register_wallet(self, wallet: WalletPolicy) -> Tuple[bytes, bytes]:
         raise NotImplementedError # legacy app does not have this functionality
 
     def get_wallet_address(
         self,
-        wallet: Wallet,
+        wallet: WalletPolicy,
         wallet_hmac: Optional[bytes],
         change: int, # Ignored
         address_index: int, # Ignored
@@ -126,11 +126,11 @@ class LegacyClient(Client):
     ) -> str:
         # TODO: check keypath
 
-        if wallet_hmac != None or wallet.n_keys != 1:
+        if wallet_hmac is not None or wallet.n_keys != 1:
             raise NotImplementedError("Policy wallets are only supported from version 2.0.0. Please update your Ledger hardware wallet")
 
-        if not isinstance(wallet, PolicyMapWallet):
-            raise ValueError("Invalid wallet policy type, it must be PolicyMapWallet")
+        if not isinstance(wallet, WalletPolicy):
+            raise ValueError("Invalid wallet policy type, it must be WalletPolicy")
 
         key_info = wallet.keys_info[0]
         try:
@@ -153,14 +153,14 @@ class LegacyClient(Client):
         return output['address'][12:-2] # HACK: A bug in getWalletPublicKey results in the address being returned as the string "bytearray(b'<address>')". This extracts the actual address to work around this.
 
     # NOTE: This is different from the new API, but we need it for multisig support.
-    def sign_psbt(self, psbt: PSBT, wallet: Wallet, wallet_hmac: Optional[bytes]) -> Mapping[int, Mapping[bytes, bytes]]:
-        if wallet_hmac != None or wallet.n_keys != 1:
+    def sign_psbt(self, psbt: PSBT, wallet: WalletPolicy, wallet_hmac: Optional[bytes]) -> List[Tuple[int, bytes, bytes]]:
+        if wallet_hmac is not None or wallet.n_keys != 1:
             raise NotImplementedError("Policy wallets are only supported from version 2.0.0. Please update your Ledger hardware wallet")
 
-        if not isinstance(wallet, PolicyMapWallet):
-            raise ValueError("Invalid wallet policy type, it must be PolicyMapWallet")
+        if not isinstance(wallet, WalletPolicy):
+            raise ValueError("Invalid wallet policy type, it must be WalletPolicy")
 
-        if not wallet.policy_map in ['pkh(@0)', 'wpkh(@0)', 'sh(wpkh(@0))']:
+        if wallet.descriptor_template not in ["pkh(@0/**)", "pkh(@0/<0;1>/*)", "wpkh(@0/**)", "wpkh(@0/<0;1>/*)", "sh(wpkh(@0/**))", "sh(wpkh(@0/<0;1>/*))"]:
             raise NotImplementedError("Unsupported policy")
 
         # the rest of the code is basically the HWI code, and it ignores wallet
@@ -275,7 +275,7 @@ class LegacyClient(Client):
 
             all_signature_attempts[i_num] = signature_attempts
 
-        result = {}
+        result: List[int, bytes, bytes] = []
 
         # Sign any segwit inputs
         if has_segwit:
@@ -292,9 +292,8 @@ class LegacyClient(Client):
                 for signature_attempt in all_signature_attempts[i]:
                     self.app.startUntrustedTransaction(False, 0, [segwit_inputs[i]], script_codes[i], c_tx.nVersion)
 
-                    if i not in result:
-                        result[i] = {}
-                    result[i][signature_attempt[1]] = self.app.untrustedHashSign(signature_attempt[0], "", c_tx.nLockTime, 0x01)
+                    result.append((i, signature_attempt[1], self.app.untrustedHashSign(signature_attempt[0], "", c_tx.nLockTime, 0x01)))
+
         elif has_legacy:
             first_input = True
             # Legacy signing if all inputs are legacy
@@ -304,13 +303,11 @@ class LegacyClient(Client):
                     self.app.startUntrustedTransaction(first_input, i, legacy_inputs, script_codes[i], c_tx.nVersion)
                     self.app.finalizeInput(b"DUMMY", -1, -1, change_path, tx_bytes)
 
-                    if i not in result:
-                        result[i] = {}
-                    result[i][signature_attempt[1]] = self.app.untrustedHashSign(signature_attempt[0], "", c_tx.nLockTime, 0x01)
+                    result.append((i, signature_attempt[1], self.app.untrustedHashSign(signature_attempt[0], "", c_tx.nLockTime, 0x01)))
 
                     first_input = False
 
-        # Send map of input signatures
+        # Send list of input signatures
         return result
 
     def get_master_fingerprint(self) -> bytes:

--- a/hwilib/devices/ledger_bitcoin/client_legacy.py
+++ b/hwilib/devices/ledger_bitcoin/client_legacy.py
@@ -37,22 +37,6 @@ def get_address_type_for_policy(policy: WalletPolicy) -> AddressType:
         raise ValueError("Invalid or unsupported policy")
 
 
-# minimal checking of string keypath
-# taken from HWI
-def check_keypath(key_path: str) -> bool:
-    parts = re.split("/", key_path)
-    if parts[0] != "m":
-        return False
-    # strip hardening chars
-    for index in parts[1:]:
-        index_int = re.sub('[hH\']', '', index)
-        if not index_int.isdigit():
-            return False
-        if int(index_int) > 0x80000000:
-            return False
-    return True
-
-
 class DongleAdaptor:
     # TODO: type for comm_client
     def __init__(self, comm_client) -> None:
@@ -315,10 +299,6 @@ class LegacyClient(Client):
         return hash160(compress_public_key(master_pubkey["publicKey"]))[:4]
 
     def sign_message(self, message: Union[str, bytes], keypath: str) -> str:
-        # copied verbatim from HWI
-
-        if not check_keypath(keypath):
-            raise ValueError("Invalid keypath")
         if isinstance(message, str):
             message = bytearray(message, 'utf-8')
         else:

--- a/hwilib/devices/ledger_bitcoin/command_builder.py
+++ b/hwilib/devices/ledger_bitcoin/command_builder.py
@@ -1,11 +1,12 @@
 import enum
 from typing import List, Tuple, Mapping, Union, Iterator, Optional
 
-from ...common import AddressType
 from ..._serialize import ser_compact_size as write_varint
 from .merkle import get_merkleized_map_commitment, MerkleTree, element_hash
-from .wallet import Wallet
+from .wallet import WalletPolicy
 
+# p2 encodes the protocol version implemented
+CURRENT_PROTOCOL_VERSION = 1
 
 def bip32_path_from_string(path: str) -> List[bytes]:
     splitted_path: List[str] = path.split("/")
@@ -67,7 +68,7 @@ class BitcoinCommandBuilder:
         cla: int,
         ins: Union[int, enum.IntEnum],
         p1: int = 0,
-        p2: int = 0,
+        p2: int = CURRENT_PROTOCOL_VERSION,
         cdata: bytes = b"",
     ) -> dict:
         """Serialize the whole APDU command (header + data).
@@ -109,7 +110,7 @@ class BitcoinCommandBuilder:
             cdata=cdata,
         )
 
-    def register_wallet(self, wallet: Wallet):
+    def register_wallet(self, wallet: WalletPolicy):
         wallet_bytes = wallet.serialize()
 
         return self.serialize(
@@ -120,7 +121,7 @@ class BitcoinCommandBuilder:
 
     def get_wallet_address(
         self,
-        wallet: Wallet,
+        wallet: WalletPolicy,
         wallet_hmac: Optional[bytes],
         address_index: int,
         change: bool,
@@ -147,7 +148,7 @@ class BitcoinCommandBuilder:
         global_mapping: Mapping[bytes, bytes],
         input_mappings: List[Mapping[bytes, bytes]],
         output_mappings: List[Mapping[bytes, bytes]],
-        wallet: Wallet,
+        wallet: WalletPolicy,
         wallet_hmac: Optional[bytes],
     ):
 

--- a/hwilib/devices/ledger_bitcoin/wallet.py
+++ b/hwilib/devices/ledger_bitcoin/wallet.py
@@ -1,3 +1,5 @@
+import re
+
 from enum import IntEnum
 from typing import List
 
@@ -13,18 +15,22 @@ def serialize_str(value: str) -> bytes:
 
 
 class WalletType(IntEnum):
-    POLICYMAP = 1
+    WALLET_POLICY_V1 = 1
+    WALLET_POLICY_V2 = 2
 
 
 # should not be instantiated directly
-class Wallet:
-    def __init__(self, name: str, wallet_type: WalletType) -> None:
+class WalletPolicyBase:
+    def __init__(self, name: str, version: WalletType) -> None:
         self.name = name
-        self.type = wallet_type
+        self.version = version
+
+        if (version != WalletType.WALLET_POLICY_V1 and version != WalletType.WALLET_POLICY_V2):
+            raise ValueError("Invalid wallet policy version")
 
     def serialize(self) -> bytes:
         return b"".join([
-            self.type.value.to_bytes(1, byteorder="big"),
+            self.version.value.to_bytes(1, byteorder="big"),
             serialize_str(self.name)
         ])
 
@@ -33,24 +39,24 @@ class Wallet:
         return sha256(self.serialize()).digest()
 
 
-class PolicyMapWallet(Wallet):
+class WalletPolicy(WalletPolicyBase):
     """
-    Represents a wallet stored with a policy map and a number of keys_info.
-    The wallet is serialized as follows:
-       - 1 byte   : wallet type
-       - 1 byte   : length of the wallet name (max 16)
+    Represents a wallet stored with a wallet policy.
+    For version V2, the wallet is serialized as follows:
+       - 1 byte   : wallet version
+       - 1 byte   : length of the wallet name (max 64)
        - (var)    : wallet name (ASCII string)
-       - (varint) : length of the policy map, at most 74 bytes at this time
-       - (var)    : policy map
+       - (varint) : length of the descriptor template
+       - 32-bytes : sha256 hash of the descriptor template
        - (varint) : number of keys (not larger than 252)
        - 32-bytes : root of the Merkle tree of all the keys information.
 
     The specific format of the keys is deferred to subclasses.
     """
 
-    def __init__(self, name: str, policy_map: str, keys_info: List[str]):
-        super().__init__(name, WalletType.POLICYMAP)
-        self.policy_map = policy_map
+    def __init__(self, name: str, descriptor_template: str, keys_info: List[str], version: WalletType = WalletType.WALLET_POLICY_V2):
+        super().__init__(name, version)
+        self.descriptor_template = descriptor_template
         self.keys_info = keys_info
 
     @property
@@ -58,45 +64,65 @@ class PolicyMapWallet(Wallet):
         return len(self.keys_info)
 
     def serialize(self) -> bytes:
-        keys_info_hashes = map(lambda k: element_hash(k.encode("latin-1")), self.keys_info)
+        keys_info_hashes = map(lambda k: element_hash(k.encode()), self.keys_info)
+
+        descriptor_template_sha256 = sha256(self.descriptor_template.encode()).digest()
 
         return b"".join([
             super().serialize(),
-            write_varint(len(self.policy_map)),
-            self.policy_map.encode("latin-1"),
+            write_varint(len(self.descriptor_template.encode())),
+            self.descriptor_template.encode() if self.version == WalletType.WALLET_POLICY_V1 else descriptor_template_sha256,
             write_varint(len(self.keys_info)),
             MerkleTree(keys_info_hashes).root
         ])
 
+    def get_descriptor(self, change: bool) -> str:
+        desc = self.descriptor_template
+        for i in reversed(range(self.n_keys)):
+            key = self.keys_info[i]
+            desc = desc.replace(f"@{i}", key)
 
-class MultisigWallet(PolicyMapWallet):
-    def __init__(self, name: str, address_type: AddressType, threshold: int, keys_info: List[str], sorted: bool = True) -> None:
+        # in V1, /** is part of the key; in V2, it's part of the policy map. This handles either
+        desc = desc.replace("/**", f"/{1 if change else 0}/*")
+
+        if self.version == WalletType.WALLET_POLICY_V2:
+            # V2, the /<M;N> syntax is supported. Replace with M if not change, or with N if change
+            regex = r"/<(\d+);(\d+)>"
+            desc = re.sub(regex, "/\\2" if change else "/\\1", desc)
+
+        return desc
+
+
+class MultisigWallet(WalletPolicy):
+    def __init__(self, name: str, address_type: AddressType, threshold: int, keys_info: List[str], sorted: bool = True, version: WalletType = WalletType.WALLET_POLICY_V2) -> None:
         n_keys = len(keys_info)
 
-        if not (1 <= threshold <= n_keys <= 15):
+        if not (1 <= threshold <= n_keys <= 16):
             raise ValueError("Invalid threshold or number of keys")
 
         multisig_op = "sortedmulti" if sorted else "multi"
 
         if (address_type == AddressType.LEGACY):
             policy_prefix = f"sh({multisig_op}("
-            policy_suffix = f"))"
+            policy_suffix = "))"
         elif address_type == AddressType.WIT:
             policy_prefix = f"wsh({multisig_op}("
-            policy_suffix = f"))"
+            policy_suffix = "))"
         elif address_type == AddressType.SH_WIT:
             policy_prefix = f"sh(wsh({multisig_op}("
-            policy_suffix = f")))"
+            policy_suffix = ")))"
         else:
             raise ValueError(f"Unexpected address type: {address_type}")
 
-        policy_map = "".join([
+        key_placeholder_suffix = "/**" if version == WalletType.WALLET_POLICY_V2 else ""
+
+        descriptor_template = "".join([
             policy_prefix,
             str(threshold) + ",",
-            ",".join("@" + str(l) for l in range(n_keys)),
+            ",".join("@" + str(k) + key_placeholder_suffix for k in range(n_keys)),
             policy_suffix
         ])
 
-        super().__init__(name, policy_map, keys_info)
+        super().__init__(name, descriptor_template, keys_info, version)
 
         self.threshold = threshold

--- a/test/test_ledger.py
+++ b/test/test_ledger.py
@@ -51,7 +51,7 @@ class LedgerEmulator(DeviceEmulator):
         super().start()
         automation_path = os.path.abspath("data/speculos-automation.json")
         app_path = "./apps/nanos#btc#2.0#ce796c1b.elf" if self.legacy else "./apps/btc-test.elf"
-        os.environ["SPECULOS_APPNAME"] = "Bitcoin Test:1.6.0" if self.legacy else "Bitcoin Test:2.0.1"
+        os.environ["SPECULOS_APPNAME"] = "Bitcoin Test:1.6.0" if self.legacy else "Bitcoin Test:2.1.0"
 
         self.emulator_stderr = open('ledger-emulator.stderr', 'a')
         # Start the emulator

--- a/test/test_ledger.py
+++ b/test/test_ledger.py
@@ -39,13 +39,13 @@ class LedgerEmulator(DeviceEmulator):
         self.fingerprint = 'f5acc2fd'
         self.master_xpub = 'tpubDCwYjpDhUdPGP5rS3wgNg13mTrrjBuG8V9VpWbyptX6TRPbNoZVXsoVUSkCjmQ8jJycjuDKBb9eataSymXakTTaGifxR6kmVsfFehH1ZgJT'
         self.password = ""
-        self.supports_ms_display = False
-        self.supports_xpub_ms_display = False
-        self.supports_unsorted_ms = False
+        self.supports_ms_display = False # Legacy does not multisig address display; tests not updated for new app
+        self.supports_xpub_ms_display = False # Legacy does not multisig address display; tests not updated for new app
+        self.supports_unsorted_ms = False # Legacy does not support unsorted multisig; tests not updated for new app
         self.supports_taproot = not legacy # Legacy does not support Taproot
         self.strict_bip48 = True
         self.include_xpubs = True
-        self.supports_device_multiple_multisig = legacy
+        self.supports_device_multiple_multisig = True
 
     def start(self):
         super().start()


### PR DESCRIPTION
### Intro and context
The upcoming version of the Ledger bitcoin app (version 2.1.0) will remove support to the legacy API (1.*).

A number of limitations of the 2.* protocol have been addressed since the first release:
- Each returned signature is now accompanied by the corresponding pubkey, instead of just the input index.
- Key origin information is no longer required for external xpubs.
- Multiple internal xpubs are supported (the device will sign for each internal xpub).
- Introduces a modified wallet policy language matching [this proposal on bitcoin-dev](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-May/020423.html), which addresses some drawbacks of the earlier version (most notably, removing the __change_/address-index_ from key information, and adding it to the policy's descriptor template instead).
- Support for message signing was added.
- OP_RETURN outputs are now supported.

Since there are incompatibilities, the modified protocol from version 2.1.0 is opt-in (signaled by using `01` instead of `00` in the _p1_ field of the APDU), and the protocol of version 2.0.* (using `00` in _p1_) will still be supported in future versions for some time. Nevertheless, the `p1 == 0` protocol should is to be considered deprecated from the moment the 2.1.0 app goes live (expected in early November).

All 2.* versions before 2.1.0 support the legacy 1.x protocol; therefore, in order to keep things simple, this PR **uses the legacy protocol for any version prior to 2.1.0**). I believe disruption will be minimal: users of the 2.0.* app will downgrade their multisig experience to the legacy protocol (which doesn't recognize change addresses), and are therefore recommended to upgrade to 2.1.0. Nothing changes for users that are still on the 1.* app series (upgrade is, of course, still recommended!).

Moreover, the 2.1.0 adds **full support to miniscript** within `wsh` descriptors.

### Changes in this PR

This is the list of changes in this PR:
- Recognize "Bitcoin Legacy" and "Bitcoin Testnet Legacy" as a valid app name for the legacy protocol (regardless of the version). It will be deployed and available as an app in the Ledger app store.
- Completely switch to the updated version (_p1_ = 1) of the new protocol starting from version 2.1.0; use legacy (1.*) protocol below version 2.1.0. Never retry with the legacy protocol on failure.
- Remove checks for the limitations that were addressed.
- Add support for message signing using the new protocol.
- Add support for displaying multisig addresses.
- Support multisig wallets with 16 keys (a previous version of the python library was limiting to 15 keys by mistake).

Miniscript support is left for a separate PR (more comments below).

### Drawbacks

Signing a psbt and displaying an address requires registering the wallet policy on the device. The current version of HWI does that right before signing (and this PR adds the same behavior for displaying addresses).

This is not secure in a compromised machine if the device participates to multiple multisignature/script wallet accounts, as the adversary could trick the user into spending from a different wallet account.

Moreover, miniscript support in HWI is not in this PR, since it requires larger changes to HWI.

I'm working on a BIP for [miniscript wallet policies](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2022-May/020423.html), and will propose a backwards-compatible and vendor-agnostic way to add native support for wallet policies in a separate PR.
