### PR TITLE
Fix Jade CI build pollution

### DIFF
--- a/test/setup_environment.sh
+++ b/test/setup_environment.sh
@@ -392,8 +392,8 @@ if [[ -n ${build_jade} ]]; then
     # always seem to pick up the locally installed python virtualenv, and instead uses
     # the system python/no-virtualenv which fails ...)
     # Only install the tools we need (ie. esp32)
+    rm -fr "${IDF_TOOLS_PATH}"
     cd esp-idf
-    rm -fr ${IDF_TOOLS_PATH}
     ./install.sh esp32
     cd ..
 
@@ -404,7 +404,7 @@ if [[ -n ${build_jade} ]]; then
     cd jade
     rm -fr sdkconfig
     cp configs/sdkconfig_qemu.defaults sdkconfig.defaults
-    idf.py all
+    idf.py fullclean all
 
     # Make the qemu flash image
     esptool.py --chip esp32 merge_bin --fill-flash-size 4MB -o main/qemu/flash_image.bin \


### PR DESCRIPTION
It appears that the Jade CI is being polluted by the output of prior runs.  This needs removing, otherwise we're not getting a true clean build for this commit using the current tools, but rather some cached values (now out of date and not applicable) can interfere with the current build.