### PR TITLE
`--without-gui` for building without GUI support

### DIFF
--- a/contrib/build_bin.sh
+++ b/contrib/build_bin.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 # Script for building standalone binary releases deterministically
+# Usage: First script parameter can be `--without-gui` to build without UI support
 
 set -ex
 
@@ -8,8 +9,14 @@ eval "$(pyenv virtualenv-init -)"
 pip install -U pip
 pip install poetry
 
+gui_support="${1:---with-gui}";
+
 # Setup poetry and install the dependencies
-poetry install -E qt
+if [[ $gui_support == "--with-gui" ]]; then
+    poetry install -E qt
+else
+    poetry install
+fi
 
 # We also need to change the timestamps of all of the base library files
 lib_dir=`pyenv root`/versions/3.9.7/lib/python3.9
@@ -18,8 +25,12 @@ TZ=UTC find ${lib_dir} -name '*.py' -type f -execdir touch -t "201901010000.00" 
 # Make the standalone binary
 export PYTHONHASHSEED=42
 poetry run pyinstaller hwi.spec
-poetry run contrib/generate-ui.sh
-poetry run pyinstaller hwi-qt.spec
+
+if [[ $gui_support == "--with-gui" ]]; then
+    poetry run contrib/generate-ui.sh
+    poetry run pyinstaller hwi-qt.spec
+fi
+
 unset PYTHONHASHSEED
 
 # Make the final compressed package
@@ -30,12 +41,20 @@ if [[ $OS == "darwin" ]]; then
     OS="mac"
 fi
 target_tarfile="hwi-${VERSION}-${OS}-amd64.tar.gz"
-tar -czf $target_tarfile hwi hwi-qt
+
+if [[ $gui_support == "--with-gui" ]]; then
+    tar -czf $target_tarfile hwi hwi-qt
+else
+    tar -czf $target_tarfile hwi
+fi
 
 # Copy the binaries to subdir for shasum
 target_dir="$target_tarfile.dir"
 mkdir $target_dir
 mv hwi $target_dir
-mv hwi-qt $target_dir
+
+if [[ $gui_support == "--with-gui" ]]; then
+    mv hwi-qt $target_dir
+fi
 
 popd

--- a/contrib/build_dist.sh
+++ b/contrib/build_dist.sh
@@ -1,5 +1,6 @@
 #! /bin/bash
 # Script for building pypi distribution archives deterministically
+# Usage: First script parameter can be `--without-gui` to build without UI support
 
 set -ex
 
@@ -8,8 +9,14 @@ eval "$(pyenv virtualenv-init -)"
 pip install -U pip
 pip install poetry
 
+gui_support="${1:---with-gui}";
+
 # Setup poetry and install the dependencies
-poetry install -E qt
+if [[ $gui_support == "--with-gui" ]]; then
+    poetry install -E qt
+else
+    poetry install
+fi
 
 # Make the distribution archives for pypi
 poetry build -f wheel

--- a/docs/development/release-process.rst
+++ b/docs/development/release-process.rst
@@ -3,7 +3,7 @@ Release Process
 
 1. Bump version number in ``pyproject.toml`` and ``hwilib/__init__.py``, generate the setup.py file, and git tag release
 2. Build distribution archives for PyPi with ``contrib/build_dist.sh``
-3. For MacOS and Linux, use ``contrib/build_bin.sh``. This needs to be run on a MacOS machine for the MacOS binary and on a Linux machine for the linux one.
+3. For MacOS and Linux, use ``contrib/build_bin.sh``. This needs to be run on a macOS machine for the macOS binary and on a Linux machine for the linux one.
 4. For Windows, use ``contrib/build_wine.sh`` to build the Windows binary using wine
 5. Make ``SHA256SUMS.txt`` using ``contrib/make_shasums.sh``.
 6. Make ``SHA256SUMS.txt.asc`` using ``gpg --clearsign SHA256SUMS.txt``


### PR DESCRIPTION
Alternative to #561

Addresses https://github.com/bitcoin-core/HWI/pull/561#issuecomment-1027110481:

> Instead of a new script, I would prefer if an option were just added to the existing script(s) that would disable the qt build.