### PR TITLE
qt: switch to PySide6

### DIFF
--- a/contrib/generate-ui.sh
+++ b/contrib/generate-ui.sh
@@ -6,7 +6,6 @@ pushd hwilib/ui
 for file in *.ui
 do
     gen_file=ui_`echo $file| cut -d. -f1`.py
-    pyside2-uic $file -o $gen_file
-    sed -i'' -e 's/raise()/raise_()/g' $gen_file
+    pyside6-uic $file -o $gen_file
 done
 popd

--- a/hwilib/_gui.py
+++ b/hwilib/_gui.py
@@ -26,9 +26,9 @@ except ImportError:
     print('Could not import UI files, did you run contrib/generate-ui.sh')
     exit(-1)
 
-from PySide2.QtGui import QRegExpValidator
-from PySide2.QtWidgets import QApplication, QDialog, QDialogButtonBox, QFileDialog, QLineEdit, QMessageBox, QMainWindow, QMenu
-from PySide2.QtCore import QCoreApplication, QRegExp, Signal, Slot
+from PySide6.QtGui import QRegularExpressionValidator
+from PySide6.QtWidgets import QApplication, QDialog, QDialogButtonBox, QFileDialog, QLineEdit, QMessageBox, QMainWindow, QMenu
+from PySide6.QtCore import QCoreApplication, QRegularExpression, Signal, Slot
 
 def do_command(f, *args, **kwargs):
     result = {}
@@ -59,7 +59,7 @@ class SendPinDialog(QDialog):
         self.setWindowTitle('Send Pin')
         self.client = client
         self.ui.pin_lineedit.setFocus()
-        self.ui.pin_lineedit.setValidator(QRegExpValidator(QRegExp("[1-9]+"), None))
+        self.ui.pin_lineedit.setValidator(QRegularExpressionValidator(QRegularExpression("[1-9]+"), None))
         self.ui.pin_lineedit.setEchoMode(QLineEdit.Password)
 
         self.ui.p1_button.clicked.connect(self.button_clicked(1))
@@ -100,7 +100,7 @@ class GetXpubDialog(QDialog):
         self.setWindowTitle('Get xpub')
         self.client = client
 
-        self.ui.path_lineedit.setValidator(QRegExpValidator(QRegExp("m(/[0-9]+['Hh]?)+"), None))
+        self.ui.path_lineedit.setValidator(QRegularExpressionValidator(QRegularExpression("m(/[0-9]+['Hh]?)+"), None))
         self.ui.path_lineedit.setFocus()
         self.ui.buttonBox.button(QDialogButtonBox.Close).setAutoDefault(False)
 
@@ -186,7 +186,7 @@ class SignMessageDialog(QDialog):
         self.setWindowTitle('Sign Message')
         self.client = client
 
-        self.ui.path_lineedit.setValidator(QRegExpValidator(QRegExp("m(/[0-9]+['Hh]?)+"), None))
+        self.ui.path_lineedit.setValidator(QRegularExpressionValidator(QRegularExpression("m(/[0-9]+['Hh]?)+"), None))
         self.ui.msg_textedit.setFocus()
 
         self.ui.signmsg_button.clicked.connect(self.signmsg_button_clicked)
@@ -207,7 +207,7 @@ class DisplayAddressDialog(QDialog):
         self.setWindowTitle('Display Address')
         self.client = client
 
-        self.ui.path_lineedit.setValidator(QRegExpValidator(QRegExp("m(/[0-9]+['Hh]?)+"), None))
+        self.ui.path_lineedit.setValidator(QRegularExpressionValidator(QRegularExpression("m(/[0-9]+['Hh]?)+"), None))
         self.ui.path_lineedit.setFocus()
 
         self.ui.go_button.clicked.connect(self.go_button_clicked)
@@ -239,7 +239,7 @@ class GetKeypoolOptionsDialog(QDialog):
         self.ui.internal_checkbox.setChecked(opts['internal'])
         self.ui.keypool_checkbox.setChecked(opts['keypool'])
         self.ui.account_spinbox.setValue(opts['account'])
-        self.ui.path_lineedit.setValidator(QRegExpValidator(QRegExp(r"m(/[0-9]+['Hh]?)+/\*"), None))
+        self.ui.path_lineedit.setValidator(QRegularExpressionValidator(QRegExp(r"m(/[0-9]+['Hh]?)+/\*"), None))
         if opts['account_used']:
             self.ui.account_radio.setChecked(True)
             self.ui.path_radio.setChecked(False)

