### PR TITLE
Support testnet4 chain

### DIFF
--- a/hwilib/common.py
+++ b/hwilib/common.py
@@ -18,6 +18,7 @@ class Chain(Enum):
     TEST = 1 #: Bitcoin Test network
     REGTEST = 2 #: Bitcoin Core Regression Test network
     SIGNET = 3 #: Bitcoin Signet
+    TESTNET4 = 4 #: Bitcoin Test network
 
     def __str__(self) -> str:
         return str(self.name).lower()


### PR DESCRIPTION
Otherwise, HWI fails with the following error when used as a external signer for Bitcoin Core 28.0:

    {"error": "hwi.py: error: argument --chain: invalid choice: 'testnet4' (choose from main, test, regtest, signet)", "code": -2}