### PR TITLE
Add model id for Ledger Nano Gen5

### DIFF
--- a/hwilib/devices/ledger.py
+++ b/hwilib/devices/ledger.py
@@ -78,7 +78,8 @@ LEDGER_MODEL_IDS = {
     0x40: "ledger_nano_x",
     0x50: "ledger_nano_s_plus",
     0x60: "ledger_stax",
-    0x70: "ledger_flex"
+    0x70: "ledger_flex",
+    0x80: "ledger_nano_gen5"
 }
 LEDGER_LEGACY_PRODUCT_IDS = {
     0x0001: "ledger_nano_s",


### PR DESCRIPTION
This allows HWI to detect the device:

```bash
$ ./hwi.py enumerate
[{"type": "ledger", "model": "ledger_nano_gen5", "label": null, "path": "3-1:1.0", "fingerprint": "f5acc2fd", "needs_pin_sent": false, "needs_passphrase_sent": false}]
```