### PR TITLE
Relax protobuf version restriction

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1311,4 +1311,4 @@ qt = ["pyside2"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9,<3.13"
-content-hash = "278dc524a94cc0c503225e4a20f353bd09fa3deaab956e9d559c3795a304ad65"
+content-hash = "cfdbc60bf068f88587fe801325c19dfada1e868dbb0cdd65c5b7a7353dc0ca6a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ cbor2 = ">=5.4.6,<5.8"
 pyserial = "^3.5"
 semver = "^3.0.1"
 noiseprotocol = "^0.3.1"
-protobuf = "^4.23.3"
+protobuf = ">=4.23.3"
 
 [tool.poetry.extras]
 qt = ["pyside2"]


### PR DESCRIPTION
Protobuf 4 has security issues.  Update to >=5 recommended.

This PR relaxes protobuf to any version greater equal the current one.


This would close: https://github.com/bitcoin-core/HWI/issues/766