### PR TITLE
Fix race condition in get_free_port (#802)

### DIFF
--- a/test/test_device.py
+++ b/test/test_device.py
@@ -68,7 +68,7 @@ class Bitcoind():
 
         def get_free_port():
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.bind(("", 0))
+            s.bind(("127.0.0.1", 0))
             s.listen(1)
             port = s.getsockname()[1]
             s.close()


### PR DESCRIPTION
Fixes #802

### Problem
The `get_free_port` function was previously binding to `""` (all interfaces). This caused a race condition where the OS would assign a port that appeared free on `0.0.0.0` but was actually unavailable or restricted when `bitcoind` specifically tried to bind to `127.0.0.1` milliseconds later.

### Solution
I updated `s.bind(("", 0))` to `s.bind(("127.0.0.1", 0))`. 
This forces the OS to select a port specifically on the loopback interface ensuring it matches the interface `bitcoind` uses in the tests.

### Verification
I verified locally that the function now returns a port explicitly bound to `127.0.0.1`.