### PR TITLE
descriptor.py: fix parsing tr() desc with single leaf TREE

### DIFF
--- a/hwilib/descriptor.py
+++ b/hwilib/descriptor.py
@@ -473,6 +473,8 @@ def _get_expr(s: str) -> Tuple[str, str]:
             level -= 1
         elif level == 0 and c in [")", "}", ","]:
             break
+    else:
+        return s, ""
     return s[0:i], s[i:]
 
 def parse_pubkey(expr: str) -> Tuple['PubkeyProvider', str]:

--- a/test/test_descriptor.py
+++ b/test/test_descriptor.py
@@ -205,5 +205,15 @@ class TestDescriptor(unittest.TestCase):
         self.assertEqual(desc.depths, [1, 3, 3, 2])
         self.assertEqual(desc.to_string_no_checksum(), d)
 
+        d = "tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd,pk(669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0))"
+        desc = parse_descriptor(d)
+        self.assertTrue(isinstance(desc, TRDescriptor))
+        self.assertEqual(len(desc.subdescriptors), 1)
+        self.assertEqual(desc.pubkeys[0].pubkey, "a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd")
+        self.assertEqual(desc.depths, [0])
+        self.assertEqual(desc.subdescriptors[0].pubkeys[0].pubkey, "669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0")
+        self.assertEqual(desc.to_string_no_checksum(), d)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`tr()` descriptors with a single leaf TREE expression cannot be parsed currently:
```py
>>> from hwilib.descriptor import parse_descriptor
>>> b = parse_descriptor("tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd,pk(669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0))") 
Traceback (most recent call last):
  File "/home/user/wspace/HWI/hwilib/descriptor.py", line 437, in _get_func_expr
    end = s.rindex(")")
ValueError: substring not found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/wspace/HWI/hwilib/descriptor.py", line 637, in parse_descriptor
    return _parse_descriptor(desc, _ParseDescriptorContext.TOP)
  File "/home/user/wspace/HWI/hwilib/descriptor.py", line 600, in _parse_descriptor
    subscripts.append(_parse_descriptor(sarg, _ParseDescriptorContext.P2TR))
  File "/home/user/wspace/HWI/hwilib/descriptor.py", line 527, in _parse_descriptor
    func, expr = _get_func_expr(desc)
  File "/home/user/wspace/HWI/hwilib/descriptor.py", line 440, in _get_func_expr
    raise ValueError("A matching pair of parentheses cannot be found")
ValueError: A matching pair of parentheses cannot be found
```