### PR TITLE
trezor: optimize signing speed by not serializing transaction in trezor

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -621,6 +621,7 @@ class TrezorClient(HardwareWalletClient):
                 prev_txes=prevtxs,
                 version=tx.tx_version,
                 lock_time=tx.compute_lock_time(),
+                serialize=False,
             )
 
             # Each input has one signature

--- a/hwilib/devices/trezorlib/messages.py
+++ b/hwilib/devices/trezorlib/messages.py
@@ -624,6 +624,7 @@ class SignTx(protobuf.MessageType):
         10: protobuf.Field("branch_id", "uint32", repeated=False, required=False),
         11: protobuf.Field("amount_unit", "AmountUnit", repeated=False, required=False),
         12: protobuf.Field("decred_staking_ticket", "bool", repeated=False, required=False),
+        13: protobuf.Field("serialize", "bool", repeated=False, required=False),
     }
 
     def __init__(
@@ -641,6 +642,7 @@ class SignTx(protobuf.MessageType):
         branch_id: Optional["int"] = None,
         amount_unit: Optional["AmountUnit"] = AmountUnit.BITCOIN,
         decred_staking_ticket: Optional["bool"] = False,
+        serialize: Optional["bool"] = True,
     ) -> None:
         self.outputs_count = outputs_count
         self.inputs_count = inputs_count
@@ -654,6 +656,7 @@ class SignTx(protobuf.MessageType):
         self.branch_id = branch_id
         self.amount_unit = amount_unit
         self.decred_staking_ticket = decred_staking_ticket
+        self.serialize = serialize
 
 
 class TxRequest(protobuf.MessageType):


### PR DESCRIPTION
[ opening as draft PR as it still needs testing , will remove the draft status once it has been tested on all supported devices ]

Since HWI is not using TxRequestSerializedType.serialized_tx we might ask the device not to serialize transactions by setting SignTx.serialize=False

This field is introduced in trezorlib 0.13.4. This PR only backports this field to local copy of trezorlib and nothing else.