### PR TITLE
build: Use a separate container for Windows builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -169,7 +169,7 @@ task:
 
 wine_builder_task:
   container:
-    dockerfile: contrib/build.Dockerfile
+    dockerfile: contrib/build-wine.Dockerfile
   build_script:
     - contrib/build_wine.sh
     - find dist -type f -exec sha256sum {} \;

--- a/contrib/build-wine.Dockerfile
+++ b/contrib/build-wine.Dockerfile
@@ -1,0 +1,30 @@
+FROM debian:oldoldstable-slim
+
+SHELL ["/bin/bash", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y \
+    build-essential \
+    g++-mingw-w64-x86-64 \
+    faketime \
+    dos2unix \
+    zip \
+    wget
+
+RUN dpkg --add-architecture i386
+RUN wget -nc https://dl.winehq.org/wine-builds/winehq.key
+RUN apt-key add winehq.key
+RUN echo "deb https://dl.winehq.org/wine-builds/debian/ stretch main" >> /etc/apt/sources.list
+RUN apt-get update
+RUN apt-get install --install-recommends -y \
+    wine-stable-amd64 \
+    wine-stable-i386 \
+    wine-stable \
+    winehq-stable \
+    p7zip-full
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV LANGUAGE=C.UTF-8
+

--- a/contrib/build.Dockerfile
+++ b/contrib/build.Dockerfile
@@ -27,8 +27,6 @@ RUN apt-get install -y \
     libudev-dev \
     faketime \
     zip \
-    dos2unix \
-    g++-mingw-w64-x86-64 \
     qt5-default
 
 RUN curl https://pyenv.run | bash
@@ -40,18 +38,6 @@ ENV PYTHON_CONFIGURE_OPTS="--enable-shared"
 ENV BUILD_DATE="Jan  1 2019"
 ENV BUILD_TIME="00:00:00"
 RUN eval "$(pyenv init --path)" && eval "$(pyenv virtualenv-init -)" && cat /opt/reproducible-python.diff | pyenv install -kp 3.9.7
-
-RUN dpkg --add-architecture i386
-RUN wget -nc https://dl.winehq.org/wine-builds/winehq.key
-RUN apt-key add winehq.key
-RUN echo "deb https://dl.winehq.org/wine-builds/debian/ stretch main" >> /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get install --install-recommends -y \
-    wine-stable-amd64 \
-    wine-stable-i386 \
-    wine-stable \
-    winehq-stable \
-    p7zip-full
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/docs/development/release-process.rst
+++ b/docs/development/release-process.rst
@@ -13,13 +13,15 @@ Release Process
 Deterministic builds with Docker
 ================================
 
-Create the docker image::
+Create the docker images::
 
     docker build --no-cache -t hwi-builder -f contrib/build.Dockerfile .
+    docker build --no-cache -t hwi-wine-builder -f contrib/build-wine.Dockerfile .
 
 Build everything::
 
-    docker run -it --name hwi-builder -v $PWD:/opt/hwi --rm  --workdir /opt/hwi hwi-builder /bin/bash -c "contrib/build_bin.sh && contrib/build_dist.sh && contrib/build_wine.sh"
+    docker run -it --name hwi-builder -v $PWD:/opt/hwi --rm  --workdir /opt/hwi hwi-builder /bin/bash -c "contrib/build_bin.sh && contrib/build_dist.sh"
+    docker run -it --name hwi-wine-builder -v $PWD:/opt/hwi --rm  --workdir /opt/hwi hwi-wine-builder /bin/bash -c "contrib/build_wine.sh"
 
 Building macOS binary
 =====================


### PR DESCRIPTION
Windows builds with WINE should use a separate container so that builds on architectures that don't have WINE will still work.