### PR TITLE
trezor: Set multisig change as PAYTOMULTISIG for non-segwit only

### DIFF
--- a/hwilib/devices/trezor.py
+++ b/hwilib/devices/trezor.py
@@ -581,7 +581,8 @@ class TrezorClient(HardwareWalletClient):
                         tx.xpub, psbt_out)
                     if is_ms:
                         txoutput.multisig = multisig
-                        txoutput.script_type = messages.OutputScriptType.PAYTOMULTISIG
+                        if not wit:
+                            txoutput.script_type = messages.OutputScriptType.PAYTOMULTISIG
 
                 # append to outputs
                 outputs.append(txoutput)


### PR DESCRIPTION
`PAYTOMULTISIG` is for P2SH only. For p2sh-segwit and native segwit, the `PAYTOWITNESS` and `PAYTOP2SHWITNESS` that are set earlier are correct.

Fixes #661