### PR TITLE
trezor: Add missing import and minor test fixes following passphrase changes

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -26,6 +26,7 @@ from ..errors import (
     DeviceConnectionError,
     DEVICE_NOT_INITIALIZED,
     DeviceNotReadyError,
+    NoPasswordError,
     UnavailableActionError,
     common_err_msgs,
     handle_errors,

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -352,7 +352,7 @@ class TestTrezorManCommands(TrezorTestCase):
                 break
         else:
             self.fail("Did not enumerate device")
-        result = self.do_command(self.dev_args + ['-p', '', 'enumerate'])
+        result = self.do_command(self.dev_args + ['-p', '\"\"', 'enumerate'])
         for dev in result:
             if dev['type'] == 'trezor' and dev['path'] == 'udp:127.0.0.1:21324':
                 self.assertFalse(dev['needs_passphrase_sent'])

--- a/test/test_trezor.py
+++ b/test/test_trezor.py
@@ -340,7 +340,7 @@ class TestTrezorManCommands(TrezorTestCase):
         result = self.do_command(self.dev_args + ['enumerate'])
         for dev in result:
             if dev['type'] == 'trezor' and dev['path'] == 'udp:127.0.0.1:21324':
-                self.assertTrue(dev['needs_passphrase_sent'])
+                self.assertIn("warnings", dev)
                 break
         else:
             self.fail("Did not enumerate device")


### PR DESCRIPTION
Fixes a couple things were missed following #644 which are causing CI failures in Trezor tests.