### PR TITLE
jade: Remove jade BLE warning

### DIFF
--- a/hwilib/devices/jadepy/jade.py
+++ b/hwilib/devices/jadepy/jade.py
@@ -20,14 +20,6 @@ from .jade_tcp import JadeTCPImpl
 logger = logging.getLogger('jade')
 device_logger = logging.getLogger('jade-device')
 
-# BLE comms backend is optional
-# It relies on the BLE dependencies being available
-try:
-    from .jade_ble import JadeBleImpl
-except ImportError as e:
-    logger.warn(e)
-    logger.warn('BLE scanning/connectivity will not be available')
-
 
 # Default serial connection
 DEFAULT_SERIAL_DEVICE = '/dev/ttyUSB0'


### PR DESCRIPTION
The warning is just noise since we don't use Jade's bluetooth functionality.