--- a/poetry.lock
+++ b/poetry.lock
@@ -804,22 +804,61 @@ files = [
 cp2110 = ["hidapi"]
 
 [[package]]
-name = "pyside2"
-version = "5.15.2.1"
+name = "pyside6"
+version = "6.5.1.1"
 description = "Python bindings for the Qt cross-platform application and UI framework"
 optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <3.11"
+python-versions = "<3.12,>=3.7"
 files = [
-    {file = "PySide2-5.15.2.1-5.15.2-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:b5e1d92f26b0bbaefff67727ccbb2e1b577f2c0164b349b3d6e80febb4c5bde2"},
-    {file = "PySide2-5.15.2.1-5.15.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:235240b6ec8206d9fdf0232472c6ef3241783d480425e5b54796f06e39ed23da"},
-    {file = "PySide2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-abi3-macosx_10_13_intel.whl", hash = "sha256:a9e2e6bbcb5d2ebb421e46e72244a0f4fe0943b2288115f80a863aacc1de1f06"},
-    {file = "PySide2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-abi3-manylinux1_x86_64.whl", hash = "sha256:23886c6391ebd916e835fa1b5ae66938048504fd3a2934ae3189a96cd5ac0b46"},
-    {file = "PySide2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-none-win32.whl", hash = "sha256:439509e53cfe05abbf9a99422a2cbad086408b0f9bf5e6f642ff1b13b1f8b055"},
-    {file = "PySide2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-none-win_amd64.whl", hash = "sha256:af6b263fe63ba6dea7eaebae80aa7b291491fe66f4f0057c0aafe780cc83da9d"},
+    {file = "PySide6-6.5.1.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:dc2d249ea2486526d1bb74e6cf96e2b49f2089cf069ab289a168aa48b5c251d5"},
+    {file = "PySide6-6.5.1.1-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b7b6588527eb1ca45afb8918f109d827f7d248beaec14e7acdaea18883680aee"},
+    {file = "PySide6-6.5.1.1-cp37-abi3-win_amd64.whl", hash = "sha256:1517dd56f7235a98f3e1fcc983d3c8cf3d539b33164815c6e06442a297d2ab0d"},
+    {file = "PySide6-6.5.1.1-pp39-pypy39_pp73-macosx_10_9_universal2.whl", hash = "sha256:a55403254ff7421bea5b8e2196fded24e4a0357d3b1f10d5f01ffc3ae937c71a"},
+    {file = "PySide6-6.5.1.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:25c83843de0aa562631620721e4599eed55bc96747ed869caa631ecf92070951"},
+    {file = "PySide6-6.5.1.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:645c1a99c37a0ce045b23fb35faacf54d98442cc16f621fe1dad2a1d2880e5e3"},
 ]
 
 [package.dependencies]
-shiboken2 = "5.15.2.1"
+PySide6-Addons = "6.5.1.1"
+PySide6-Essentials = "6.5.1.1"
+shiboken6 = "6.5.1.1"
+
+[[package]]
+name = "pyside6-addons"
+version = "6.5.1.1"
+description = "Python bindings for the Qt cross-platform application and UI framework (Addons)"
+optional = true
+python-versions = "<3.12,>=3.7"
+files = [
+    {file = "PySide6_Addons-6.5.1.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:aadda3376a81dbead867380f7ae81d2fe0fb1ffd482bfc10212be8b0d06c2c4c"},
+    {file = "PySide6_Addons-6.5.1.1-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:cf18c88274d6c9c29cccbecb11c72b1f0b0bb077dc044f9b40354f13d0c1c52e"},
+    {file = "PySide6_Addons-6.5.1.1-cp37-abi3-win_amd64.whl", hash = "sha256:d6370dfd03329cdcc91288d64bd1e26a5fc1908958b8a81fea5010a5849db441"},
+    {file = "PySide6_Addons-6.5.1.1-pp39-pypy39_pp73-macosx_10_9_universal2.whl", hash = "sha256:e3ab22776e620d9467ffb2d76be06d5a3b8b3859d77e2e73f65f2b29018645e7"},
+    {file = "PySide6_Addons-6.5.1.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:4e1bc141a7aa9488dc77c9b29ad412e417e601cc8e23050517f7c6c8634feb46"},
+    {file = "PySide6_Addons-6.5.1.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:441f8797d6b01c9dd9b848d0e156b2b5042d71d9266d0a6ded48c9b1cd337821"},
+]
+
+[package.dependencies]
+PySide6-Essentials = "6.5.1.1"
+shiboken6 = "6.5.1.1"
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.5.1.1"
+description = "Python bindings for the Qt cross-platform application and UI framework (Essentials)"
+optional = true
+python-versions = "<3.12,>=3.7"
+files = [
+    {file = "PySide6_Essentials-6.5.1.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:c0cc3b1e7ca0e6b7a0cb8190a8538242972df43c1f9014cc0cd066d4ed7fc83a"},
+    {file = "PySide6_Essentials-6.5.1.1-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:bfd8900b1bf6a595b7d63539817bc825941f737486a093d519514c5b67af789f"},
+    {file = "PySide6_Essentials-6.5.1.1-cp37-abi3-win_amd64.whl", hash = "sha256:1346e6a4e97d97f54e6c0805150c6dead4cc0e7914d77167f836eb36b83acb5c"},
+    {file = "PySide6_Essentials-6.5.1.1-pp39-pypy39_pp73-macosx_10_9_universal2.whl", hash = "sha256:0111386918064fa84a498ed7a6e93ec4155fe96e8d4f9c9e3ac54a5b65ddfadf"},
+    {file = "PySide6_Essentials-6.5.1.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:6264b00099a9bed0020460033e2a4369513e0e69f7abe3f436c3c6390164bcea"},
+    {file = "PySide6_Essentials-6.5.1.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:620cefb6c954d59f941f06acecfe5cdf42bf470f2f3e6b9d023f49f93d740080"},
+]
+
+[package.dependencies]
+shiboken6 = "6.5.1.1"
 
 [[package]]
 name = "pytz"
@@ -892,18 +931,18 @@ testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-202
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
-name = "shiboken2"
-version = "5.15.2.1"
-description = "Python / C++ bindings helper module"
+name = "shiboken6"
+version = "6.5.1.1"
+description = "Python/C++ bindings helper module"
 optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <3.11"
+python-versions = "<3.12,>=3.7"
 files = [
-    {file = "shiboken2-5.15.2.1-5.15.2-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:f890f5611ab8f48b88cfecb716da2ac55aef99e2923198cefcf781842888ea65"},
-    {file = "shiboken2-5.15.2.1-5.15.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:87079c07587859a525b9800d60b1be971338ce9b371d6ead81f15ee5a46d448b"},
-    {file = "shiboken2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-abi3-macosx_10_13_intel.whl", hash = "sha256:ffd3d0ec3d508e592d7ee3885d27fee1f279a49989f734eb130f46d9501273a9"},
-    {file = "shiboken2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-abi3-manylinux1_x86_64.whl", hash = "sha256:63debfcc531b6a2b4985aa9b71433d2ad3bac542acffc729cc0ecaa3854390c0"},
-    {file = "shiboken2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-none-win32.whl", hash = "sha256:eb0da44b6fa60c6bd317b8f219e500595e94e0322b33ec5b4e9f406bedaee555"},
-    {file = "shiboken2-5.15.2.1-5.15.2-cp35.cp36.cp37.cp38.cp39.cp310-none-win_amd64.whl", hash = "sha256:a0d0fdeb12b72c8af349b9642ccc67afd783dca449309f45e78cda50272fd6b7"},
+    {file = "shiboken6-6.5.1.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:59fc1797df38c9e8c89cc43d5996a4c0331d0258087fa9d6466b03822aba6ff2"},
+    {file = "shiboken6-6.5.1.1-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:4338a8eb00e8d6f5b27edf85ab689ada905a4490c73ed3f23ff3b3c5f72a563e"},
+    {file = "shiboken6-6.5.1.1-cp37-abi3-win_amd64.whl", hash = "sha256:aa6289cdbaa12f364f1c45d60d9d483c3842ee9cf6e9acdc3efd21cd460c2eb5"},
+    {file = "shiboken6-6.5.1.1-pp39-pypy39_pp73-macosx_10_9_universal2.whl", hash = "sha256:db029b9d895052c1f42b1f929af3a5f6e688a88c5862aed24d5094086b034ab2"},
+    {file = "shiboken6-6.5.1.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:1c7ba82093d66ace5c7a07ed9c7b4ea57a311ddbfecbe44aff7ed023efc8a380"},
+    {file = "shiboken6-6.5.1.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:34cacba2954bff632476fbead190868c6f068a6dd9e5c8fd7d2ed4f8f5cfade4"},
 ]
 
 [[package]]
@@ -1198,9 +1237,9 @@ docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker
 testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-qt = ["pyside2"]
+qt = ["pyside6"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7,<3.12"
-content-hash = "fb58d9f81e83da6ac11708f02d1d0503daef1c29dcc5e77b1997868a221cb574"
+content-hash = "8521ea85461d03321da689da66301e922e0b15df50d961e1aba1df90d25c4ab3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ pyaes = "^1.6"
 mnemonic = "~0"
 typing-extensions = "^4.4"
 libusb1 = ">=1.7,<4"
-pyside2 = { version = "^5.14.0", optional = true, python = "<3.10" }
+pyside6 = { version = ">=6.0,<7.0", optional = true }
 cbor = "^1.0.0"
 pyserial = "^3.5"
 dataclasses = {version = "^0.8", python = ">=3.6,<3.7"}
@@ -32,7 +32,7 @@ noiseprotocol = "^0.3.1"
 protobuf = "^4.23.3"
 
 [tool.poetry.extras]
-qt = ["pyside2"]
+qt = ["pyside6"]
 
 [tool.poetry.dev-dependencies]
 pyinstaller = "^5.3"


### PR DESCRIPTION
PySide2 uses Qt5 which is no longer maintained. PySide6 uses Qt6 and is the current version of Qt, so we should switch to that. This also lets us build the GUI for Apple Silicon macs.

TODOs:
* Binary builds (debian oldoldstable doesn't have qt6)