### PR TITLE
test/test_device: do not enforce a password

### DIFF
--- a/test/test_device.py
+++ b/test/test_device.py
@@ -41,7 +41,8 @@ class DeviceEmulator():
         assert self.path is not None
         assert self.fingerprint is not None
         assert self.master_xpub is not None
-        assert self.password is not None
+        # No need to check that self.password is not None, as it can be None if the device does not
+        # accept a password/passphrase from the host.
         assert self.supports_ms_display is not None
         assert self.supports_xpub_ms_display is not None
         assert self.supports_unsorted_ms is not None


### PR DESCRIPTION
According to the type in `HardwareWalletClient`, password is optional and can be `None`:

```
def __init__(self, path: str, password: Optional[str], expert: bool, chain: Chain = Chain.MAIN) -> None:
```

The test code also expects that it can be `None`, e.g.:

https://github.com/bitcoin-core/HWI/blob/d774d65255e1e78ea4d97846c2b4d26a23febcfb/test/test_device.py#L140

The BitBox02 client in fact checks that it must be `None` and raises a `BadArgumentError` otherwise, as the BitBox02 does not accept any password/passphrase from the host:

https://github.com/bitcoin-core/HWI/blob/d774d65255e1e78ea4d97846c2b4d26a23febcfb/hwilib/devices/bitbox02.py#L266

Other devices like the Jade also don't take a host password/passphrase, and simply ignore the param. We could also do this for the BitBox02 (not raise any error if a password is supplied), but the right solution is to not enforce a password in the tests.

This commit is in preparation of adding a BitBox02 simulator with tests.