### PR TITLE
build: Detect architecture and use x86_64 naming

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -322,7 +322,7 @@ task:
       install_script: pip install dist/*.whl
       test_script: cd test; ./run_tests.py $DEVICE --interface=cli --device-only; cd ..
     - name: Python $PYTHON $DEVICE Sdist
-      install_script: pip install $(find dist -name "*.tar.gz" -a -not -name "*amd64*")
+      install_script: pip install $(find dist -name "*.tar.gz" -a -not -name "*linux*")
       test_script: cd test; ./run_tests.py $DEVICE --interface=cli --device-only; cd ..
     - name: Python $PYTHON $DEVICE Bindist
       install_script: poetry install

--- a/contrib/build_bin.sh
+++ b/contrib/build_bin.sh
@@ -40,7 +40,8 @@ OS=`uname | tr '[:upper:]' '[:lower:]'`
 if [[ $OS == "darwin" ]]; then
     OS="mac"
 fi
-target_tarfile="hwi-${VERSION}-${OS}-amd64.tar.gz"
+ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+target_tarfile="hwi-${VERSION}-${OS}-${ARCH}.tar.gz"
 
 if [[ $gui_support == "--with-gui" ]]; then
     tar -czf $target_tarfile hwi hwi-qt

--- a/contrib/build_wine.sh
+++ b/contrib/build_wine.sh
@@ -88,7 +88,7 @@ unset PYTHONHASHSEED
 # Make the final compressed package
 pushd dist
 VERSION=`$POETRY run hwi --version | cut -d " " -f 2 | dos2unix`
-target_zipfile="hwi-${VERSION}-windows-amd64.zip"
+target_zipfile="hwi-${VERSION}-windows-x86_64.zip"
 zip $target_zipfile hwi.exe hwi-qt.exe
 
 # Copy the binaries to subdir for shasum


### PR DESCRIPTION
We want to build on other architectures in the future, so change binary build naming to support detecting those architectures.

Also renames amd64 to the standard x86_64 for the windows build.