### PR TITLE
Fix incorrect check in `cache_unsigned_tx_pieces`

### DIFF
--- a/hwilib/psbt.py
+++ b/hwilib/psbt.py
@@ -1047,7 +1047,7 @@ class PSBT(object):
         """
         # To make things easier, we split up the global transaction
         # and use the PSBTv2 fields for PSBTv0
-        if self.tx is not None:
+        if self.version == 0:
             self.setup_from_tx(self.tx)
 
     def setup_from_tx(self, tx: CTransaction):


### PR DESCRIPTION
`self.tx is not None` is always true because the constructor sets `self.tx = CTransaction()` when `None` is passed, which causes a call to `setup_from_tx` also for PSBT version 2, contrarily to the function's stated intent in the documentation.