### PR TITLE
ledger: handle script path (use SignPsbtYieldedObject)

### DIFF
--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -363,9 +363,11 @@ class LedgerClient(HardwareWalletClient):
                 is_wit, wit_ver, _ = utxo.is_witness()
 
                 if is_wit and wit_ver >= 1:
-                    # TODO: Deal with script path signatures
-                    # For now, assume key path signature
-                    psbt_in.tap_key_sig = yielded.signature
+                    if yielded.tapleaf_hash is None:
+                        psbt_in.tap_key_sig = yielded.signature
+                    else:
+                        psbt_in.tap_script_sigs[(yielded.pubkey, yielded.tapleaf_hash)] = yielded.signature
+
                 else:
                     psbt_in.partial_sigs[yielded.pubkey] = yielded.signature
 

--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -209,9 +209,9 @@ class LedgerClient(HardwareWalletClient):
             wallet = WalletPolicy("", "wpkh(@0/**)", [""])
             legacy_input_sigs = client.sign_psbt(tx, wallet, None)
 
-            for idx, pubkey, sig in legacy_input_sigs:
+            for idx, partial_sig in legacy_input_sigs:
                 psbt_in = tx.inputs[idx]
-                psbt_in.partial_sigs[pubkey] = sig
+                psbt_in.partial_sigs[partial_sig.pubkey] = partial_sig.signature
             return tx
 
         if isinstance(self.client, LegacyClient):
@@ -349,7 +349,7 @@ class LedgerClient(HardwareWalletClient):
 
             input_sigs = self.client.sign_psbt(psbt2, wallet, wallet_hmac)
 
-            for idx, pubkey, sig in input_sigs:
+            for idx, yielded in input_sigs:
                 psbt_in = psbt2.inputs[idx]
 
                 utxo = None
@@ -365,9 +365,9 @@ class LedgerClient(HardwareWalletClient):
                 if is_wit and wit_ver >= 1:
                     # TODO: Deal with script path signatures
                     # For now, assume key path signature
-                    psbt_in.tap_key_sig = sig
+                    psbt_in.tap_key_sig = yielded.signature
                 else:
-                    psbt_in.partial_sigs[pubkey] = sig
+                    psbt_in.partial_sigs[yielded.pubkey] = yielded.signature
 
         # Extract the sigs from psbt2 and put them into tx
         for sig_in, psbt_in in zip(psbt2.inputs, tx.inputs):


### PR DESCRIPTION
Recent versions of the Ledger app changed the `sign_psbt` to return a `SignPsbtYieldedObject ` instead of `bytes, bytes`.

For our purposes this yielded object is just a `PartialSignature`, but once we're ready to add MuSig2 support it can also yield `MusigPubNonce` (round 1) and `MusigPartialSignature` (round 2).