### PR TITLE
gui: add chain in the title

### DIFF
--- a/hwilib/_gui.py
+++ b/hwilib/_gui.py
@@ -325,7 +325,7 @@ class HWIQt(QMainWindow):
         super(HWIQt, self).__init__()
         self.ui = Ui_MainWindow()
         self.ui.setupUi(self)
-        self.setWindowTitle('HWI Qt')
+        self.setWindowTitle(f'HWI Qt - {chain}')
 
         self.devices = []
         self.client = None


### PR DESCRIPTION
It allows to identify the chain (main, test, etc)
when using the GUI.