### PR TITLE
allow "hwi signtx -"

### DIFF
--- a/hwilib/_cli.py
+++ b/hwilib/_cli.py
@@ -160,7 +160,7 @@ def get_parser() -> HWIArgumentParser:
     getmasterxpub_parser.set_defaults(func=getmasterxpub_handler)
 
     signtx_parser = subparsers.add_parser('signtx', help='Sign a PSBT')
-    signtx_parser.add_argument('psbt', help='The Partially Signed Bitcoin Transaction to sign')
+    signtx_parser.add_argument('psbt', help='The Partially Signed Bitcoin Transaction to sign or special charater "-" to read the PSBT from standard input')
     signtx_parser.set_defaults(func=signtx_handler)
 
     getxpub_parser = subparsers.add_parser('getxpub', help='Get an extended public key')


### PR DESCRIPTION
Enhanced `signtx` to accept special character `-` to indicate to read the base64-encoded PSBT from the stdin instead of from the command line. This allows running commands like
`xclip -o -selection clipboard | hwi -t <device> signtx -`.