### PR TITLE
add an automated release process with build provenance attestations, documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,483 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g., 3.1.1)"
+        required: true
+        type: string
+      create_release:
+        description: "Create GitHub release"
+        required: true
+        type: boolean
+        default: true
+
+env:
+  LC_ALL: C.UTF-8
+  LANG: C.UTF-8
+  LANGUAGE: C.UTF-8
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Validate version consistency before building
+  validate:
+    name: Validate Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version from tag or input
+        id: get_version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            # Extract version from tag (semver format, no 'v' prefix)
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Building version: $VERSION"
+
+      - name: Verify version in pyproject.toml
+        run: |
+          PYPROJECT_VERSION=$(grep -Po '(?<=^version = ")[^"]*' pyproject.toml)
+          echo "pyproject.toml version: $PYPROJECT_VERSION"
+          echo "Expected version: ${{ steps.get_version.outputs.version }}"
+          if [ "$PYPROJECT_VERSION" != "${{ steps.get_version.outputs.version }}" ]; then
+            echo "::warning::Version mismatch: pyproject.toml has $PYPROJECT_VERSION but releasing ${{ steps.get_version.outputs.version }}"
+          fi
+
+      - name: Verify version in hwilib/__init__.py
+        run: |
+          INIT_VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' hwilib/__init__.py)
+          echo "hwilib/__init__.py version: $INIT_VERSION"
+          echo "Expected version: ${{ steps.get_version.outputs.version }}"
+          if [ "$INIT_VERSION" != "${{ steps.get_version.outputs.version }}" ]; then
+            echo "::warning::Version mismatch: hwilib/__init__.py has $INIT_VERSION but releasing ${{ steps.get_version.outputs.version }}"
+          fi
+
+  # Build Linux x86_64 binaries and Python distributions
+  build-linux:
+    name: Build Linux x86_64
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: |
+          docker build --no-cache -t hwi-builder -f contrib/build.Dockerfile .
+
+      - name: Build binaries and distributions
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/opt/hwi \
+            --workdir /opt/hwi \
+            hwi-builder \
+            /bin/bash -c "contrib/build_bin.sh && contrib/build_dist.sh"
+
+      - name: List build artifacts
+        run: |
+          echo "=== dist/ contents ==="
+          ls -la dist/
+          echo ""
+          echo "=== Artifact details ==="
+          find dist/ -type f -exec sha256sum {} \;
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-x86_64-artifacts
+          path: |
+            dist/hwi-*-linux-*.tar.gz
+          retention-days: 5
+
+      - name: Upload Python distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist-artifacts
+          path: |
+            dist/*.whl
+            dist/hwi-*.tar.gz
+            !dist/hwi-*-linux-*.tar.gz
+            !dist/hwi-*-windows-*.zip
+          retention-days: 5
+
+  # Build Linux ARM64 binaries (without GUI)
+  build-linux-arm64:
+    name: Build Linux ARM64
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ARM64 Docker image
+        run: |
+          docker buildx build \
+            --no-cache \
+            --platform linux/arm64 \
+            --load \
+            -t hwi-builder-arm64 \
+            -f contrib/build.Dockerfile .
+
+      - name: Build ARM64 binaries
+        run: |
+          docker run --rm \
+            --platform linux/arm64 \
+            -v ${{ github.workspace }}:/opt/hwi \
+            --workdir /opt/hwi \
+            hwi-builder-arm64 \
+            /bin/bash -c "contrib/build_bin.sh --without-gui"
+
+      - name: List build artifacts
+        run: |
+          echo "=== dist/ contents ==="
+          ls -la dist/
+          echo ""
+          echo "=== Artifact details ==="
+          find dist/ -type f -name "*arm*" -exec sha256sum {} \;
+
+      - name: Upload ARM64 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-arm64-artifacts
+          path: |
+            dist/hwi-*-linux-*.tar.gz
+          retention-days: 5
+
+  # Build macOS x86_64 binaries (Intel)
+  build-macos-intel:
+    name: Build macOS x86_64
+    needs: validate
+    runs-on: macos-15-intel
+    env:
+      PYTHON_VERSION: "3.9.19"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew install pyenv
+          # Install libusb only if not already present
+          brew list libusb &>/dev/null || brew install libusb
+
+      - name: Setup pyenv and install Python
+        run: |
+          echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
+          echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
+          echo 'eval "$(pyenv init --path)"' >> ~/.bash_profile
+          echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bash_profile
+          source ~/.bash_profile
+
+          # Install Python with the reproducible patch
+          cat contrib/reproducible-python.diff | \
+            PYTHON_CONFIGURE_OPTS="--enable-framework" \
+            BUILD_DATE="Jan  1 2019" \
+            BUILD_TIME="00:00:00" \
+            pyenv install -kp ${{ env.PYTHON_VERSION }}
+
+          pyenv global ${{ env.PYTHON_VERSION }}
+
+      - name: Build macOS binaries
+        run: |
+          source ~/.bash_profile
+          eval "$(pyenv init --path)"
+          eval "$(pyenv virtualenv-init -)"
+          contrib/build_bin.sh --with-gui
+
+      - name: List build artifacts
+        run: |
+          echo "=== dist/ contents ==="
+          ls -la dist/
+          echo ""
+          echo "=== Artifact details ==="
+          find dist/ -type f -name "*mac*" -exec shasum -a 256 {} \;
+
+      - name: Upload macOS Intel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-x86_64-artifacts
+          path: |
+            dist/hwi-*-mac-*.tar.gz
+          retention-days: 5
+
+  # Build macOS ARM64 binaries (Apple Silicon)
+  build-macos-arm:
+    name: Build macOS ARM64
+    needs: validate
+    runs-on: macos-15
+    env:
+      PYTHON_VERSION: "3.9.19"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew install pyenv
+          # libusb is pre-installed on macos-15 ARM runners
+          brew list libusb &>/dev/null || brew install libusb
+
+      - name: Setup pyenv and install Python
+        run: |
+          echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
+          echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
+          echo 'eval "$(pyenv init --path)"' >> ~/.zshrc
+          echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.zshrc
+          source ~/.zshrc
+
+          # Install Python with the reproducible patch
+          cat contrib/reproducible-python.diff | \
+            PYTHON_CONFIGURE_OPTS="--enable-framework" \
+            BUILD_DATE="Jan  1 2019" \
+            BUILD_TIME="00:00:00" \
+            pyenv install -kp ${{ env.PYTHON_VERSION }}
+
+          pyenv global ${{ env.PYTHON_VERSION }}
+
+      - name: Build macOS binaries
+        run: |
+          source ~/.zshrc
+          eval "$(pyenv init --path)"
+          eval "$(pyenv virtualenv-init -)"
+          # ARM64 builds without GUI (Qt not supported)
+          contrib/build_bin.sh --without-gui
+
+      - name: List build artifacts
+        run: |
+          echo "=== dist/ contents ==="
+          ls -la dist/
+          echo ""
+          echo "=== Artifact details ==="
+          find dist/ -type f -name "*mac*" -exec shasum -a 256 {} \;
+
+      - name: Upload macOS ARM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-arm64-artifacts
+          path: |
+            dist/hwi-*-mac-*.tar.gz
+          retention-days: 5
+
+  # Build Windows binaries using Wine
+  build-windows:
+    name: Build Windows x86_64
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Wine Docker image
+        run: |
+          docker build --no-cache -t hwi-wine-builder -f contrib/build-wine.Dockerfile .
+
+      - name: Build Windows binaries
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/opt/hwi \
+            --workdir /opt/hwi \
+            hwi-wine-builder \
+            /bin/bash -c "contrib/build_wine.sh"
+
+      - name: List build artifacts
+        run: |
+          echo "=== dist/ contents ==="
+          ls -la dist/
+          echo ""
+          echo "=== Artifact details ==="
+          find dist/ -type f -name "*windows*" -exec sha256sum {} \;
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-x86_64-artifacts
+          path: |
+            dist/hwi-*-windows-*.zip
+          retention-days: 5
+
+  # Generate checksums, attest artifacts, and create release
+  release:
+    name: Create Release
+    needs:
+      [
+        validate,
+        build-linux,
+        build-linux-arm64,
+        build-macos-intel,
+        build-macos-arm,
+        build-windows,
+      ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Organize artifacts
+        run: |
+          mkdir -p release
+          find artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.whl" \) -exec cp {} release/ \;
+          echo "=== Release artifacts ==="
+          ls -la release/
+
+      - name: Generate SHA256SUMS
+        run: |
+          cd release
+          sha256sum * > SHA256SUMS.txt
+          echo "=== SHA256SUMS.txt ==="
+          cat SHA256SUMS.txt
+
+      - name: Attest Linux x86_64 binary
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: release/hwi-*-linux-x86_64.tar.gz
+
+      - name: Attest Linux ARM64 binary
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: release/hwi-*-linux-aarch64.tar.gz
+
+      - name: Attest macOS Intel binary
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: release/hwi-*-mac-x86_64.tar.gz
+
+      - name: Attest macOS ARM binary
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: release/hwi-*-mac-arm64.tar.gz
+
+      - name: Attest Windows binary
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: release/hwi-*-windows-x86_64.zip
+
+      - name: Attest Python wheel
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: release/*.whl
+
+      - name: Attest Python sdist
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: release/hwi-${{ needs.validate.outputs.version }}.tar.gz
+
+      - name: Attest SHA256SUMS
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: release/SHA256SUMS.txt
+
+      - name: Generate release notes
+        id: release_notes
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          UPSTREAM_COMMIT=$(git rev-parse HEAD)
+
+          cat << EOF > release_notes.md
+          ## HWI $VERSION
+
+          Hardware Wallet Interface - command line tool and Python library for interacting with hardware wallets.
+
+          ### Build Information
+          - **Version:** $VERSION
+          - **Commit:** \`$UPSTREAM_COMMIT\`
+          - **Build date:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+
+          ### Artifacts
+
+          | Platform | Architecture | GUI | File |
+          |----------|--------------|-----|------|
+          | Linux | x86_64 | ✅ | \`hwi-$VERSION-linux-x86_64.tar.gz\` |
+          | Linux | aarch64 | ❌ | \`hwi-$VERSION-linux-aarch64.tar.gz\` |
+          | macOS | x86_64 (Intel) | ✅ | \`hwi-$VERSION-mac-x86_64.tar.gz\` |
+          | macOS | arm64 (Apple Silicon) | ❌ | \`hwi-$VERSION-mac-arm64.tar.gz\` |
+          | Windows | x86_64 | ✅ | \`hwi-$VERSION-windows-x86_64.zip\` |
+          | Python | any | ✅ | \`hwi-$VERSION-py3-none-any.whl\` |
+
+          ### Verification
+
+          This release uses [immutable releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#immutable-releases) and [artifact attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) to provide cryptographic proof of build provenance.
+
+          **Download artifacts first**, either from the GitHub release page or via CLI:
+          \`\`\`bash
+          # Download a specific asset
+          gh release download $VERSION --repo bitcoin-core/HWI --pattern 'hwi-*-linux-x86_64.tar.gz'
+
+          # Or download all assets
+          gh release download $VERSION --repo bitcoin-core/HWI
+          \`\`\`
+
+          **Verify Immutable Release Assets:**
+          \`\`\`bash
+          # Verify a specific asset was published via immutable release
+          gh release verify-asset hwi-$VERSION-linux-x86_64.tar.gz --repo bitcoin-core/HWI
+
+          # Or verify all downloaded assets
+          for f in hwi-$VERSION* SHA256SUMS.txt; do gh release verify-asset "\$f" --repo bitcoin-core/HWI; done
+          \`\`\`
+
+          **Verify Artifact Attestations:**
+          \`\`\`bash
+          # Verify build provenance attestation for a specific artifact
+          gh attestation verify hwi-$VERSION-linux-x86_64.tar.gz --repo bitcoin-core/HWI
+
+          # Or verify all downloaded assets
+          for f in hwi-$VERSION* SHA256SUMS.txt; do gh attestation verify "\$f" --repo bitcoin-core/HWI; done
+
+          # Successful verification confirms:
+          # - The artifact was built by GitHub Actions in this repository
+          # - The specific workflow file and commit that produced it
+          # - The artifact has not been modified since the build
+          \`\`\`
+
+          **SHA256 Checksums:**
+          \`\`\`bash
+          # Download SHA256SUMS.txt and verify file integrity
+          sha256sum -c SHA256SUMS.txt
+          \`\`\`
+          EOF
+
+          echo "Generated release notes"
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push' || inputs.create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: HWI ${{ needs.validate.outputs.version }}
+          body_path: release_notes.md
+          fail_on_unmatched_files: true
+          files: |
+            release/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload release artifacts (for workflow_dispatch without release)
+        if: github.event_name == 'workflow_dispatch' && !inputs.create_release
+        uses: actions/upload-artifact@v4
+        with:
+          name: all-release-artifacts
+          path: release/
+          retention-days: 30

--- a/docs/development/release-process.rst
+++ b/docs/development/release-process.rst
@@ -1,17 +1,277 @@
 Release Process
 ***************
 
-1. Bump version number in ``pyproject.toml`` and ``hwilib/__init__.py``, generate the setup.py file, and git tag release
-2. Build distribution archives for PyPi with ``contrib/build_dist.sh``
-3. For MacOS and Linux, use ``contrib/build_bin.sh``. This needs to be run on a macOS machine for the macOS binary and on a Linux machine for the linux one.
-4. For Windows, use ``contrib/build_wine.sh`` to build the Windows binary using wine
-5. Make ``SHA256SUMS.txt`` using ``contrib/make_shasums.sh``.
-6. Make ``SHA256SUMS.txt.asc`` using ``gpg --clearsign SHA256SUMS.txt``
-7. Upload distribution archives to PyPi
-8. Upload distribution archives and standalone binaries to Github
+Automated Release Process
+=========================
+
+HWI uses GitHub Actions to automate the release process. The workflow is defined
+in ``.github/workflows/release.yml``.
+
+Creating a Release
+------------------
+
+1. Update version numbers in both files:
+
+   - ``pyproject.toml`` - the ``version`` field
+   - ``hwilib/__init__.py`` - the ``__version__`` variable
+
+2. Commit the version bump::
+
+    git add pyproject.toml hwilib/__init__.py
+    git commit -m "Bump version to X.Y.Z"
+
+3. Create and push a signed tag::
+
+    git tag -s X.Y.Z -m "Release X.Y.Z"
+    git push origin X.Y.Z
+
+4. The GitHub Actions workflow will automatically:
+
+   - Validate version consistency
+   - Build Linux x86_64 binaries (with GUI)
+   - Build Linux ARM64 binaries (without GUI)
+   - Build macOS x86_64 Intel binaries (with GUI)
+   - Build macOS ARM64 Apple Silicon binaries (without GUI)
+   - Build Windows x86_64 binaries (with GUI)
+   - Build Python wheel and source distribution
+   - Generate SHA256SUMS.txt
+   - Create build provenance attestations for all artifacts
+   - Create the GitHub release
+
+Alternatively, the workflow can be triggered manually from the GitHub Actions UI
+using the "Run workflow" button, which allows specifying a version without creating a tag.
+
+
+Build Provenance Attestation
+============================
+
+HWI uses GitHub Artifact Attestations instead of GPG signing. Attestations provide
+cryptographic proof that artifacts were built by the GitHub Actions workflow in this
+repository, not by a potentially compromised local environment.
+
+**Benefits over GPG signing:**
+
+- No private keys to manage or protect
+- Cryptographically tied to the specific repository, workflow, and commit
+- Recorded in Sigstore's public transparency log for auditability
+- Verification does not require trusting individual maintainer keys
+
+**How it works:**
+
+1. During the release workflow, GitHub generates an OIDC token proving the build context
+2. The ``actions/attest-build-provenance`` action creates a SLSA provenance attestation
+3. The attestation is signed using Sigstore and recorded in the Rekor transparency log
+4. The attestation links the artifact's SHA256 hash to the repository, workflow, and commit
+
+**GitHub Documentation:**
+
+- `Using artifact attestations to establish provenance for builds <https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds>`_
+- `Verifying artifact attestations with the GitHub CLI <https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/verifying-artifact-attestations-with-the-github-cli>`_
+- `About artifact attestations <https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/about-artifact-attestations>`_
+
+
+Verifying Release Artifacts
+===========================
+
+HWI uses `immutable releases <https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#immutable-releases>`_
+and `artifact attestations <https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds>`_
+to provide cryptographic proof of build provenance.
+
+Install the `GitHub CLI <https://cli.github.com/>`_ if not already installed.
+
+Downloading Release Artifacts
+-----------------------------
+
+Download artifacts from the GitHub release page or via CLI::
+
+    # Download a specific asset
+    gh release download X.Y.Z --repo bitcoin-core/HWI --pattern 'hwi-*-linux-x86_64.tar.gz'
+
+    # Or download all assets
+    gh release download X.Y.Z --repo bitcoin-core/HWI
+
+Immutable Release Verification
+------------------------------
+
+Verify release assets were published via immutable release (not manually uploaded)::
+
+    # Verify a specific asset
+    gh release verify-asset hwi-X.Y.Z-linux-x86_64.tar.gz --repo bitcoin-core/HWI
+
+    # Verify all downloaded assets
+    for f in hwi-X.Y.Z* SHA256SUMS.txt; do gh release verify-asset "$f" --repo bitcoin-core/HWI; done
+
+Immutable releases guarantee that:
+
+- The release was created by an automated workflow, not a human
+- Release artifacts cannot be modified or replaced after publication
+- The release is permanently linked to the workflow run that created it
+
+Verifying Attestations
+----------------------
+
+Verify any downloaded artifact has a valid attestation::
+
+    # Verify a specific artifact
+    gh attestation verify hwi-X.Y.Z-linux-x86_64.tar.gz --repo bitcoin-core/HWI
+
+    # Or verify all downloaded assets
+    for f in hwi-X.Y.Z* SHA256SUMS.txt; do gh attestation verify "$f" --repo bitcoin-core/HWI; done
+
+Successful verification confirms:
+
+- The artifact was built by the GitHub Actions workflow in this repository
+- The specific workflow file and job that produced it
+- The git commit SHA the artifact was built from
+- The build has not been tampered with since creation
+
+SHA256 Checksums
+----------------
+
+Download ``SHA256SUMS.txt`` from the release and verify file integrity::
+
+    sha256sum -c SHA256SUMS.txt
+
+
+Release Artifacts
+=================
+
+Each release includes the following artifacts:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Platform
+     - Architecture
+     - GUI
+     - Filename
+   * - Linux
+     - x86_64
+     - Yes
+     - ``hwi-X.Y.Z-linux-x86_64.tar.gz``
+   * - Linux
+     - aarch64
+     - No
+     - ``hwi-X.Y.Z-linux-aarch64.tar.gz``
+   * - macOS
+     - x86_64 (Intel)
+     - Yes
+     - ``hwi-X.Y.Z-mac-x86_64.tar.gz``
+   * - macOS
+     - arm64 (Apple Silicon)
+     - No
+     - ``hwi-X.Y.Z-mac-arm64.tar.gz``
+   * - Windows
+     - x86_64
+     - Yes
+     - ``hwi-X.Y.Z-windows-x86_64.zip``
+   * - Python (any)
+     - any
+     - Yes
+     - ``hwi-X.Y.Z-py3-none-any.whl``
+   * - Source
+     - any
+     - Yes
+     - ``hwi-X.Y.Z.tar.gz``
+
+All artifacts are accompanied by ``SHA256SUMS.txt`` containing their checksums.
+
+
+Deterministic vs Non-Deterministic Builds
+=========================================
+
+**Deterministic (reproducible) builds** means that given the same source code, build
+environment, and instructions, you get byte-for-byte identical output every time,
+regardless of when or where you build it.
+
+Why Determinism Matters
+-----------------------
+
+For security-critical software like HWI (which handles cryptocurrency transaction signing),
+deterministic builds provide important guarantees:
+
+- **Verification**: Anyone can rebuild from source and verify the binary matches the release
+- **Trust**: Users don't have to trust that the build machine wasn't compromised
+- **Auditability**: If binaries differ unexpectedly, something changed (malicious or otherwise)
+
+Factors That Break Determinism
+------------------------------
+
+Several factors cause binary output to vary between builds:
+
+- **Timestamps**: Compilers and tools embed build time into binaries
+- **File ordering**: Filesystems may return files in different orders during builds
+- **Memory addresses**: ASLR and pointer values can leak into output
+- **Absolute paths**: Build paths like ``/home/alice/project`` get embedded in debug info
+- **Python bytecode**: Hash randomization changes ``.pyc`` file contents
+- **Toolchain versions**: Different compiler versions produce different machine code
+
+How HWI Achieves Determinism (Linux/Windows)
+--------------------------------------------
+
+The Linux and Windows builds use Docker containers with several techniques to ensure
+reproducibility:
+
+**Fixed timestamps**::
+
+    # Set all Python source files to a fixed date
+    TZ=UTC find ${lib_dir} -name '*.py' -type f -execdir touch -t "201901010000.00" '{}' \;
+
+**Fixed Python hash seed**::
+
+    export PYTHONHASHSEED=42
+
+**Patched Python build with fixed date**::
+
+    BUILD_DATE="Jan  1 2019" BUILD_TIME="00:00:00" pyenv install ...
+
+**Containerized environment**: Docker ensures identical toolchain versions and paths.
+
+Why macOS Builds Are Non-Deterministic
+--------------------------------------
+
+macOS builds cannot achieve full determinism for several reasons:
+
+- **No Docker on macOS**: Cannot use the same containerized environment as Linux
+- **Xcode/system libraries**: Apple's toolchain embeds UUIDs and timestamps into binaries
+- **Code signing**: macOS binaries receive ad-hoc signatures containing timestamps
+- **Homebrew variations**: Library versions may differ between build machines
+- **System frameworks**: macOS links against system frameworks that vary by OS version
+
+Mitigating Non-Determinism with Attestation
+-------------------------------------------
+
+Since macOS builds cannot be deterministic, we use **build provenance attestation** as
+an alternative trust mechanism. Instead of "anyone can reproduce this exact binary,"
+attestation provides "GitHub cryptographically attests this binary came from our CI pipeline."
+
+Attestation proves:
+
+- The binary was built by GitHub Actions (not a potentially compromised local machine)
+- From a specific commit in this repository
+- Using the exact workflow file at that commit
+- The binary has not been modified since the build completed
+
+This is a different but valid trust model. Users trust GitHub's infrastructure and the
+transparency log rather than relying on reproducibility for verification.
+
+For more information, see the `Build Provenance Attestation`_ section above.
+
+
+Manual Build Process
+====================
+
+The following documents the manual build process using Docker containers. This is
+useful for:
+
+- Local development and testing
+- Reproducing builds for verification
+- Building releases if CI is unavailable
+
+Note: The automated GitHub Actions workflow is the preferred method for official releases.
 
 Deterministic builds with Docker
-================================
+--------------------------------
 
 Create the docker images::
 
@@ -26,10 +286,10 @@ Build everything::
 
     docker run -it --name hwi-builder -v $PWD:/opt/hwi --rm  --workdir /opt/hwi hwi-builder /bin/bash -c "contrib/build_bin.sh && contrib/build_dist.sh"
     docker run -it --name hwi-wine-builder -v $PWD:/opt/hwi --rm  --workdir /opt/hwi hwi-wine-builder /bin/bash -c "contrib/build_wine.sh"
-    docker run --platform linux/arm64 -it --rm --name hwi-builder-arm64 -v $PWD:/opt/hwi --workdir /opt/hwi hwi-builder-arm64 /bin/bash -c "contrib/build_bin.sh --without-gui && contrib/build_dist.sh --without-gui" 
+    docker run --platform linux/arm64 -it --rm --name hwi-builder-arm64 -v $PWD:/opt/hwi --workdir /opt/hwi hwi-builder-arm64 /bin/bash -c "contrib/build_bin.sh --without-gui && contrib/build_dist.sh --without-gui"
 
 Building macOS binary
-=====================
+---------------------
 
 Note that the macOS build is non-deterministic.
 


### PR DESCRIPTION
This PR introduces an automated release workflow via Github Actions, replacing the manual build process. This process is triggered by tag push, significantly reducing the manual steps.

This PR is meant to help resolve https://github.com/bitcoin-core/HWI/issues/814.

We can rely on github attestations for authenticity verification (see below). In the likely case that you prefer to continue using your GPG signing key (instead of, or in addition to the github attestations) that step can be added to the release pipeline. You'll need to make your secret key available in github secrets to do so.

See https://github.com/turkycat/HWI/releases/tag/3.2.1 for proof that this process works and can be attested. I've squashed my fork's changes on this branch and corrected the language where necessary.

## Changes
  - New workflow (.github/workflows/release.yml): Builds all platform binaries, generates checksums, creates attestations, and publishes releases automatically on tag push
  - Updated documentation (docs/development/release-process.rst): Documents the automated process, verification steps, and retains manual build instructions as reference

## Why Attestations Instead of GPG?

GPG signing requires access to the maintainer's private key, which is intentionally not shared. Rather than establishing a new key pair and trust chain, this PR proposes the use of https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations which:

  - Cryptographically bind artifacts to the repository, workflow, and commit
  - Require no private key management
  - Are recorded in Sigstore's public transparency log
  - Can be verified with `gh attestation verify`

Combined with https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#immutable-releases, this ensures artifacts are tamper-proof and verifiably built by CI.