### PR TITLE
errors: fix UNKNWON_DEVICE_TYPE misspelling, keep it as a compat alias

### DIFF
--- a/hwilib/errors.py
+++ b/hwilib/errors.py
@@ -16,7 +16,8 @@ from contextlib import contextmanager
 NO_DEVICE_TYPE = -1 #: Device type was not specified
 MISSING_ARGUMENTS = -2 #: Arguments are missing
 DEVICE_CONN_ERROR = -3 #: Error connecting to the device
-UNKNWON_DEVICE_TYPE = -4 #: Device type is unknown
+UNKNOWN_DEVICE_TYPE = -4 #: Device type is unknown
+UNKNWON_DEVICE_TYPE = UNKNOWN_DEVICE_TYPE #: Deprecated misspelling of :data:`UNKNOWN_DEVICE_TYPE`, kept for compatibility
 INVALID_TX = -5 #: Transaction is invalid
 NO_PASSWORD = -6 #: No password provided, but one is needed
 BAD_ARGUMENT = -7 #: Bad, malformed, or conflicting argument was provided
@@ -122,13 +123,13 @@ class DeviceAlreadyUnlockedError(HWWError):
 
 class UnknownDeviceError(HWWError):
     """
-    :class:`HWWError` for :data:`DEVICE_TYPE`
+    :class:`HWWError` for :data:`UNKNOWN_DEVICE_TYPE`
     """
     def __init__(self, msg: str):
         """
         :param msg: The error message
         """
-        HWWError.__init__(self, msg, UNKNWON_DEVICE_TYPE)
+        HWWError.__init__(self, msg, UNKNOWN_DEVICE_TYPE)
 
 class NotImplementedError(HWWError):
     """


### PR DESCRIPTION
Fixes #845.

`UNKNWON_DEVICE_TYPE` (error code -4, in `hwilib/errors.py`) is a transposition of "UNKNOWN". This adds the correctly-spelled `UNKNOWN_DEVICE_TYPE` and aliases the old name to it, rather than renaming outright: it's a public, documented module-level name (the module is `automodule`'d), so an external importer of the misspelled name should not break.

`UnknownDeviceError` now raises with the correct spelling. Its docstring's `:data:`DEVICE_TYPE`` cross-reference is also fixed — it pointed at a name that didn't exist under either spelling, so the Sphinx `:data:` role couldn't have resolved it before this either.

Out of scope for this PR: `hwilib/devices/ledger_bitcoin/errors.py` carries the same misspelling in a comment-credited copy of this file ("Original version: https://github.com/bitcoin-core/HWI"), vendored as part of the `ledger_bitcoin` client subpackage. I didn't touch it, since it's a separate vendored copy and not literally this file; flagging it here in case maintainers want it addressed too, either in this PR or separately.

No behavioural change: both names resolve to the same value, `UnknownDeviceError().get_code()` still returns -4.