### PR TITLE
getdescriptors: add --multipath

### DIFF
--- a/hwilib/_cli.py
+++ b/hwilib/_cli.py
@@ -80,8 +80,8 @@ def getxpub_handler(args: argparse.Namespace, client: HardwareWalletClient) -> D
 def getkeypool_handler(args: argparse.Namespace, client: HardwareWalletClient) -> List[Dict[str, Any]]:
     return getkeypool(client, path=args.path, start=args.start, end=args.end, internal=args.internal, keypool=args.keypool, account=args.account, addr_type=args.addr_type, addr_all=args.all)
 
-def getdescriptors_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, List[str]]:
-    return getdescriptors(client, account=args.account)
+def getdescriptors_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Union[Dict[str, List[str]], List[str]]:
+    return getdescriptors(client, account=args.account, multipath=args.multipath)
 
 def restore_device_handler(args: argparse.Namespace, client: HardwareWalletClient) -> Dict[str, bool]:
     if args.interactive:
@@ -200,6 +200,7 @@ def get_parser() -> HWIArgumentParser:
 
     getdescriptors_parser = subparsers.add_parser('getdescriptors', help='Return receive and change descriptors for each supported address type, for import into a wallet.')
     getdescriptors_parser.add_argument('--account', help='BIP43 account', type=int, default=0)
+    getdescriptors_parser.add_argument('--multipath', help='Combine receive and change paths in BIP 389 multipath descriptors', action='store_true')
     getdescriptors_parser.set_defaults(func=getdescriptors_handler)
 
     displayaddr_parser = subparsers.add_parser('displayaddress', help='Display an address')

--- a/hwilib/commands.py
+++ b/hwilib/commands.py
@@ -279,7 +279,8 @@ def getdescriptor(
     addr_type: AddressType = AddressType.WIT,
     account: int = 0,
     start: Optional[int] = None,
-    end: Optional[int] = None
+    end: Optional[int] = None,
+    multipath: bool = False,
 ) -> Descriptor:
     """
     Get a descriptor from the client.
@@ -292,6 +293,8 @@ def getdescriptor(
     :param account: The BIP 44 account to use if ``path`` is not specified
     :param start: The start of the range to import, inclusive
     :param end: The end of the range to import, inclusive
+    :param multipath: Whether to combine the standard receive and change branches in a multipath descriptor.
+        Only applies when ``path`` is not specified.
     :return: The descriptor constructed given the above arguments and key fetched from the device
     :raises: BadArgumentError: if an argument is malformed or missing.
     """
