### PR TITLE
descriptor.py: fix PubkeyProvider.get_pubkey_bytes for ranged desc

### DIFF
--- a/hwilib/descriptor.py
+++ b/hwilib/descriptor.py
@@ -166,7 +166,7 @@ class PubkeyProvider(object):
             if self.deriv_path is not None:
                 path_str = self.deriv_path[1:]
                 if path_str[-1] == "*":
-                    path_str = path_str[-1] + str(pos)
+                    path_str = path_str[:-1] + str(pos)
                 path = parse_path(path_str)
                 child_key = self.extkey.derive_pub_path(path)
                 return child_key.pubkey


### PR DESCRIPTION
To trigger bug:
```py
>>> from hwilib.descriptor import parse_descriptor
>>> b = parse_descriptor("wsh(multi(1,xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/1/0/*,xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH/0/0/*))") 
>>> b.expand(3).output_script.hex()
Traceback (most recent call last):
  File "/home/user/wspace/HWI/hwilib/key.py", line 361, in parse_path
    return [str_to_harden(x) for x in n]
  File "/home/user/wspace/HWI/hwilib/key.py", line 361, in <listcomp>
    return [str_to_harden(x) for x in n]
  File "/home/user/wspace/HWI/hwilib/key.py", line 358, in str_to_harden
    return int(x)
ValueError: invalid literal for int() with base 10: '*3'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/wspace/HWI/hwilib/descriptor.py", line 385, in expand
    witness_script, _, _ = self.subdescriptors[0].expand(pos)
  File "/home/user/wspace/HWI/hwilib/descriptor.py", line 340, in expand
    der_pks = [p.get_pubkey_bytes(pos) for p in self.pubkeys]
  File "/home/user/wspace/HWI/hwilib/descriptor.py", line 340, in <listcomp>
    der_pks = [p.get_pubkey_bytes(pos) for p in self.pubkeys]
  File "/home/user/wspace/HWI/hwilib/descriptor.py", line 170, in get_pubkey_bytes
    path = parse_path(path_str)
  File "/home/user/wspace/HWI/hwilib/key.py", line 363, in parse_path
    raise ValueError("Invalid BIP32 path", nstr)
ValueError: ('Invalid BIP32 path', '*3')
```