### PR TITLE
ci: fix coldcard build

### DIFF
--- a/.github/actions/install-sim/action.yml
+++ b/.github/actions/install-sim/action.yml
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: |
         apt-get update
-        apt-get install -y libpcsclite-dev libusb-1.0-0 swig
+        apt-get install -y libpcsclite-dev libusb-1.0-0 swig libsdl2-dev
         git config --global user.email "ci@ci.com"
         git config --global user.name "ci"
         pushd test/work; git clone --recursive https://github.com/Coldcard/firmware.git; popd


### PR DESCRIPTION
The coldcard job (for different python versions) is failling due to the following error: 

From CI (e.g https://github.com/bitcoin-core/HWI/actions/runs/10762544360/job/29843131139):
```
Traceback (most recent call last):
  File "/github/home/.cache/pypoetry/virtualenvs/hwi-crEDFiR--py3.8/lib/python3.8/site-packages/sdl2/dll.py", line 362, in <module>
    dll = DLL("SDL2", ["SDL2", "SDL2-2.0", "SDL2-2.0.0"], os.getenv("PYSDL2_DLL_PATH"))
  File "/github/home/.cache/pypoetry/virtualenvs/hwi-crEDFiR--py3.8/lib/python3.8/site-packages/sdl2/dll.py", line 253, in __init__
    raise RuntimeError("could not find any library for %s (%s)" %
RuntimeError: could not find any library for SDL2 (PYSDL2_DLL_PATH: unset)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "simulator.py", line 20, in <module>
    import sdl2.ext
  File "/github/home/.cache/pypoetry/virtualenvs/hwi-crEDFiR--py3.8/lib/python3.8/site-packages/sdl2/__init__.py", line 2, in <module>
    from .dll import get_dll_file, _bind
  File "/github/home/.cache/pypoetry/virtualenvs/hwi-crEDFiR--py3.8/lib/python3.8/site-packages/sdl2/dll.py", line 364, in <module>
    raise ImportError(exc)
ImportError: could not find any library for SDL2 (PYSDL2_DLL_PATH: unset)
coldcard: test_backup (test_coldcard.TestColdcardManCommands) ... 
```

According to the coldcard documentation (https://github.com/Coldcard/firmware?tab=readme-ov-file#linux), besides running `pip install -r requirements.txt`, it's required to install `pysdl2-dll`.