### PR TITLE
Repos for Ledger bitcoin apps renamed

### DIFF
--- a/.github/workflows/ledger-app-builder.yml
+++ b/.github/workflows/ledger-app-builder.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - run: |
           # Pin to v2.4.1 - last version that worked with HWI CI (PR #795 merged Sept 2025)
-          git clone --branch 2.4.1 --depth 1 https://github.com/LedgerHQ/app-bitcoin-new.git
-          cd app-bitcoin-new
+          git clone --branch 2.4.1 --depth 1 https://github.com/LedgerHQ/app-bitcoin.git
+          cd app-bitcoin
           make DEBUG=1 BOLOS_SDK=$NANOX_SDK
       - uses: actions/upload-artifact@v4
         with:
           name: ledger_app
-          path: app-bitcoin-new/bin/app.elf
+          path: app-bitcoin/bin/app.elf

--- a/.github/workflows/ledger-legacy-app-builder.yml
+++ b/.github/workflows/ledger-legacy-app-builder.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - run: |
           # Pin to legacy-1.6.6 HEAD commit for reproducibility
-          git clone --depth 1 https://github.com/LedgerHQ/app-bitcoin.git -b legacy-1.6.6
-          cd app-bitcoin
+          git clone --depth 1 https://github.com/LedgerHQ/app-bitcoin-legacy.git -b legacy-1.6.6
+          cd app-bitcoin-legacy
           make DEBUG=1 BOLOS_SDK=$NANOSP_SDK
       - uses: actions/upload-artifact@v4
         with:
           name: ledger_app_legacy
-          path: app-bitcoin/bin/app.elf
+          path: app-bitcoin-legacy/bin/app.elf

--- a/hwilib/devices/ledger_bitcoin/README.md
+++ b/hwilib/devices/ledger_bitcoin/README.md
@@ -1,8 +1,8 @@
 # Ledger Bitcoin application client
 
-This is a stripped down version of the client provided at https://github.com/LedgerHQ/app-bitcoin-new/tree/master/bitcoin_client.
+This is a stripped down version of the client provided at https://github.com/LedgerHQ/app-bitcoin/tree/master/bitcoin_client.
 
-This stripped down version was made at commit [4e82e44ecfe4ba358da9848087e7e597309abc53](https://github.com/LedgerHQ/app-bitcoin-new/commit/4e82e44ecfe4ba358da9848087e7e597309abc53)
+This stripped down version was made at commit [4e82e44ecfe4ba358da9848087e7e597309abc53](https://github.com/LedgerHQ/app-bitcoin/commit/4e82e44ecfe4ba358da9848087e7e597309abc53)
 
 ## Changes
 


### PR DESCRIPTION
The repos of both the legacy and the new bitcoin app have moved.

- new app: from LedgerHQ/app-bitcoin-new to LedgerHQ/app-bitcoin
- legacy app: from LedgerHQ/app-bitcoin to LedgerHQ/app-bitcoin-legacy