@@ -307,11 +310,10 @@ def getdescriptor(
         # Account
         parsed_path.append(H_(account))
 
-        # Receive or change
-        if internal:
-            parsed_path.append(1)
-        else:
-            parsed_path.append(0)
+        # Receive or change. For multipath descriptors, this is added to the
+        # public derivation suffix below so that both branches can be included.
+        if not multipath:
+            parsed_path.append(1 if internal else 0)
     else:
         if path[0] != "m":
             raise BadArgumentError("Path must start with m/")
@@ -329,6 +331,8 @@ def getdescriptor(
     path_base = origin.get_derivation_path()
 
     path_suffix = [[p] for p in parsed_path[i:]]
+    if multipath and not path:
+        path_suffix.append([0, 1])
 
     # Get the key at the base
     if client.xpub_cache.get(path_base) is None:
@@ -400,32 +404,44 @@ def getkeypool(
 
 def getdescriptors(
     client: HardwareWalletClient,
-    account: int = 0
-) -> Dict[str, List[str]]:
+    account: int = 0,
+    multipath: bool = False,
+) -> Union[Dict[str, List[str]], List[str]]:
     """
     Get descriptors from the client.
 
     :param client: The client to interact with
     :param account: The BIP 44 account to use
+    :param multipath: Whether to combine receive and change paths in multipath descriptors
     :return: Multiple descriptors from the device matching the BIP 44 standard paths and the given ``account``.
+        Multipath descriptors are returned as a list; otherwise they are grouped into receive and internal lists.
     :raises: BadArgumentError: if an argument is malformed or missing.
     """
     master_fpr = client.get_master_fingerprint()
 
     result = {}
 
-    for internal in [False, True]:
+    for internal in [False] if multipath else [False, True]:
         descriptors = []
         for addr_type in list(AddressType):
             try:
-                desc = getdescriptor(client, master_fpr=master_fpr, internal=internal, addr_type=addr_type, account=account)
+                desc = getdescriptor(
+                    client,
+                    master_fpr=master_fpr,
+                    internal=internal,
+                    addr_type=addr_type,
+                    account=account,
+                    multipath=multipath,
+                )
             except UnavailableActionError:
                 # Device does not support this address type or network. Skip.
                 continue
             if not isinstance(desc, Descriptor):
                 return desc
             descriptors.append(desc.to_string())
-        if internal:
+        if multipath:
+            return descriptors
+        elif internal:
             result["internal"] = descriptors
         else:
             result["receive"] = descriptors

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -336,24 +336,30 @@ class TestGetDescriptors(DeviceTestCase):
         self.emulator.stop()
 
     def test_getdescriptors(self):
+        expected_count = 4 if self.emulator.supports_taproot else 3
+        multipath_descriptors = self.do_command(self.dev_args + ['getdescriptors', '--multipath'])
+        self.assertIsInstance(multipath_descriptors, list)
+        self.assertEqual(len(multipath_descriptors), expected_count)
+
+        expected_descriptors = {'receive': [], 'internal': []}
+        for descriptor in multipath_descriptors:
+            self.assertNotIn("'", descriptor)
+            self.assertIn('/<0;1>/*', descriptor)
+            info_result = self.rpc.getdescriptorinfo(descriptor)
+            self.assertTrue(info_result['isrange'])
+            self.assertTrue(info_result['issolvable'])
+            self.assertEqual(len(info_result['multipath_expansion']), 2)
+            for branch, expansion in zip(['receive', 'internal'], info_result['multipath_expansion']):
+                expected_descriptors[branch].append(expansion)
+
         descriptors = self.do_command(self.dev_args + ['getdescriptors'])
-
-        self.assertIn('receive', descriptors)
-        self.assertIn('internal', descriptors)
-        self.assertEqual(len(descriptors['receive']), 4 if self.emulator.supports_taproot else 3)
-        self.assertEqual(len(descriptors['internal']), 4 if self.emulator.supports_taproot else 3)
-
-        for descriptor in descriptors['receive']:
-            self.assertNotIn("'", descriptor)
-            info_result = self.rpc.getdescriptorinfo(descriptor)
-            self.assertTrue(info_result['isrange'])
-            self.assertTrue(info_result['issolvable'])
-
-        for descriptor in descriptors['internal']:
-            self.assertNotIn("'", descriptor)
-            info_result = self.rpc.getdescriptorinfo(descriptor)
-            self.assertTrue(info_result['isrange'])
-            self.assertTrue(info_result['issolvable'])
+        self.assertEqual(descriptors, expected_descriptors)
+        for descriptor_list in descriptors.values():
+            for descriptor in descriptor_list:
+                self.assertNotIn("'", descriptor)
+                info_result = self.rpc.getdescriptorinfo(descriptor)
+                self.assertTrue(info_result['isrange'])
+                self.assertTrue(info_result['issolvable'])
 
 class TestSignTx(DeviceTestCase):
     def __init__(self, *args, signtx_cases, **kwargs):


### PR DESCRIPTION
Allow clients to obtain multipath descriptors, instead separate receive and change descriptors, by calling `getdescriptors` with `--multipath`.

So in addition to:

```sh
$ <cmd> --fingerprint f5acc2fd --chain test getdescriptors --account 0
{
  "receive": [
    "pkh([f5acc2fd/44h/1h/0h]tpubDCwY.../0/*)#...",
    "wpkh([f5acc2fd/84h/1h/0h]tpubDCtK.../0/*)#...",
    ...
  ],
  "internal": [
    "pkh([f5acc2fd/44h/1h/0h]tpubDCwY.../1/*)#...",
    "wpkh([f5acc2fd/84h/1h/0h]tpubDCtK.../1/*)#...",
    ...
  ]
}
```

Clients can use:

```sh
$ <cmd> --fingerprint f5acc2fd --chain test getdescriptors --account 0 --multipath
[
  "pkh([f5acc2fd/44h/1h/0h]tpubDCwY.../<0;1>/*)#...",
  "wpkh([f5acc2fd/84h/1h/0h]tpubDCtK.../<0;1>/*)#...",
  "sh(wpkh([f5acc2fd/49h/1h/0h]tpubDC87.../<0;1>/*))#...",
  "tr([f5acc2fd/86h/1h/0h]tpubDDKY.../<0;1>/*)#..."
]
```