### PR TITLE
use warning instead of deprecated warn

### DIFF
--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -118,7 +118,7 @@ def enumerate(password: Optional[str] = None, expert: bool = False, chain: Chain
         except ImportError as e:
             # Warn for ImportErrors, but largely ignore them to allow users not install
             # all device dependencies if only one or some devices are wanted.
-            logging.warn(f"{e}, required for {module}. Ignore if you do not want this device.")
+            logging.warning(f"{e}, required for {module}. Ignore if you do not want this device.")
             pass
     return result
 

--- a/hwilib/devices/jadepy/jade.py
+++ b/hwilib/devices/jadepy/jade.py
@@ -1541,7 +1541,7 @@ class JadeInterface:
         Log any/all outstanding messages/data.
         NOTE: can run indefinitely if data is arriving constantly.
         """
-        logger.warn("Draining interface...")
+        logger.warning("Draining interface...")
         drained = bytearray()
         finished = False
 
@@ -1552,14 +1552,14 @@ class JadeInterface:
 
             if finished or byte_ == b'\n' or len(drained) > 256:
                 try:
-                    device_logger.warn(drained.decode('utf-8'))
+                    device_logger.warning(drained.decode('utf-8'))
                 except Exception as e:
                     # Dump the bytes raw and as hex if decoding as utf-8 failed
-                    device_logger.warn("Raw:")
-                    device_logger.warn(drained)
-                    device_logger.warn("----")
-                    device_logger.warn("Hex dump:")
-                    device_logger.warn(drained.hex())
+                    device_logger.warning("Raw:")
+                    device_logger.warning(drained)
+                    device_logger.warning("----")
+                    device_logger.warning("Hex dump:")
+                    device_logger.warning(drained.hex())
 
                 # Clear and loop to continue collecting
                 drained.clear()
@@ -1693,7 +1693,7 @@ class JadeInterface:
                         response = message['log'].decode("utf-8")
                         log_methods = {
                             'E': device_logger.error,
-                            'W': device_logger.warn,
+                            'W': device_logger.warning,
                             'I': device_logger.info,
                             'D': device_logger.debug,
                             'V': device_logger.debug,


### PR DESCRIPTION
logging.warn has been deprecated since Python 3.3 and one should use logging.warning

see also https://github.com/Blockstream/Jade/pull/77