### PR TITLE
Add vendor/device IDs for DIY Jade running on M5StickC-Plus and ESP32-Wrover-CAM

### DIFF
--- a/hwilib/devices/jade.py
+++ b/hwilib/devices/jade.py
@@ -58,7 +58,7 @@ import os
 # The test emulator port
 SIMULATOR_PATH = 'tcp:127.0.0.1:30121'
 
-JADE_DEVICE_IDS = [(0x10c4, 0xea60), (0x1a86, 0x55d4)]
+JADE_DEVICE_IDS = [(0x10c4, 0xea60), (0x1a86, 0x55d4), (0x0403, 0x6001)]
 HAS_NETWORKING = hasattr(jade, '_http_request')
 
 py_enumerate = enumerate # To use the enumerate built-in, since the name is overridden below

--- a/hwilib/devices/jade.py
+++ b/hwilib/devices/jade.py
@@ -58,7 +58,7 @@ import os
 # The test emulator port
 SIMULATOR_PATH = 'tcp:127.0.0.1:30121'
 
-JADE_DEVICE_IDS = [(0x10c4, 0xea60), (0x1a86, 0x55d4), (0x0403, 0x6001)]
+JADE_DEVICE_IDS = [(0x10c4, 0xea60), (0x1a86, 0x55d4), (0x0403, 0x6001), (0x1a86, 0x7523)]
 HAS_NETWORKING = hasattr(jade, '_http_request')
 
 py_enumerate = enumerate # To use the enumerate built-in, since the name is overridden below


### PR DESCRIPTION
DIY build of Jade runs great on this hardware, but uses a different device ID.

See https://github.com/3rdIteration/Jade/tree/master/diy
and open PR on main Jade repo here:
https://github.com/Blockstream/Jade/pull/58