### PR TITLE
Pass '--expert' and '--chain' cmd-line arguments to enumerate() functions

### DIFF
--- a/hwilib/_cli.py
+++ b/hwilib/_cli.py
@@ -60,7 +60,7 @@ def displayaddress_handler(args: argparse.Namespace, client: HardwareWalletClien
     return displayaddress(client, desc=args.desc, path=args.path, addr_type=args.addr_type)
 
 def enumerate_handler(args: argparse.Namespace) -> List[Dict[str, Any]]:
-    return enumerate(password=args.password)
+    return enumerate(password=args.password, expert=args.expert, chain=args.chain)
 
 def getmasterxpub_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, str]:
     return getmasterxpub(client, addrtype=args.addr_type, account=args.account)

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -101,7 +101,7 @@ def get_client(device_type: str, device_path: str, password: Optional[str] = Non
     return client
 
 # Get a list of all available hardware wallets
-def enumerate(password: Optional[str] = None) -> List[Dict[str, Any]]:
+def enumerate(password: Optional[str] = None, expert: bool = False, chain: Chain = Chain.MAIN) -> List[Dict[str, Any]]:
     """
     Enumerate all of the devices that HWI can potentially access.
 
@@ -114,7 +114,7 @@ def enumerate(password: Optional[str] = None) -> List[Dict[str, Any]]:
     for module in all_devs:
         try:
             imported_dev = importlib.import_module('.devices.' + module, __package__)
-            result.extend(imported_dev.enumerate(password))
+            result.extend(imported_dev.enumerate(password, expert, chain))
         except ImportError as e:
             # Warn for ImportErrors, but largely ignore them to allow users not install
             # all device dependencies if only one or some devices are wanted.

--- a/hwilib/devices/bitbox02.py
+++ b/hwilib/devices/bitbox02.py
@@ -174,7 +174,7 @@ def _xpubs_equal_ignoring_version(xpub1: bytes, xpub2: bytes) -> bool:
     return xpub1[4:] == xpub2[4:]
 
 
-def enumerate(password: Optional[str] = None) -> List[Dict[str, object]]:
+def enumerate(password: Optional[str] = None, expert: bool = False, chain: Chain = Chain.MAIN) -> List[Dict[str, Any]]:
     """
     Enumerate all BitBox02 devices. Bootloaders excluded.
     """

--- a/hwilib/devices/coldcard.py
+++ b/hwilib/devices/coldcard.py
@@ -399,7 +399,7 @@ class ColdcardClient(HardwareWalletClient):
         return False
 
 
-def enumerate(password: Optional[str] = None) -> List[Dict[str, Any]]:
+def enumerate(password: Optional[str] = None, expert: bool = False, chain: Chain = Chain.MAIN) -> List[Dict[str, Any]]:
     results = []
     devices = hid.enumerate(COINKITE_VID, CKCC_PID)
     devices.append({'path': CC_SIMULATOR_SOCK.encode()})

--- a/hwilib/devices/digitalbitbox.py
+++ b/hwilib/devices/digitalbitbox.py
@@ -679,7 +679,7 @@ class DigitalbitboxClient(HardwareWalletClient):
         return False
 
 
-def enumerate(password: Optional[str] = None) -> List[Dict[str, Any]]:
+def enumerate(password: Optional[str] = None, expert: bool = False, chain: Chain = Chain.MAIN) -> List[Dict[str, Any]]:
     results = []
     devices = hid.enumerate(DBB_VENDOR_ID, DBB_DEVICE_ID)
     # Try connecting to simulator

--- a/hwilib/devices/jade.py
+++ b/hwilib/devices/jade.py
@@ -145,8 +145,8 @@ class JadeClient(HardwareWalletClient):
         else:
             if uninitialized and not HAS_NETWORKING:
                 # Wallet not initialised/unlocked nor do we have networking dependencies
-                # User must use 'Emergency Restore' feature to enter mnemonic on Jade hw
-                raise DeviceNotReadyError('Use "Emergency Restore" feature on Jade hw to enter wallet mnemonic')
+                # User must use 'Recovery Phrase Login' or 'QR Unlock' feature to access wallet
+                raise DeviceNotReadyError('Use "Recovery Phrase Login" or "QR PIN Unlock" feature on Jade hw to access wallet')
 
             # Push some host entropy into jade
             self.jade.add_entropy(os.urandom(32))
@@ -508,7 +508,7 @@ class JadeClient(HardwareWalletClient):
         return False
 
 
-def enumerate(password: Optional[str] = None) -> List[Dict[str, Any]]:
+def enumerate(password: Optional[str] = None, expert: bool = False, chain: Chain = Chain.MAIN) -> List[Dict[str, Any]]:
     results = []
 
     def _get_device_entry(device_model: str, device_path: str) -> Dict[str, Any]:
@@ -521,7 +521,7 @@ def enumerate(password: Optional[str] = None) -> List[Dict[str, Any]]:
 
         client = None
         with handle_errors(common_err_msgs['enumerate'], d_data):
-            client = JadeClient(device_path, password, timeout=1)
+            client = JadeClient(device_path, password, expert, chain, timeout=1)
             d_data['fingerprint'] = client.get_master_fingerprint().hex()
 
         if client:

--- a/hwilib/devices/keepkey.py
+++ b/hwilib/devices/keepkey.py
@@ -171,7 +171,7 @@ class KeepkeyClient(TrezorClient):
         return False
 
 
-def enumerate(password: Optional[str] = None) -> List[Dict[str, Any]]:
+def enumerate(password: Optional[str] = None, expert: bool = False, chain: Chain = Chain.MAIN) -> List[Dict[str, Any]]:
     results = []
     devs = hid.HidTransport.enumerate(usb_ids=KEEPKEY_HID_IDS)
     devs.extend(webusb.WebUsbTransport.enumerate(usb_ids=KEEPKEY_WEBUSB_IDS))

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -539,7 +539,7 @@ class LedgerClient(HardwareWalletClient):
         return isinstance(self.client, NewClient)
 
 
-def enumerate(password: Optional[str] = None) -> List[Dict[str, Any]]:
+def enumerate(password: Optional[str] = None, expert: bool = False, chain: Chain = Chain.MAIN) -> List[Dict[str, Any]]:
     results = []
     devices = []
     devices.extend(hid.enumerate(LEDGER_VENDOR_ID, 0))

--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -847,7 +847,7 @@ class TrezorClient(HardwareWalletClient):
         return bool(self.client.version >= (1, 10, 4))
 
 
-def enumerate(password: Optional[str] = None) -> List[Dict[str, Any]]:
+def enumerate(password: Optional[str] = None, expert: bool = False, chain: Chain = Chain.MAIN) -> List[Dict[str, Any]]:
     results = []
     devs = hid.HidTransport.enumerate()
     devs.extend(webusb.WebUsbTransport.enumerate())


### PR DESCRIPTION
These arguments are currently discarded/ignored for the enumerate command.  Pass them through to the per-hw enumerate() calls.

In the Jade client, use the 'chain' parameter to enable testnet-configured Jade units to enumerate successfully.