### PR TITLE
2 new commandline arguments: --clipin and --clipout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,11 @@ libusb1 = ">=1.7,<4"
 pyside2 = { version = "^5.14.0", optional = true, python = "<3.10" }
 cbor2 = "^5.4.6"
 pyserial = "^3.5"
-dataclasses = {version = "^0.8", python = ">=3.6,<3.7"}
+dataclasses = { version = "^0.8", python = ">=3.6,<3.7" }
 semver = "^3.0.1"
 noiseprotocol = "^0.3.1"
 protobuf = "^4.23.3"
+pyperclip = "^1.9.0"
 
 [tool.poetry.extras]
 qt = ["pyside2"]

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ install_requires = \
  'protobuf>=4.23.3,<5.0.0',
  'pyaes>=1.6,<2.0',
  'pyserial>=3.5,<4.0',
+ 'pyperclip>=1.9.0,<2.0.0',
  'semver>=3.0.1,<4.0.0',
  'typing-extensions>=4.4,<5.0']
 


### PR DESCRIPTION
Added 2 new features, implemented as 2 new command line arguments:

- `--clipin`: similar to --stdin, reads arguments from clipboard
- `--clipout`: for selected commands writes output additionally to clipboard
- example use case: `hwi -t $DEVICE --clipin --clipout signtx # works well in combination with e.g. Bitcoin Core wallet`